### PR TITLE
Remove Jax-RS dependencies from the shared REST libraries

### DIFF
--- a/Rest/alm-distributedtask-client/src/main/generated/com/microsoft/alm/teamfoundation/distributedtask/webapi/AzureSpnOperationStatus.java
+++ b/Rest/alm-distributedtask-client/src/main/generated/com/microsoft/alm/teamfoundation/distributedtask/webapi/AzureSpnOperationStatus.java
@@ -1,0 +1,41 @@
+// @formatter:off
+/*
+* ---------------------------------------------------------
+* Copyright(C) Microsoft Corporation. All rights reserved.
+* Licensed under the MIT license. See License.txt in the project root.
+* ---------------------------------------------------------
+*
+* ---------------------------------------------------------
+* Generated file, DO NOT EDIT
+* ---------------------------------------------------------
+*
+* See following wiki page for instructions on how to regenerate:
+*   https://vsowiki.com/index.php?title=Rest_Client_Generation
+*/
+
+package com.microsoft.alm.teamfoundation.distributedtask.webapi;
+
+
+/** 
+ */
+public class AzureSpnOperationStatus {
+
+    private String state;
+    private String statusMessage;
+
+    public String getState() {
+        return state;
+    }
+
+    public void setState(final String state) {
+        this.state = state;
+    }
+
+    public String getStatusMessage() {
+        return statusMessage;
+    }
+
+    public void setStatusMessage(final String statusMessage) {
+        this.statusMessage = statusMessage;
+    }
+}

--- a/Rest/alm-distributedtask-client/src/main/generated/com/microsoft/alm/teamfoundation/distributedtask/webapi/AzureSubscription.java
+++ b/Rest/alm-distributedtask-client/src/main/generated/com/microsoft/alm/teamfoundation/distributedtask/webapi/AzureSubscription.java
@@ -1,0 +1,41 @@
+// @formatter:off
+/*
+* ---------------------------------------------------------
+* Copyright(C) Microsoft Corporation. All rights reserved.
+* Licensed under the MIT license. See License.txt in the project root.
+* ---------------------------------------------------------
+*
+* ---------------------------------------------------------
+* Generated file, DO NOT EDIT
+* ---------------------------------------------------------
+*
+* See following wiki page for instructions on how to regenerate:
+*   https://vsowiki.com/index.php?title=Rest_Client_Generation
+*/
+
+package com.microsoft.alm.teamfoundation.distributedtask.webapi;
+
+
+/** 
+ */
+public class AzureSubscription {
+
+    private String displayName;
+    private String subscriptionId;
+
+    public String getDisplayName() {
+        return displayName;
+    }
+
+    public void setDisplayName(final String displayName) {
+        this.displayName = displayName;
+    }
+
+    public String getSubscriptionId() {
+        return subscriptionId;
+    }
+
+    public void setSubscriptionId(final String subscriptionId) {
+        this.subscriptionId = subscriptionId;
+    }
+}

--- a/Rest/alm-distributedtask-client/src/main/generated/com/microsoft/alm/teamfoundation/distributedtask/webapi/ServiceEndpoint.java
+++ b/Rest/alm-distributedtask-client/src/main/generated/com/microsoft/alm/teamfoundation/distributedtask/webapi/ServiceEndpoint.java
@@ -18,6 +18,8 @@ package com.microsoft.alm.teamfoundation.distributedtask.webapi;
 import java.net.URI;
 import java.util.HashMap;
 import java.util.UUID;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.microsoft.alm.visualstudio.services.webapi.IdentityRef;
 
 /** 
@@ -46,9 +48,17 @@ public class ServiceEndpoint {
     */
     private UUID id;
     /**
+    * EndPoint state indictor
+    */
+    private boolean isReady;
+    /**
     * Gets or sets the friendly name of the endpoint.
     */
     private String name;
+    /**
+    * Error message during creation/deletion of endpoint
+    */
+    private ObjectNode operationStatus;
     private IdentityRef readersGroup;
     /**
     * Gets or sets the type of the endpoint.
@@ -140,6 +150,22 @@ public class ServiceEndpoint {
     }
 
     /**
+    * EndPoint state indictor
+    */
+    @JsonProperty("isReady")
+    public boolean isReady() {
+        return isReady;
+    }
+
+    /**
+    * EndPoint state indictor
+    */
+    @JsonProperty("isReady")
+    public void setReady(final boolean isReady) {
+        this.isReady = isReady;
+    }
+
+    /**
     * Gets or sets the friendly name of the endpoint.
     */
     public String getName() {
@@ -151,6 +177,20 @@ public class ServiceEndpoint {
     */
     public void setName(final String name) {
         this.name = name;
+    }
+
+    /**
+    * Error message during creation/deletion of endpoint
+    */
+    public ObjectNode getOperationStatus() {
+        return operationStatus;
+    }
+
+    /**
+    * Error message during creation/deletion of endpoint
+    */
+    public void setOperationStatus(final ObjectNode operationStatus) {
+        this.operationStatus = operationStatus;
     }
 
     public IdentityRef getReadersGroup() {

--- a/Rest/alm-distributedtask-client/src/main/generated/com/microsoft/alm/teamfoundation/distributedtask/webapi/TaskAgentHttpClientBase.java
+++ b/Rest/alm-distributedtask-client/src/main/generated/com/microsoft/alm/teamfoundation/distributedtask/webapi/TaskAgentHttpClientBase.java
@@ -24,8 +24,13 @@ import java.util.Map;
 import java.util.UUID;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.JsonNode;
+import com.microsoft.alm.client.HttpMethod;
 import com.microsoft.alm.client.model.NameValueCollection;
 import com.microsoft.alm.client.VssHttpClientBase;
+import com.microsoft.alm.client.VssMediaTypes;
+import com.microsoft.alm.client.VssRestClientHandler;
+import com.microsoft.alm.client.VssRestRequest;
+import com.microsoft.alm.teamfoundation.distributedtask.webapi.AzureSubscription;
 import com.microsoft.alm.teamfoundation.distributedtask.webapi.DataSourceBinding;
 import com.microsoft.alm.teamfoundation.distributedtask.webapi.MetaTaskDefinition;
 import com.microsoft.alm.teamfoundation.distributedtask.webapi.PackageMetadata;
@@ -56,22 +61,13 @@ public abstract class TaskAgentHttpClientBase
     * Create a new instance of TaskAgentHttpClientBase
     *
     * @param jaxrsClient
-    *            an initialized instance of a JAX-RS Client implementation
+    *            a DefaultRestClientHandler initialized with an instance of a JAX-RS Client implementation or
+    *            a TEERestClientHamdler initialized with TEE HTTP client implementation
     * @param baseUrl
-    *            a TFS project collection URL
+    *            a TFS services URL
     */
-    protected TaskAgentHttpClientBase(final Object jaxrsClient, final URI baseUrl) {
-        super(jaxrsClient, baseUrl);
-    }
-
-    /**
-    * Create a new instance of TaskAgentHttpClientBase
-    *
-    * @param tfsConnection
-    *            an initialized instance of a TfsTeamProjectCollection
-    */
-    protected TaskAgentHttpClientBase(final Object tfsConnection) {
-        super(tfsConnection);
+    protected TaskAgentHttpClientBase(final VssRestClientHandler clientHandler, final URI baseUrl) {
+        super(clientHandler, baseUrl);
     }
 
     @Override
@@ -98,13 +94,13 @@ public abstract class TaskAgentHttpClientBase
         final Map<String, Object> routeValues = new HashMap<String, Object>();
         routeValues.put("poolId", poolId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.POST,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       agent,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.POST,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               agent,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, TaskAgent.class);
     }
@@ -128,11 +124,11 @@ public abstract class TaskAgentHttpClientBase
         routeValues.put("poolId", poolId); //$NON-NLS-1$
         routeValues.put("agentId", agentId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.DELETE,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.DELETE,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         super.sendRequest(httpRequest);
     }
@@ -171,12 +167,12 @@ public abstract class TaskAgentHttpClientBase
         queryParameters.addIfNotNull("includeAssignedRequest", includeAssignedRequest); //$NON-NLS-1$
         queryParameters.addIfNotNull("propertyFilters", propertyFilters); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, TaskAgent.class);
     }
@@ -219,12 +215,12 @@ public abstract class TaskAgentHttpClientBase
         queryParameters.addIfNotNull("propertyFilters", propertyFilters); //$NON-NLS-1$
         queryParameters.addIfNotNull("demands", demands); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<TaskAgent>>() {});
     }
@@ -252,13 +248,13 @@ public abstract class TaskAgentHttpClientBase
         routeValues.put("poolId", poolId); //$NON-NLS-1$
         routeValues.put("agentId", agentId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.PUT,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       agent,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.PUT,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               agent,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, TaskAgent.class);
     }
@@ -286,15 +282,39 @@ public abstract class TaskAgentHttpClientBase
         routeValues.put("poolId", poolId); //$NON-NLS-1$
         routeValues.put("agentId", agentId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.PATCH,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       agent,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.PATCH,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               agent,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, TaskAgent.class);
+    }
+
+    /** 
+     * [Preview API 3.0-preview.1]
+     * 
+     * @param scopeIdentifier 
+     *            The project GUID to scope the request
+     * @return ArrayList&lt;AzureSubscription&gt;
+     */
+    public ArrayList<AzureSubscription> getAzureSubscriptions(final UUID scopeIdentifier) { 
+
+        final UUID locationId = UUID.fromString("bcd6189c-0303-471f-a8e1-acb22b74d700"); //$NON-NLS-1$
+        final ApiResourceVersion apiVersion = new ApiResourceVersion("3.0-preview.1"); //$NON-NLS-1$
+
+        final Map<String, Object> routeValues = new HashMap<String, Object>();
+        routeValues.put("scopeIdentifier", scopeIdentifier); //$NON-NLS-1$
+
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
+
+        return super.sendRequest(httpRequest, new TypeReference<ArrayList<AzureSubscription>>() {});
     }
 
     /** 
@@ -309,12 +329,12 @@ public abstract class TaskAgentHttpClientBase
         final UUID locationId = UUID.fromString("f223b809-8c33-4b7d-b53f-07232569b5d6"); //$NON-NLS-1$
         final ApiResourceVersion apiVersion = new ApiResourceVersion("3.0-preview.1"); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.POST,
-                                                       locationId,
-                                                       apiVersion,
-                                                       endpoint,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.POST,
+                                                               locationId,
+                                                               apiVersion,
+                                                               endpoint,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<String>>() {});
     }
@@ -339,11 +359,11 @@ public abstract class TaskAgentHttpClientBase
         routeValues.put("taskId", taskId); //$NON-NLS-1$
         routeValues.put("versionString", versionString); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, InputStream.class);
     }
@@ -373,12 +393,12 @@ public abstract class TaskAgentHttpClientBase
         final NameValueCollection queryParameters = new NameValueCollection();
         queryParameters.addIfNotNull("lockToken", lockToken); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.DELETE,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.DELETE,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         super.sendRequest(httpRequest);
     }
@@ -403,11 +423,11 @@ public abstract class TaskAgentHttpClientBase
         routeValues.put("poolId", poolId); //$NON-NLS-1$
         routeValues.put("requestId", requestId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, TaskAgentJobRequest.class);
     }
@@ -438,12 +458,12 @@ public abstract class TaskAgentHttpClientBase
         queryParameters.put("agentId", String.valueOf(agentId)); //$NON-NLS-1$
         queryParameters.addIfNotNull("completedRequestCount", completedRequestCount); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<TaskAgentJobRequest>>() {});
     }
@@ -474,12 +494,12 @@ public abstract class TaskAgentHttpClientBase
         queryParameters.addIfNotNull("agentIds", agentIds); //$NON-NLS-1$
         queryParameters.addIfNotNull("completedRequestCount", completedRequestCount); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<TaskAgentJobRequest>>() {});
     }
@@ -510,12 +530,12 @@ public abstract class TaskAgentHttpClientBase
         queryParameters.addIfNotNull("planId", planId); //$NON-NLS-1$
         queryParameters.addIfNotNull("jobId", jobId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<TaskAgentJobRequest>>() {});
     }
@@ -539,13 +559,13 @@ public abstract class TaskAgentHttpClientBase
         final Map<String, Object> routeValues = new HashMap<String, Object>();
         routeValues.put("poolId", poolId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.POST,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       request,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.POST,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               request,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, TaskAgentJobRequest.class);
     }
@@ -579,14 +599,14 @@ public abstract class TaskAgentHttpClientBase
         final NameValueCollection queryParameters = new NameValueCollection();
         queryParameters.addIfNotNull("lockToken", lockToken); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.PATCH,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       request,
-                                                       APPLICATION_JSON_TYPE,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.PATCH,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               request,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, TaskAgentJobRequest.class);
     }
@@ -616,12 +636,12 @@ public abstract class TaskAgentHttpClientBase
         final NameValueCollection queryParameters = new NameValueCollection();
         queryParameters.addIfNotNull("sessionId", sessionId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.DELETE,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.DELETE,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         super.sendRequest(httpRequest);
     }
@@ -652,12 +672,12 @@ public abstract class TaskAgentHttpClientBase
         queryParameters.addIfNotNull("sessionId", sessionId); //$NON-NLS-1$
         queryParameters.addIfNotNull("lastMessageId", lastMessageId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, TaskAgentMessage.class);
     }
@@ -683,12 +703,12 @@ public abstract class TaskAgentHttpClientBase
         final NameValueCollection queryParameters = new NameValueCollection();
         queryParameters.put("agentId", String.valueOf(agentId)); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.POST,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.POST,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         super.sendRequest(httpRequest);
     }
@@ -707,11 +727,11 @@ public abstract class TaskAgentHttpClientBase
         final Map<String, Object> routeValues = new HashMap<String, Object>();
         routeValues.put("poolId", poolId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.POST,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.POST,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         super.sendRequest(httpRequest);
     }
@@ -740,14 +760,14 @@ public abstract class TaskAgentHttpClientBase
         final NameValueCollection queryParameters = new NameValueCollection();
         queryParameters.put("requestId", String.valueOf(requestId)); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.POST,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       message,
-                                                       APPLICATION_JSON_TYPE,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.POST,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               message,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         super.sendRequest(httpRequest);
     }
@@ -771,13 +791,13 @@ public abstract class TaskAgentHttpClientBase
         final Map<String, Object> routeValues = new HashMap<String, Object>();
         routeValues.put("project", project); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.POST,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       definition,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.POST,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               definition,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, MetaTaskDefinition.class);
     }
@@ -801,13 +821,13 @@ public abstract class TaskAgentHttpClientBase
         final Map<String, Object> routeValues = new HashMap<String, Object>();
         routeValues.put("project", project); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.POST,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       definition,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.POST,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               definition,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, MetaTaskDefinition.class);
     }
@@ -831,11 +851,11 @@ public abstract class TaskAgentHttpClientBase
         routeValues.put("project", project); //$NON-NLS-1$
         routeValues.put("metaTaskDefinitionId", metaTaskDefinitionId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.DELETE,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.DELETE,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         super.sendRequest(httpRequest);
     }
@@ -859,11 +879,11 @@ public abstract class TaskAgentHttpClientBase
         routeValues.put("project", project); //$NON-NLS-1$
         routeValues.put("metaTaskDefinitionId", metaTaskDefinitionId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.DELETE,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.DELETE,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         super.sendRequest(httpRequest);
     }
@@ -894,12 +914,12 @@ public abstract class TaskAgentHttpClientBase
         final NameValueCollection queryParameters = new NameValueCollection();
         queryParameters.addIfNotNull("expanded", expanded); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<MetaTaskDefinition>>() {});
     }
@@ -930,12 +950,12 @@ public abstract class TaskAgentHttpClientBase
         final NameValueCollection queryParameters = new NameValueCollection();
         queryParameters.addIfNotNull("expanded", expanded); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<MetaTaskDefinition>>() {});
     }
@@ -959,13 +979,13 @@ public abstract class TaskAgentHttpClientBase
         final Map<String, Object> routeValues = new HashMap<String, Object>();
         routeValues.put("project", project); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.PUT,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       definition,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.PUT,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               definition,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, MetaTaskDefinition.class);
     }
@@ -989,13 +1009,13 @@ public abstract class TaskAgentHttpClientBase
         final Map<String, Object> routeValues = new HashMap<String, Object>();
         routeValues.put("project", project); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.PUT,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       definition,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.PUT,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               definition,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, MetaTaskDefinition.class);
     }
@@ -1024,11 +1044,11 @@ public abstract class TaskAgentHttpClientBase
         routeValues.put("platform", platform); //$NON-NLS-1$
         routeValues.put("version", version); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, PackageMetadata.class);
     }
@@ -1059,12 +1079,12 @@ public abstract class TaskAgentHttpClientBase
         final NameValueCollection queryParameters = new NameValueCollection();
         queryParameters.addIfNotNull("$top", top); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<PackageMetadata>>() {});
     }
@@ -1084,11 +1104,11 @@ public abstract class TaskAgentHttpClientBase
         final Map<String, Object> routeValues = new HashMap<String, Object>();
         routeValues.put("poolId", poolId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<IdentityRef>>() {});
     }
@@ -1105,12 +1125,12 @@ public abstract class TaskAgentHttpClientBase
         final UUID locationId = UUID.fromString("a8c47e17-4d56-4a56-92bb-de7ea7dc65be"); //$NON-NLS-1$
         final ApiResourceVersion apiVersion = new ApiResourceVersion("3.0-preview.1"); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.POST,
-                                                       locationId,
-                                                       apiVersion,
-                                                       pool,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.POST,
+                                                               locationId,
+                                                               apiVersion,
+                                                               pool,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, TaskAgentPool.class);
     }
@@ -1129,11 +1149,11 @@ public abstract class TaskAgentHttpClientBase
         final Map<String, Object> routeValues = new HashMap<String, Object>();
         routeValues.put("poolId", poolId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.DELETE,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.DELETE,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         super.sendRequest(httpRequest);
     }
@@ -1160,12 +1180,12 @@ public abstract class TaskAgentHttpClientBase
         final NameValueCollection queryParameters = new NameValueCollection();
         queryParameters.addIfNotNull("properties", properties); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, TaskAgentPool.class);
     }
@@ -1190,11 +1210,11 @@ public abstract class TaskAgentHttpClientBase
         queryParameters.addIfNotEmpty("poolName", poolName); //$NON-NLS-1$
         queryParameters.addIfNotNull("properties", properties); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<TaskAgentPool>>() {});
     }
@@ -1218,13 +1238,13 @@ public abstract class TaskAgentHttpClientBase
         final Map<String, Object> routeValues = new HashMap<String, Object>();
         routeValues.put("poolId", poolId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.PATCH,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       pool,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.PATCH,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               pool,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, TaskAgentPool.class);
     }
@@ -1244,11 +1264,11 @@ public abstract class TaskAgentHttpClientBase
         final Map<String, Object> routeValues = new HashMap<String, Object>();
         routeValues.put("queueId", queueId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<IdentityRef>>() {});
     }
@@ -1265,12 +1285,12 @@ public abstract class TaskAgentHttpClientBase
         final UUID locationId = UUID.fromString("900fa995-c559-4923-aae7-f8424fe4fbea"); //$NON-NLS-1$
         final ApiResourceVersion apiVersion = new ApiResourceVersion("3.0-preview.1"); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.POST,
-                                                       locationId,
-                                                       apiVersion,
-                                                       queue,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.POST,
+                                                               locationId,
+                                                               apiVersion,
+                                                               queue,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, TaskAgentQueue.class);
     }
@@ -1294,13 +1314,13 @@ public abstract class TaskAgentHttpClientBase
         final Map<String, Object> routeValues = new HashMap<String, Object>();
         routeValues.put("project", project); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.POST,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queue,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.POST,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queue,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, TaskAgentQueue.class);
     }
@@ -1324,13 +1344,13 @@ public abstract class TaskAgentHttpClientBase
         final Map<String, Object> routeValues = new HashMap<String, Object>();
         routeValues.put("project", project); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.POST,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queue,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.POST,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queue,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, TaskAgentQueue.class);
     }
@@ -1344,10 +1364,10 @@ public abstract class TaskAgentHttpClientBase
         final UUID locationId = UUID.fromString("900fa995-c559-4923-aae7-f8424fe4fbea"); //$NON-NLS-1$
         final ApiResourceVersion apiVersion = new ApiResourceVersion("3.0-preview.1"); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.PUT,
-                                                       locationId,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.PUT,
+                                                               locationId,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         super.sendRequest(httpRequest);
     }
@@ -1366,11 +1386,11 @@ public abstract class TaskAgentHttpClientBase
         final Map<String, Object> routeValues = new HashMap<String, Object>();
         routeValues.put("project", project); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.PUT,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.PUT,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         super.sendRequest(httpRequest);
     }
@@ -1389,11 +1409,11 @@ public abstract class TaskAgentHttpClientBase
         final Map<String, Object> routeValues = new HashMap<String, Object>();
         routeValues.put("project", project); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.PUT,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.PUT,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         super.sendRequest(httpRequest);
     }
@@ -1412,11 +1432,11 @@ public abstract class TaskAgentHttpClientBase
         final Map<String, Object> routeValues = new HashMap<String, Object>();
         routeValues.put("queueId", queueId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.DELETE,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.DELETE,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         super.sendRequest(httpRequest);
     }
@@ -1440,11 +1460,11 @@ public abstract class TaskAgentHttpClientBase
         routeValues.put("project", project); //$NON-NLS-1$
         routeValues.put("queueId", queueId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.DELETE,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.DELETE,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         super.sendRequest(httpRequest);
     }
@@ -1468,11 +1488,11 @@ public abstract class TaskAgentHttpClientBase
         routeValues.put("project", project); //$NON-NLS-1$
         routeValues.put("queueId", queueId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.DELETE,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.DELETE,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         super.sendRequest(httpRequest);
     }
@@ -1503,12 +1523,12 @@ public abstract class TaskAgentHttpClientBase
         final NameValueCollection queryParameters = new NameValueCollection();
         queryParameters.addIfNotNull("actionFilter", actionFilter); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, TaskAgentQueue.class);
     }
@@ -1539,12 +1559,12 @@ public abstract class TaskAgentHttpClientBase
         final NameValueCollection queryParameters = new NameValueCollection();
         queryParameters.addIfNotNull("actionFilter", actionFilter); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, TaskAgentQueue.class);
     }
@@ -1571,12 +1591,12 @@ public abstract class TaskAgentHttpClientBase
         final NameValueCollection queryParameters = new NameValueCollection();
         queryParameters.addIfNotNull("actionFilter", actionFilter); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, TaskAgentQueue.class);
     }
@@ -1607,12 +1627,12 @@ public abstract class TaskAgentHttpClientBase
         queryParameters.addIfNotEmpty("queueName", queueName); //$NON-NLS-1$
         queryParameters.addIfNotNull("actionFilter", actionFilter); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<TaskAgentQueue>>() {});
     }
@@ -1643,12 +1663,12 @@ public abstract class TaskAgentHttpClientBase
         queryParameters.addIfNotEmpty("queueName", queueName); //$NON-NLS-1$
         queryParameters.addIfNotNull("actionFilter", actionFilter); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<TaskAgentQueue>>() {});
     }
@@ -1673,11 +1693,11 @@ public abstract class TaskAgentHttpClientBase
         queryParameters.addIfNotEmpty("queueName", queueName); //$NON-NLS-1$
         queryParameters.addIfNotNull("actionFilter", actionFilter); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<TaskAgentQueue>>() {});
     }
@@ -1707,14 +1727,14 @@ public abstract class TaskAgentHttpClientBase
         final NameValueCollection queryParameters = new NameValueCollection();
         queryParameters.addIfNotEmpty("endpointId", endpointId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.POST,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       binding,
-                                                       APPLICATION_JSON_TYPE,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.POST,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               binding,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, JsonNode.class);
     }
@@ -1738,13 +1758,13 @@ public abstract class TaskAgentHttpClientBase
         final Map<String, Object> routeValues = new HashMap<String, Object>();
         routeValues.put("scopeIdentifier", scopeIdentifier); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.POST,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       binding,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.POST,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               binding,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<String>>() {});
     }
@@ -1768,13 +1788,13 @@ public abstract class TaskAgentHttpClientBase
         final Map<String, Object> routeValues = new HashMap<String, Object>();
         routeValues.put("scopeIdentifier", scopeIdentifier); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.POST,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       endpoint,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.POST,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               endpoint,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, ServiceEndpoint.class);
     }
@@ -1798,11 +1818,11 @@ public abstract class TaskAgentHttpClientBase
         routeValues.put("scopeIdentifier", scopeIdentifier); //$NON-NLS-1$
         routeValues.put("endpointId", endpointId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.DELETE,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.DELETE,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         super.sendRequest(httpRequest);
     }
@@ -1827,11 +1847,11 @@ public abstract class TaskAgentHttpClientBase
         routeValues.put("scopeIdentifier", scopeIdentifier); //$NON-NLS-1$
         routeValues.put("endpointId", endpointId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, ServiceEndpoint.class);
     }
@@ -1866,12 +1886,12 @@ public abstract class TaskAgentHttpClientBase
         queryParameters.addIfNotNull("authSchemes", authSchemes); //$NON-NLS-1$
         queryParameters.addIfNotNull("endpointIds", endpointIds); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<ServiceEndpoint>>() {});
     }
@@ -1899,13 +1919,13 @@ public abstract class TaskAgentHttpClientBase
         routeValues.put("scopeIdentifier", scopeIdentifier); //$NON-NLS-1$
         routeValues.put("endpointId", endpointId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.PUT,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       endpoint,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.PUT,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               endpoint,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, ServiceEndpoint.class);
     }
@@ -1936,12 +1956,12 @@ public abstract class TaskAgentHttpClientBase
         queryParameters.addIfNotEmpty("type", type); //$NON-NLS-1$
         queryParameters.addIfNotEmpty("scheme", scheme); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<ServiceEndpointType>>() {});
     }
@@ -1965,13 +1985,13 @@ public abstract class TaskAgentHttpClientBase
         final Map<String, Object> routeValues = new HashMap<String, Object>();
         routeValues.put("poolId", poolId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.POST,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       session,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.POST,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               session,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, TaskAgentSession.class);
     }
@@ -1995,11 +2015,11 @@ public abstract class TaskAgentHttpClientBase
         routeValues.put("poolId", poolId); //$NON-NLS-1$
         routeValues.put("sessionId", sessionId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.DELETE,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.DELETE,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         super.sendRequest(httpRequest);
     }
@@ -2018,11 +2038,11 @@ public abstract class TaskAgentHttpClientBase
         final Map<String, Object> routeValues = new HashMap<String, Object>();
         routeValues.put("taskId", taskId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.DELETE,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.DELETE,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         super.sendRequest(httpRequest);
     }
@@ -2057,12 +2077,12 @@ public abstract class TaskAgentHttpClientBase
         queryParameters.addIfNotNull("visibility", visibility); //$NON-NLS-1$
         queryParameters.addIfNotNull("scopeLocal", scopeLocal); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_ZIP_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_ZIP_TYPE);
 
         return super.sendRequest(httpRequest, InputStream.class);
     }
@@ -2097,12 +2117,12 @@ public abstract class TaskAgentHttpClientBase
         queryParameters.addIfNotNull("visibility", visibility); //$NON-NLS-1$
         queryParameters.addIfNotNull("scopeLocal", scopeLocal); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, TaskDefinition.class);
     }
@@ -2133,12 +2153,12 @@ public abstract class TaskAgentHttpClientBase
         queryParameters.addIfNotNull("visibility", visibility); //$NON-NLS-1$
         queryParameters.addIfNotNull("scopeLocal", scopeLocal); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<TaskDefinition>>() {});
     }
@@ -2166,13 +2186,13 @@ public abstract class TaskAgentHttpClientBase
         routeValues.put("poolId", poolId); //$NON-NLS-1$
         routeValues.put("agentId", agentId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.PUT,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       userCapabilities,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.PUT,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               userCapabilities,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, TaskAgent.class);
     }

--- a/Rest/alm-distributedtask-client/src/main/generated/com/microsoft/alm/teamfoundation/distributedtask/webapi/TaskAgentQueue.java
+++ b/Rest/alm-distributedtask-client/src/main/generated/com/microsoft/alm/teamfoundation/distributedtask/webapi/TaskAgentQueue.java
@@ -25,6 +25,7 @@ public class TaskAgentQueue {
     private int id;
     private String name;
     private TaskAgentPoolReference pool;
+    private UUID projectId;
     private boolean provisioned;
 
     public UUID getGroupScopeId() {
@@ -57,6 +58,14 @@ public class TaskAgentQueue {
 
     public void setPool(final TaskAgentPoolReference pool) {
         this.pool = pool;
+    }
+
+    public UUID getProjectId() {
+        return projectId;
+    }
+
+    public void setProjectId(final UUID projectId) {
+        this.projectId = projectId;
     }
 
     public boolean getProvisioned() {

--- a/Rest/alm-distributedtask-client/src/main/generated/com/microsoft/alm/teamfoundation/distributedtask/webapi/TaskHttpClientBase.java
+++ b/Rest/alm-distributedtask-client/src/main/generated/com/microsoft/alm/teamfoundation/distributedtask/webapi/TaskHttpClientBase.java
@@ -23,8 +23,12 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import com.fasterxml.jackson.core.type.TypeReference;
+import com.microsoft.alm.client.HttpMethod;
 import com.microsoft.alm.client.model.NameValueCollection;
 import com.microsoft.alm.client.VssHttpClientBase;
+import com.microsoft.alm.client.VssMediaTypes;
+import com.microsoft.alm.client.VssRestClientHandler;
+import com.microsoft.alm.client.VssRestRequest;
 import com.microsoft.alm.teamfoundation.distributedtask.webapi.TaskAttachment;
 import com.microsoft.alm.teamfoundation.distributedtask.webapi.TaskLog;
 import com.microsoft.alm.teamfoundation.distributedtask.webapi.TaskOrchestrationPlan;
@@ -46,22 +50,13 @@ public abstract class TaskHttpClientBase
     * Create a new instance of TaskHttpClientBase
     *
     * @param jaxrsClient
-    *            an initialized instance of a JAX-RS Client implementation
+    *            a DefaultRestClientHandler initialized with an instance of a JAX-RS Client implementation or
+    *            a TEERestClientHamdler initialized with TEE HTTP client implementation
     * @param baseUrl
-    *            a TFS project collection URL
+    *            a TFS services URL
     */
-    protected TaskHttpClientBase(final Object jaxrsClient, final URI baseUrl) {
-        super(jaxrsClient, baseUrl);
-    }
-
-    /**
-    * Create a new instance of TaskHttpClientBase
-    *
-    * @param tfsConnection
-    *            an initialized instance of a TfsTeamProjectCollection
-    */
-    protected TaskHttpClientBase(final Object tfsConnection) {
-        super(tfsConnection);
+    protected TaskHttpClientBase(final VssRestClientHandler clientHandler, final URI baseUrl) {
+        super(clientHandler, baseUrl);
     }
 
     @Override
@@ -97,11 +92,11 @@ public abstract class TaskHttpClientBase
         routeValues.put("planId", planId); //$NON-NLS-1$
         routeValues.put("type", type); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<TaskAttachment>>() {});
     }
@@ -149,13 +144,13 @@ public abstract class TaskHttpClientBase
         routeValues.put("type", type); //$NON-NLS-1$
         routeValues.put("name", name); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.PUT,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       uploadStream,
-                                                       APPLICATION_OCTET_STREAM_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.PUT,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               uploadStream,
+                                                               VssMediaTypes.APPLICATION_OCTET_STREAM_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, TaskAttachment.class);
     }
@@ -200,11 +195,11 @@ public abstract class TaskHttpClientBase
         routeValues.put("type", type); //$NON-NLS-1$
         routeValues.put("name", name); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, TaskAttachment.class);
     }
@@ -249,11 +244,11 @@ public abstract class TaskHttpClientBase
         routeValues.put("type", type); //$NON-NLS-1$
         routeValues.put("name", name); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_OCTET_STREAM_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_OCTET_STREAM_TYPE);
 
         return super.sendRequest(httpRequest, InputStream.class);
     }
@@ -294,11 +289,11 @@ public abstract class TaskHttpClientBase
         routeValues.put("recordId", recordId); //$NON-NLS-1$
         routeValues.put("type", type); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<TaskAttachment>>() {});
     }
@@ -337,13 +332,13 @@ public abstract class TaskHttpClientBase
         routeValues.put("timelineId", timelineId); //$NON-NLS-1$
         routeValues.put("recordId", recordId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.POST,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       lines,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.POST,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               lines,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         super.sendRequest(httpRequest);
     }
@@ -379,13 +374,13 @@ public abstract class TaskHttpClientBase
         routeValues.put("planId", planId); //$NON-NLS-1$
         routeValues.put("logId", logId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.POST,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       uploadStream,
-                                                       APPLICATION_OCTET_STREAM_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.POST,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               uploadStream,
+                                                               VssMediaTypes.APPLICATION_OCTET_STREAM_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, TaskLog.class);
     }
@@ -417,13 +412,13 @@ public abstract class TaskHttpClientBase
         routeValues.put("hubName", hubName); //$NON-NLS-1$
         routeValues.put("planId", planId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.POST,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       log,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.POST,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               log,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, TaskLog.class);
     }
@@ -466,12 +461,12 @@ public abstract class TaskHttpClientBase
         queryParameters.addIfNotNull("startLine", startLine); //$NON-NLS-1$
         queryParameters.addIfNotNull("endLine", endLine); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<String>>() {});
     }
@@ -500,11 +495,11 @@ public abstract class TaskHttpClientBase
         routeValues.put("hubName", hubName); //$NON-NLS-1$
         routeValues.put("planId", planId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<TaskLog>>() {});
     }
@@ -533,11 +528,11 @@ public abstract class TaskHttpClientBase
         routeValues.put("hubName", hubName); //$NON-NLS-1$
         routeValues.put("planId", planId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, TaskOrchestrationPlan.class);
     }
@@ -576,12 +571,12 @@ public abstract class TaskHttpClientBase
         final NameValueCollection queryParameters = new NameValueCollection();
         queryParameters.addIfNotNull("changeId", changeId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<TimelineRecord>>() {});
     }
@@ -617,13 +612,13 @@ public abstract class TaskHttpClientBase
         routeValues.put("planId", planId); //$NON-NLS-1$
         routeValues.put("timelineId", timelineId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.PATCH,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       records,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.PATCH,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               records,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<TimelineRecord>>() {});
     }
@@ -655,13 +650,13 @@ public abstract class TaskHttpClientBase
         routeValues.put("hubName", hubName); //$NON-NLS-1$
         routeValues.put("planId", planId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.POST,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       timeline,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.POST,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               timeline,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, Timeline.class);
     }
@@ -693,11 +688,11 @@ public abstract class TaskHttpClientBase
         routeValues.put("planId", planId); //$NON-NLS-1$
         routeValues.put("timelineId", timelineId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.DELETE,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.DELETE,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         super.sendRequest(httpRequest);
     }
@@ -740,12 +735,12 @@ public abstract class TaskHttpClientBase
         queryParameters.addIfNotNull("changeId", changeId); //$NON-NLS-1$
         queryParameters.addIfNotNull("includeRecords", includeRecords); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, Timeline.class);
     }
@@ -774,11 +769,11 @@ public abstract class TaskHttpClientBase
         routeValues.put("hubName", hubName); //$NON-NLS-1$
         routeValues.put("planId", planId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<Timeline>>() {});
     }

--- a/Rest/alm-distributedtask-client/src/main/java/com/microsoft/alm/teamfoundation/distributedtask/webapi/TaskAgentHttpClient.java
+++ b/Rest/alm-distributedtask-client/src/main/java/com/microsoft/alm/teamfoundation/distributedtask/webapi/TaskAgentHttpClient.java
@@ -3,12 +3,13 @@
 
 package com.microsoft.alm.teamfoundation.distributedtask.webapi;
 
-import javax.ws.rs.client.Client;
 import java.net.URI;
+
+import com.microsoft.alm.client.VssRestClientHandler;
 
 public class TaskAgentHttpClient extends TaskAgentHttpClientBase {
 
-    public TaskAgentHttpClient(final Client jaxrsClient, final URI baseUrl) {
-        super(jaxrsClient, baseUrl);
+    public TaskAgentHttpClient(final VssRestClientHandler clientHandler, final URI baseUrl) {
+        super(clientHandler, baseUrl);
     }
 }

--- a/Rest/alm-distributedtask-client/src/main/java/com/microsoft/alm/teamfoundation/distributedtask/webapi/TaskHttpClient.java
+++ b/Rest/alm-distributedtask-client/src/main/java/com/microsoft/alm/teamfoundation/distributedtask/webapi/TaskHttpClient.java
@@ -3,30 +3,17 @@
 
 package com.microsoft.alm.teamfoundation.distributedtask.webapi;
 
-import java.io.InputStream;
 import java.net.URI;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.UUID;
 
-import javax.ws.rs.client.Client;
-import javax.xml.ws.Response;
-
-import com.fasterxml.jackson.core.type.TypeReference;
-import com.microsoft.alm.client.model.NameValueCollection;
-import com.microsoft.alm.teamfoundation.distributedtask.webapi.JobEvent;
-import com.microsoft.alm.teamfoundation.distributedtask.webapi.TaskLog;
-import com.microsoft.alm.teamfoundation.distributedtask.webapi.TaskOrchestrationPlan;
-import com.microsoft.alm.teamfoundation.distributedtask.webapi.Timeline;
-import com.microsoft.alm.teamfoundation.distributedtask.webapi.TimelineRecord;
-import com.microsoft.alm.visualstudio.services.webapi.ApiResourceVersion;
+import com.microsoft.alm.client.VssRestClientHandler;
 import com.microsoft.alm.visualstudio.services.webapi.VssJsonCollectionWrapper;
 
 public class TaskHttpClient extends TaskHttpClientBase {
 
-    public TaskHttpClient(final Client jaxrsClient, final URI baseUrl) {
-        super(jaxrsClient, baseUrl);
+    public TaskHttpClient(final VssRestClientHandler clientHandler, final URI baseUrl) {
+        super(clientHandler, baseUrl);
     }
 
     /**

--- a/Rest/alm-extensionmanagement-client/src/main/generated/com/microsoft/alm/visualstudio/services/extensionmanagement/webapi/ContributionsHttpClientBase.java
+++ b/Rest/alm-extensionmanagement-client/src/main/generated/com/microsoft/alm/visualstudio/services/extensionmanagement/webapi/ContributionsHttpClientBase.java
@@ -22,8 +22,12 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import com.fasterxml.jackson.core.type.TypeReference;
+import com.microsoft.alm.client.HttpMethod;
 import com.microsoft.alm.client.model.NameValueCollection;
 import com.microsoft.alm.client.VssHttpClientBase;
+import com.microsoft.alm.client.VssMediaTypes;
+import com.microsoft.alm.client.VssRestClientHandler;
+import com.microsoft.alm.client.VssRestRequest;
 import com.microsoft.alm.visualstudio.services.extensionmanagement.webapi.DataProviderQuery;
 import com.microsoft.alm.visualstudio.services.extensionmanagement.webapi.DataProviderResult;
 import com.microsoft.alm.visualstudio.services.extensionmanagement.webapi.InstalledExtension;
@@ -42,22 +46,13 @@ public abstract class ContributionsHttpClientBase
     * Create a new instance of ContributionsHttpClientBase
     *
     * @param jaxrsClient
-    *            an initialized instance of a JAX-RS Client implementation
+    *            a DefaultRestClientHandler initialized with an instance of a JAX-RS Client implementation or
+    *            a TEERestClientHamdler initialized with TEE HTTP client implementation
     * @param baseUrl
-    *            a TFS project collection URL
+    *            a TFS services URL
     */
-    protected ContributionsHttpClientBase(final Object jaxrsClient, final URI baseUrl) {
-        super(jaxrsClient, baseUrl);
-    }
-
-    /**
-    * Create a new instance of ContributionsHttpClientBase
-    *
-    * @param tfsConnection
-    *            an initialized instance of a TfsTeamProjectCollection
-    */
-    protected ContributionsHttpClientBase(final Object tfsConnection) {
-        super(tfsConnection);
+    protected ContributionsHttpClientBase(final VssRestClientHandler clientHandler, final URI baseUrl) {
+        super(clientHandler, baseUrl);
     }
 
     @Override
@@ -77,12 +72,12 @@ public abstract class ContributionsHttpClientBase
         final UUID locationId = UUID.fromString("738368db-35ee-4b85-9f94-77ed34af2b0d"); //$NON-NLS-1$
         final ApiResourceVersion apiVersion = new ApiResourceVersion("3.0-preview.1"); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.POST,
-                                                       locationId,
-                                                       apiVersion,
-                                                       query,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.POST,
+                                                               locationId,
+                                                               apiVersion,
+                                                               query,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, DataProviderResult.class);
     }
@@ -111,11 +106,11 @@ public abstract class ContributionsHttpClientBase
         queryParameters.addIfNotNull("includeDisabledApps", includeDisabledApps); //$NON-NLS-1$
         queryParameters.addIfNotNull("assetTypes", assetTypes); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<InstalledExtension>>() {});
     }
@@ -146,12 +141,12 @@ public abstract class ContributionsHttpClientBase
         final NameValueCollection queryParameters = new NameValueCollection();
         queryParameters.addIfNotNull("assetTypes", assetTypes); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, InstalledExtension.class);
     }

--- a/Rest/alm-extensionmanagement-client/src/main/generated/com/microsoft/alm/visualstudio/services/extensionmanagement/webapi/ExtensionManagementHttpClientBase.java
+++ b/Rest/alm-extensionmanagement-client/src/main/generated/com/microsoft/alm/visualstudio/services/extensionmanagement/webapi/ExtensionManagementHttpClientBase.java
@@ -23,8 +23,12 @@ import java.util.Map;
 import java.util.UUID;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.microsoft.alm.client.HttpMethod;
 import com.microsoft.alm.client.model.NameValueCollection;
 import com.microsoft.alm.client.VssHttpClientBase;
+import com.microsoft.alm.client.VssMediaTypes;
+import com.microsoft.alm.client.VssRestClientHandler;
+import com.microsoft.alm.client.VssRestRequest;
 import com.microsoft.alm.visualstudio.services.extensionmanagement.webapi.AcquisitionOptions;
 import com.microsoft.alm.visualstudio.services.extensionmanagement.webapi.acquisitionrequest.ExtensionAcquisitionRequest;
 import com.microsoft.alm.visualstudio.services.extensionmanagement.webapi.ExtensionAuthorization;
@@ -51,22 +55,13 @@ public abstract class ExtensionManagementHttpClientBase
     * Create a new instance of ExtensionManagementHttpClientBase
     *
     * @param jaxrsClient
-    *            an initialized instance of a JAX-RS Client implementation
+    *            a DefaultRestClientHandler initialized with an instance of a JAX-RS Client implementation or
+    *            a TEERestClientHamdler initialized with TEE HTTP client implementation
     * @param baseUrl
-    *            a TFS project collection URL
+    *            a TFS services URL
     */
-    protected ExtensionManagementHttpClientBase(final Object jaxrsClient, final URI baseUrl) {
-        super(jaxrsClient, baseUrl);
-    }
-
-    /**
-    * Create a new instance of ExtensionManagementHttpClientBase
-    *
-    * @param tfsConnection
-    *            an initialized instance of a TfsTeamProjectCollection
-    */
-    protected ExtensionManagementHttpClientBase(final Object tfsConnection) {
-        super(tfsConnection);
+    protected ExtensionManagementHttpClientBase(final VssRestClientHandler clientHandler, final URI baseUrl) {
+        super(clientHandler, baseUrl);
     }
 
     @Override
@@ -98,11 +93,11 @@ public abstract class ExtensionManagementHttpClientBase
         queryParameters.addIfNotNull("testCommerce", testCommerce); //$NON-NLS-1$
         queryParameters.addIfNotNull("isFreeOrTrialInstall", isFreeOrTrialInstall); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, AcquisitionOptions.class);
     }
@@ -119,12 +114,12 @@ public abstract class ExtensionManagementHttpClientBase
         final UUID locationId = UUID.fromString("da616457-eed3-4672-92d7-18d21f5c1658"); //$NON-NLS-1$
         final ApiResourceVersion apiVersion = new ApiResourceVersion("3.0-preview.1"); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.POST,
-                                                       locationId,
-                                                       apiVersion,
-                                                       acquisitionRequest,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.POST,
+                                                               locationId,
+                                                               apiVersion,
+                                                               acquisitionRequest,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, ExtensionAcquisitionRequest.class);
     }
@@ -153,11 +148,11 @@ public abstract class ExtensionManagementHttpClientBase
         routeValues.put("extensionName", extensionName); //$NON-NLS-1$
         routeValues.put("registrationId", registrationId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.PUT,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.PUT,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, ExtensionAuthorization.class);
     }
@@ -197,13 +192,13 @@ public abstract class ExtensionManagementHttpClientBase
         routeValues.put("scopeValue", scopeValue); //$NON-NLS-1$
         routeValues.put("collectionName", collectionName); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.POST,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       doc,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.POST,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               doc,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, ObjectNode.class);
     }
@@ -243,11 +238,11 @@ public abstract class ExtensionManagementHttpClientBase
         routeValues.put("collectionName", collectionName); //$NON-NLS-1$
         routeValues.put("documentId", documentId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.DELETE,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.DELETE,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         super.sendRequest(httpRequest);
     }
@@ -288,11 +283,11 @@ public abstract class ExtensionManagementHttpClientBase
         routeValues.put("collectionName", collectionName); //$NON-NLS-1$
         routeValues.put("documentId", documentId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, ObjectNode.class);
     }
@@ -329,11 +324,11 @@ public abstract class ExtensionManagementHttpClientBase
         routeValues.put("scopeValue", scopeValue); //$NON-NLS-1$
         routeValues.put("collectionName", collectionName); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<ObjectNode>>() {});
     }
@@ -373,13 +368,13 @@ public abstract class ExtensionManagementHttpClientBase
         routeValues.put("scopeValue", scopeValue); //$NON-NLS-1$
         routeValues.put("collectionName", collectionName); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.PUT,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       doc,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.PUT,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               doc,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, ObjectNode.class);
     }
@@ -419,13 +414,13 @@ public abstract class ExtensionManagementHttpClientBase
         routeValues.put("scopeValue", scopeValue); //$NON-NLS-1$
         routeValues.put("collectionName", collectionName); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.PATCH,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       doc,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.PATCH,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               doc,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, ObjectNode.class);
     }
@@ -453,13 +448,13 @@ public abstract class ExtensionManagementHttpClientBase
         routeValues.put("publisherName", publisherName); //$NON-NLS-1$
         routeValues.put("extensionName", extensionName); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.POST,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       collectionQuery,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.POST,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               collectionQuery,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<ExtensionDataCollection>>() {});
     }
@@ -488,11 +483,11 @@ public abstract class ExtensionManagementHttpClientBase
         queryParameters.addIfNotNull("includeErrors", includeErrors); //$NON-NLS-1$
         queryParameters.addIfNotNull("includeInstallationIssues", includeInstallationIssues); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<ExtensionState>>() {});
     }
@@ -509,12 +504,12 @@ public abstract class ExtensionManagementHttpClientBase
         final UUID locationId = UUID.fromString("046c980f-1345-4ce2-bf85-b46d10ff4cfd"); //$NON-NLS-1$
         final ApiResourceVersion apiVersion = new ApiResourceVersion("3.0-preview.1"); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.POST,
-                                                       locationId,
-                                                       apiVersion,
-                                                       query,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.POST,
+                                                               locationId,
+                                                               apiVersion,
+                                                               query,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<InstalledExtension>>() {});
     }
@@ -547,11 +542,11 @@ public abstract class ExtensionManagementHttpClientBase
         queryParameters.addIfNotNull("assetTypes", assetTypes); //$NON-NLS-1$
         queryParameters.addIfNotNull("includeInstallationIssues", includeInstallationIssues); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<InstalledExtension>>() {});
     }
@@ -568,12 +563,12 @@ public abstract class ExtensionManagementHttpClientBase
         final UUID locationId = UUID.fromString("275424d0-c844-4fe2-bda6-04933a1357d8"); //$NON-NLS-1$
         final ApiResourceVersion apiVersion = new ApiResourceVersion("3.0-preview.1"); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.PATCH,
-                                                       locationId,
-                                                       apiVersion,
-                                                       extension,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.PATCH,
+                                                               locationId,
+                                                               apiVersion,
+                                                               extension,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, InstalledExtension.class);
     }
@@ -604,12 +599,12 @@ public abstract class ExtensionManagementHttpClientBase
         final NameValueCollection queryParameters = new NameValueCollection();
         queryParameters.addIfNotNull("assetTypes", assetTypes); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, InstalledExtension.class);
     }
@@ -638,11 +633,11 @@ public abstract class ExtensionManagementHttpClientBase
         routeValues.put("extensionName", extensionName); //$NON-NLS-1$
         routeValues.put("version", version); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.POST,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.POST,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, InstalledExtension.class);
     }
@@ -676,12 +671,12 @@ public abstract class ExtensionManagementHttpClientBase
         queryParameters.addIfNotEmpty("reason", reason); //$NON-NLS-1$
         queryParameters.addIfNotEmpty("reasonCode", reasonCode); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.DELETE,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.DELETE,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         super.sendRequest(httpRequest);
     }
@@ -701,11 +696,11 @@ public abstract class ExtensionManagementHttpClientBase
         final Map<String, Object> routeValues = new HashMap<String, Object>();
         routeValues.put("userId", userId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, UserExtensionPolicy.class);
     }
@@ -743,14 +738,14 @@ public abstract class ExtensionManagementHttpClientBase
         final NameValueCollection queryParameters = new NameValueCollection();
         queryParameters.addIfNotNull("state", state); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.PATCH,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       rejectMessage,
-                                                       APPLICATION_JSON_TYPE,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.PATCH,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               rejectMessage,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, int.class);
     }
@@ -765,10 +760,10 @@ public abstract class ExtensionManagementHttpClientBase
         final UUID locationId = UUID.fromString("216b978f-b164-424e-ada2-b77561e842b7"); //$NON-NLS-1$
         final ApiResourceVersion apiVersion = new ApiResourceVersion("3.0-preview.1"); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<RequestedExtension>>() {});
     }
@@ -802,14 +797,14 @@ public abstract class ExtensionManagementHttpClientBase
         final NameValueCollection queryParameters = new NameValueCollection();
         queryParameters.addIfNotNull("state", state); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.PATCH,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       rejectMessage,
-                                                       APPLICATION_JSON_TYPE,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.PATCH,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               rejectMessage,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, int.class);
     }
@@ -833,11 +828,11 @@ public abstract class ExtensionManagementHttpClientBase
         routeValues.put("publisherName", publisherName); //$NON-NLS-1$
         routeValues.put("extensionName", extensionName); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.DELETE,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.DELETE,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         super.sendRequest(httpRequest);
     }
@@ -865,13 +860,13 @@ public abstract class ExtensionManagementHttpClientBase
         routeValues.put("publisherName", publisherName); //$NON-NLS-1$
         routeValues.put("extensionName", extensionName); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.POST,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       requestMessage,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.POST,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               requestMessage,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, RequestedExtension.class);
     }
@@ -886,10 +881,10 @@ public abstract class ExtensionManagementHttpClientBase
         final UUID locationId = UUID.fromString("3a2e24ed-1d6f-4cb2-9f3b-45a96bbfaf50"); //$NON-NLS-1$
         final ApiResourceVersion apiVersion = new ApiResourceVersion("3.0-preview.1"); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, String.class);
     }

--- a/Rest/alm-extensionmanagement-client/src/main/java/com/microsoft/alm/visualstudio/services/extensionmanagement/webapi/ExtensionManagementHttpClient.java
+++ b/Rest/alm-extensionmanagement-client/src/main/java/com/microsoft/alm/visualstudio/services/extensionmanagement/webapi/ExtensionManagementHttpClient.java
@@ -3,12 +3,13 @@
 
 package com.microsoft.alm.visualstudio.services.extensionmanagement.webapi;
 
-import javax.ws.rs.client.Client;
 import java.net.URI;
+
+import com.microsoft.alm.client.VssRestClientHandler;
 
 public class ExtensionManagementHttpClient extends ExtensionManagementHttpClientBase {
 
-    public ExtensionManagementHttpClient(final Client jaxrsClient, final URI baseUrl) {
-        super(jaxrsClient, baseUrl);
+    public ExtensionManagementHttpClient(final VssRestClientHandler clientHandler, final URI baseUrl) {
+        super(clientHandler, baseUrl);
     }
 }

--- a/Rest/alm-gallery-client/src/main/generated/com/microsoft/alm/visualstudio/services/gallery/webapi/GalleryHttpClientBase.java
+++ b/Rest/alm-gallery-client/src/main/generated/com/microsoft/alm/visualstudio/services/gallery/webapi/GalleryHttpClientBase.java
@@ -24,8 +24,12 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import com.fasterxml.jackson.core.type.TypeReference;
+import com.microsoft.alm.client.HttpMethod;
 import com.microsoft.alm.client.model.NameValueCollection;
 import com.microsoft.alm.client.VssHttpClientBase;
+import com.microsoft.alm.client.VssMediaTypes;
+import com.microsoft.alm.client.VssRestClientHandler;
+import com.microsoft.alm.client.VssRestRequest;
 import com.microsoft.alm.visualstudio.services.gallery.webapi.acquisitionoption.AcquisitionOptions;
 import com.microsoft.alm.visualstudio.services.gallery.webapi.acquisitionrequest.ExtensionAcquisitionRequest;
 import com.microsoft.alm.visualstudio.services.gallery.webapi.AzurePublisher;
@@ -59,22 +63,13 @@ public abstract class GalleryHttpClientBase
     * Create a new instance of GalleryHttpClientBase
     *
     * @param jaxrsClient
-    *            an initialized instance of a JAX-RS Client implementation
+    *            a DefaultRestClientHandler initialized with an instance of a JAX-RS Client implementation or
+    *            a TEERestClientHamdler initialized with TEE HTTP client implementation
     * @param baseUrl
-    *            a TFS project collection URL
+    *            a TFS services URL
     */
-    protected GalleryHttpClientBase(final Object jaxrsClient, final URI baseUrl) {
-        super(jaxrsClient, baseUrl);
-    }
-
-    /**
-    * Create a new instance of GalleryHttpClientBase
-    *
-    * @param tfsConnection
-    *            an initialized instance of a TfsTeamProjectCollection
-    */
-    protected GalleryHttpClientBase(final Object tfsConnection) {
-        super(tfsConnection);
+    protected GalleryHttpClientBase(final VssRestClientHandler clientHandler, final URI baseUrl) {
+        super(clientHandler, baseUrl);
     }
 
     @Override
@@ -101,11 +96,11 @@ public abstract class GalleryHttpClientBase
         routeValues.put("extensionId", extensionId); //$NON-NLS-1$
         routeValues.put("accountName", accountName); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.POST,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.POST,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         super.sendRequest(httpRequest);
     }
@@ -129,11 +124,11 @@ public abstract class GalleryHttpClientBase
         routeValues.put("extensionId", extensionId); //$NON-NLS-1$
         routeValues.put("accountName", accountName); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.DELETE,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.DELETE,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         super.sendRequest(httpRequest);
     }
@@ -161,11 +156,11 @@ public abstract class GalleryHttpClientBase
         routeValues.put("extensionName", extensionName); //$NON-NLS-1$
         routeValues.put("accountName", accountName); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.POST,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.POST,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         super.sendRequest(httpRequest);
     }
@@ -193,11 +188,11 @@ public abstract class GalleryHttpClientBase
         routeValues.put("extensionName", extensionName); //$NON-NLS-1$
         routeValues.put("accountName", accountName); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.DELETE,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.DELETE,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         super.sendRequest(httpRequest);
     }
@@ -232,12 +227,12 @@ public abstract class GalleryHttpClientBase
         queryParameters.addIfNotNull("testCommerce", testCommerce); //$NON-NLS-1$
         queryParameters.addIfNotNull("isFreeOrTrialInstall", isFreeOrTrialInstall); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, AcquisitionOptions.class);
     }
@@ -254,12 +249,12 @@ public abstract class GalleryHttpClientBase
         final UUID locationId = UUID.fromString("3adb1f2d-e328-446e-be73-9f6d98071c45"); //$NON-NLS-1$
         final ApiResourceVersion apiVersion = new ApiResourceVersion("3.0-preview.1"); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.POST,
-                                                       locationId,
-                                                       apiVersion,
-                                                       acquisitionRequest,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.POST,
+                                                               locationId,
+                                                               apiVersion,
+                                                               acquisitionRequest,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, ExtensionAcquisitionRequest.class);
     }
@@ -302,12 +297,12 @@ public abstract class GalleryHttpClientBase
         queryParameters.addIfNotEmpty("accountToken", accountToken); //$NON-NLS-1$
         queryParameters.addIfNotNull("acceptDefault", acceptDefault); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_OCTET_STREAM_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_OCTET_STREAM_TYPE);
 
         return super.sendRequest(httpRequest, InputStream.class);
     }
@@ -346,12 +341,12 @@ public abstract class GalleryHttpClientBase
         queryParameters.addIfNotEmpty("accountToken", accountToken); //$NON-NLS-1$
         queryParameters.addIfNotNull("acceptDefault", acceptDefault); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_OCTET_STREAM_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_OCTET_STREAM_TYPE);
 
         return super.sendRequest(httpRequest, InputStream.class);
     }
@@ -390,12 +385,12 @@ public abstract class GalleryHttpClientBase
         final NameValueCollection queryParameters = new NameValueCollection();
         queryParameters.addIfNotEmpty("accountToken", accountToken); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_OCTET_STREAM_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_OCTET_STREAM_TYPE);
 
         return super.sendRequest(httpRequest, InputStream.class);
     }
@@ -422,12 +417,12 @@ public abstract class GalleryHttpClientBase
         final NameValueCollection queryParameters = new NameValueCollection();
         queryParameters.addIfNotEmpty("azurePublisherId", azurePublisherId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.PUT,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.PUT,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, AzurePublisher.class);
     }
@@ -447,11 +442,11 @@ public abstract class GalleryHttpClientBase
         final Map<String, Object> routeValues = new HashMap<String, Object>();
         routeValues.put("publisherName", publisherName); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, AzurePublisher.class);
     }
@@ -471,11 +466,11 @@ public abstract class GalleryHttpClientBase
         final NameValueCollection queryParameters = new NameValueCollection();
         queryParameters.addIfNotEmpty("languages", languages); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<String>>() {});
     }
@@ -504,11 +499,11 @@ public abstract class GalleryHttpClientBase
         routeValues.put("extensionName", extensionName); //$NON-NLS-1$
         routeValues.put("version", version); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_OCTET_STREAM_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_OCTET_STREAM_TYPE);
 
         return super.sendRequest(httpRequest, InputStream.class);
     }
@@ -532,13 +527,13 @@ public abstract class GalleryHttpClientBase
         final NameValueCollection queryParameters = new NameValueCollection();
         queryParameters.addIfNotEmpty("accountToken", accountToken); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.POST,
-                                                       locationId,
-                                                       apiVersion,
-                                                       extensionQuery,
-                                                       APPLICATION_JSON_TYPE,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.POST,
+                                                               locationId,
+                                                               apiVersion,
+                                                               extensionQuery,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, ExtensionQueryResult.class);
     }
@@ -555,12 +550,12 @@ public abstract class GalleryHttpClientBase
         final UUID locationId = UUID.fromString("a41192c8-9525-4b58-bc86-179fa549d80d"); //$NON-NLS-1$
         final ApiResourceVersion apiVersion = new ApiResourceVersion("3.0-preview.1"); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.POST,
-                                                       locationId,
-                                                       apiVersion,
-                                                       extensionPackage,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.POST,
+                                                               locationId,
+                                                               apiVersion,
+                                                               extensionPackage,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, PublishedExtension.class);
     }
@@ -586,12 +581,12 @@ public abstract class GalleryHttpClientBase
         final NameValueCollection queryParameters = new NameValueCollection();
         queryParameters.addIfNotEmpty("version", version); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.DELETE,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.DELETE,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         super.sendRequest(httpRequest);
     }
@@ -622,12 +617,12 @@ public abstract class GalleryHttpClientBase
         queryParameters.addIfNotEmpty("version", version); //$NON-NLS-1$
         queryParameters.addIfNotNull("flags", flags); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, PublishedExtension.class);
     }
@@ -651,13 +646,13 @@ public abstract class GalleryHttpClientBase
         final Map<String, Object> routeValues = new HashMap<String, Object>();
         routeValues.put("extensionId", extensionId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.PUT,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       extensionPackage,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.PUT,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               extensionPackage,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, PublishedExtension.class);
     }
@@ -681,13 +676,13 @@ public abstract class GalleryHttpClientBase
         final Map<String, Object> routeValues = new HashMap<String, Object>();
         routeValues.put("publisherName", publisherName); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.POST,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       extensionPackage,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.POST,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               extensionPackage,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, PublishedExtension.class);
     }
@@ -717,12 +712,12 @@ public abstract class GalleryHttpClientBase
         final NameValueCollection queryParameters = new NameValueCollection();
         queryParameters.addIfNotEmpty("version", version); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.DELETE,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.DELETE,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         super.sendRequest(httpRequest);
     }
@@ -761,12 +756,12 @@ public abstract class GalleryHttpClientBase
         queryParameters.addIfNotNull("flags", flags); //$NON-NLS-1$
         queryParameters.addIfNotEmpty("accountToken", accountToken); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, PublishedExtension.class);
     }
@@ -794,13 +789,13 @@ public abstract class GalleryHttpClientBase
         routeValues.put("publisherName", publisherName); //$NON-NLS-1$
         routeValues.put("extensionName", extensionName); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.PUT,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       extensionPackage,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.PUT,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               extensionPackage,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, PublishedExtension.class);
     }
@@ -816,12 +811,12 @@ public abstract class GalleryHttpClientBase
         final UUID locationId = UUID.fromString("05e8a5e1-8c59-4c2c-8856-0ff087d1a844"); //$NON-NLS-1$
         final ApiResourceVersion apiVersion = new ApiResourceVersion("3.0-preview.1"); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.POST,
-                                                       locationId,
-                                                       apiVersion,
-                                                       azureRestApiRequestModel,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.POST,
+                                                               locationId,
+                                                               apiVersion,
+                                                               azureRestApiRequestModel,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         super.sendRequest(httpRequest);
     }
@@ -860,12 +855,12 @@ public abstract class GalleryHttpClientBase
         queryParameters.addIfNotEmpty("accountToken", accountToken); //$NON-NLS-1$
         queryParameters.addIfNotNull("acceptDefault", acceptDefault); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_OCTET_STREAM_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_OCTET_STREAM_TYPE);
 
         return super.sendRequest(httpRequest, InputStream.class);
     }
@@ -912,12 +907,12 @@ public abstract class GalleryHttpClientBase
         queryParameters.addIfNotEmpty("accountToken", accountToken); //$NON-NLS-1$
         queryParameters.addIfNotNull("acceptDefault", acceptDefault); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_OCTET_STREAM_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_OCTET_STREAM_TYPE);
 
         return super.sendRequest(httpRequest, InputStream.class);
     }
@@ -934,12 +929,12 @@ public abstract class GalleryHttpClientBase
         final UUID locationId = UUID.fromString("2ad6ee0a-b53f-4034-9d1d-d009fda1212e"); //$NON-NLS-1$
         final ApiResourceVersion apiVersion = new ApiResourceVersion("3.0-preview.1"); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.POST,
-                                                       locationId,
-                                                       apiVersion,
-                                                       publisherQuery,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.POST,
+                                                               locationId,
+                                                               apiVersion,
+                                                               publisherQuery,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, PublisherQueryResult.class);
     }
@@ -956,12 +951,12 @@ public abstract class GalleryHttpClientBase
         final UUID locationId = UUID.fromString("4ddec66a-e4f6-4f5d-999e-9e77710d7ff4"); //$NON-NLS-1$
         final ApiResourceVersion apiVersion = new ApiResourceVersion("3.0-preview.1"); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.POST,
-                                                       locationId,
-                                                       apiVersion,
-                                                       publisher,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.POST,
+                                                               locationId,
+                                                               apiVersion,
+                                                               publisher,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, Publisher.class);
     }
@@ -980,11 +975,11 @@ public abstract class GalleryHttpClientBase
         final Map<String, Object> routeValues = new HashMap<String, Object>();
         routeValues.put("publisherName", publisherName); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.DELETE,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.DELETE,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         super.sendRequest(httpRequest);
     }
@@ -1011,12 +1006,12 @@ public abstract class GalleryHttpClientBase
         final NameValueCollection queryParameters = new NameValueCollection();
         queryParameters.addIfNotNull("flags", flags); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, Publisher.class);
     }
@@ -1040,13 +1035,13 @@ public abstract class GalleryHttpClientBase
         final Map<String, Object> routeValues = new HashMap<String, Object>();
         routeValues.put("publisherName", publisherName); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.PUT,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       publisher,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.PUT,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               publisher,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, Publisher.class);
     }
@@ -1089,12 +1084,12 @@ public abstract class GalleryHttpClientBase
         queryParameters.addIfNotNull("beforeDate", beforeDate); //$NON-NLS-1$
         queryParameters.addIfNotNull("afterDate", afterDate); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, ReviewsResult.class);
     }
@@ -1122,13 +1117,13 @@ public abstract class GalleryHttpClientBase
         routeValues.put("pubName", pubName); //$NON-NLS-1$
         routeValues.put("extName", extName); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.POST,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       review,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.POST,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               review,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, Review.class);
     }
@@ -1160,13 +1155,13 @@ public abstract class GalleryHttpClientBase
         routeValues.put("extName", extName); //$NON-NLS-1$
         routeValues.put("resourceId", resourceId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.PATCH,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       reviewPatch,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.PATCH,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               reviewPatch,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, ReviewPatch.class);
     }
@@ -1183,12 +1178,12 @@ public abstract class GalleryHttpClientBase
         final UUID locationId = UUID.fromString("476531a3-7024-4516-a76a-ed64d3008ad6"); //$NON-NLS-1$
         final ApiResourceVersion apiVersion = new ApiResourceVersion("3.0-preview.1"); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.POST,
-                                                       locationId,
-                                                       apiVersion,
-                                                       category,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.POST,
+                                                               locationId,
+                                                               apiVersion,
+                                                               category,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, ExtensionCategory.class);
     }
@@ -1214,12 +1209,12 @@ public abstract class GalleryHttpClientBase
         final NameValueCollection queryParameters = new NameValueCollection();
         queryParameters.addIfNotNull("expireCurrentSeconds", expireCurrentSeconds); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.POST,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.POST,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         super.sendRequest(httpRequest);
     }
@@ -1239,11 +1234,11 @@ public abstract class GalleryHttpClientBase
         final Map<String, Object> routeValues = new HashMap<String, Object>();
         routeValues.put("keyType", keyType); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, String.class);
     }
@@ -1270,13 +1265,13 @@ public abstract class GalleryHttpClientBase
         routeValues.put("publisherName", publisherName); //$NON-NLS-1$
         routeValues.put("extensionName", extensionName); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.PATCH,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       extensionStatisticsUpdate,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.PATCH,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               extensionStatisticsUpdate,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         super.sendRequest(httpRequest);
     }

--- a/Rest/alm-gallery-client/src/main/java/com/microsoft/alm/visualstudio/services/gallery/webapi/GalleryHttpClient.java
+++ b/Rest/alm-gallery-client/src/main/java/com/microsoft/alm/visualstudio/services/gallery/webapi/GalleryHttpClient.java
@@ -3,18 +3,13 @@
 
 package com.microsoft.alm.visualstudio.services.gallery.webapi;
 
-import java.io.InputStream;
 import java.net.URI;
-import java.util.List;
-import java.util.UUID;
 
-import com.microsoft.alm.client.utils.ArgumentUtility;
-
-import javax.ws.rs.client.Client;
+import com.microsoft.alm.client.VssRestClientHandler;
 
 public class GalleryHttpClient extends GalleryHttpClientBase {
 
-    public GalleryHttpClient(final Client jaxrsClient, final URI baseUrl) {
-        super(jaxrsClient, baseUrl);
+    public GalleryHttpClient(final VssRestClientHandler clientHandler, final URI baseUrl) {
+        super(clientHandler, baseUrl);
     }
 }

--- a/Rest/alm-releasemanagement-client/src/main/generated/com/microsoft/alm/visualstudio/services/releasemanagement/webapi/DeployPhaseStatus.java
+++ b/Rest/alm-releasemanagement-client/src/main/generated/com/microsoft/alm/visualstudio/services/releasemanagement/webapi/DeployPhaseStatus.java
@@ -1,0 +1,81 @@
+// @formatter:off
+/*
+* ---------------------------------------------------------
+* Copyright(C) Microsoft Corporation. All rights reserved.
+* Licensed under the MIT license. See License.txt in the project root.
+* ---------------------------------------------------------
+*
+* ---------------------------------------------------------
+* Generated file, DO NOT EDIT
+* ---------------------------------------------------------
+*
+* See following wiki page for instructions on how to regenerate:
+*   https://vsowiki.com/index.php?title=Rest_Client_Generation
+*/
+
+package com.microsoft.alm.visualstudio.services.releasemanagement.webapi;
+
+
+/** 
+ */
+public enum DeployPhaseStatus {
+
+    UNDEFINED(0),
+    NOT_STARTED(1),
+    IN_PROGRESS(2),
+    PARTIALLY_SUCCEEDED(4),
+    SUCCEEDED(8),
+    FAILED(16),
+    CANCELED(32),
+    SKIPPED(64),
+    ;
+
+    private int value;
+
+    private DeployPhaseStatus(final int value) {
+        this.value = value;
+    }
+
+    public int getValue() {
+        return value;
+    }
+
+    @Override
+    public String toString() {
+        final String name = super.toString();
+
+        if (name.equals("UNDEFINED")) { //$NON-NLS-1$
+            return "undefined"; //$NON-NLS-1$
+        }
+
+        if (name.equals("NOT_STARTED")) { //$NON-NLS-1$
+            return "notStarted"; //$NON-NLS-1$
+        }
+
+        if (name.equals("IN_PROGRESS")) { //$NON-NLS-1$
+            return "inProgress"; //$NON-NLS-1$
+        }
+
+        if (name.equals("PARTIALLY_SUCCEEDED")) { //$NON-NLS-1$
+            return "partiallySucceeded"; //$NON-NLS-1$
+        }
+
+        if (name.equals("SUCCEEDED")) { //$NON-NLS-1$
+            return "succeeded"; //$NON-NLS-1$
+        }
+
+        if (name.equals("FAILED")) { //$NON-NLS-1$
+            return "failed"; //$NON-NLS-1$
+        }
+
+        if (name.equals("CANCELED")) { //$NON-NLS-1$
+            return "canceled"; //$NON-NLS-1$
+        }
+
+        if (name.equals("SKIPPED")) { //$NON-NLS-1$
+            return "skipped"; //$NON-NLS-1$
+        }
+
+        return null;
+    }
+}

--- a/Rest/alm-releasemanagement-client/src/main/generated/com/microsoft/alm/visualstudio/services/releasemanagement/webapi/DeployPhaseTypes.java
+++ b/Rest/alm-releasemanagement-client/src/main/generated/com/microsoft/alm/visualstudio/services/releasemanagement/webapi/DeployPhaseTypes.java
@@ -1,0 +1,61 @@
+// @formatter:off
+/*
+* ---------------------------------------------------------
+* Copyright(C) Microsoft Corporation. All rights reserved.
+* Licensed under the MIT license. See License.txt in the project root.
+* ---------------------------------------------------------
+*
+* ---------------------------------------------------------
+* Generated file, DO NOT EDIT
+* ---------------------------------------------------------
+*
+* See following wiki page for instructions on how to regenerate:
+*   https://vsowiki.com/index.php?title=Rest_Client_Generation
+*/
+
+package com.microsoft.alm.visualstudio.services.releasemanagement.webapi;
+
+
+/** 
+ */
+public enum DeployPhaseTypes {
+
+    UNDEFINED(0),
+    AGENT_BASED_DEPLOYMENT(1),
+    RUN_ON_SERVER(2),
+    MACHINE_GROUP_BASED_DEPLOYMENT(4),
+    ;
+
+    private int value;
+
+    private DeployPhaseTypes(final int value) {
+        this.value = value;
+    }
+
+    public int getValue() {
+        return value;
+    }
+
+    @Override
+    public String toString() {
+        final String name = super.toString();
+
+        if (name.equals("UNDEFINED")) { //$NON-NLS-1$
+            return "undefined"; //$NON-NLS-1$
+        }
+
+        if (name.equals("AGENT_BASED_DEPLOYMENT")) { //$NON-NLS-1$
+            return "agentBasedDeployment"; //$NON-NLS-1$
+        }
+
+        if (name.equals("RUN_ON_SERVER")) { //$NON-NLS-1$
+            return "runOnServer"; //$NON-NLS-1$
+        }
+
+        if (name.equals("MACHINE_GROUP_BASED_DEPLOYMENT")) { //$NON-NLS-1$
+            return "machineGroupBasedDeployment"; //$NON-NLS-1$
+        }
+
+        return null;
+    }
+}

--- a/Rest/alm-releasemanagement-client/src/main/generated/com/microsoft/alm/visualstudio/services/releasemanagement/webapi/Deployment.java
+++ b/Rest/alm-releasemanagement-client/src/main/generated/com/microsoft/alm/visualstudio/services/releasemanagement/webapi/Deployment.java
@@ -1,0 +1,162 @@
+// @formatter:off
+/*
+* ---------------------------------------------------------
+* Copyright(C) Microsoft Corporation. All rights reserved.
+* Licensed under the MIT license. See License.txt in the project root.
+* ---------------------------------------------------------
+*
+* ---------------------------------------------------------
+* Generated file, DO NOT EDIT
+* ---------------------------------------------------------
+*
+* See following wiki page for instructions on how to regenerate:
+*   https://vsowiki.com/index.php?title=Rest_Client_Generation
+*/
+
+package com.microsoft.alm.visualstudio.services.releasemanagement.webapi;
+
+import java.util.ArrayList;
+import java.util.Date;
+import com.microsoft.alm.visualstudio.services.releasemanagement.webapi.contracts.ShallowReference;
+import com.microsoft.alm.visualstudio.services.webapi.IdentityRef;
+
+/** 
+ */
+public class Deployment {
+
+    private int attempt;
+    private int definitionEnvironmentId;
+    private DeploymentStatus deploymentStatus;
+    private int id;
+    private IdentityRef lastModifiedBy;
+    private Date lastModifiedOn;
+    private DeploymentOperationStatus operationStatus;
+    private ArrayList<ReleaseApproval> postDeployApprovals;
+    private ArrayList<ReleaseApproval> preDeployApprovals;
+    private DeploymentReason reason;
+    private ReleaseReference release;
+    private ShallowReference releaseDefinition;
+    private ShallowReference releaseEnvironment;
+    private IdentityRef requestedBy;
+    private Date startedOn;
+
+    public int getAttempt() {
+        return attempt;
+    }
+
+    public void setAttempt(final int attempt) {
+        this.attempt = attempt;
+    }
+
+    public int getDefinitionEnvironmentId() {
+        return definitionEnvironmentId;
+    }
+
+    public void setDefinitionEnvironmentId(final int definitionEnvironmentId) {
+        this.definitionEnvironmentId = definitionEnvironmentId;
+    }
+
+    public DeploymentStatus getDeploymentStatus() {
+        return deploymentStatus;
+    }
+
+    public void setDeploymentStatus(final DeploymentStatus deploymentStatus) {
+        this.deploymentStatus = deploymentStatus;
+    }
+
+    public int getId() {
+        return id;
+    }
+
+    public void setId(final int id) {
+        this.id = id;
+    }
+
+    public IdentityRef getLastModifiedBy() {
+        return lastModifiedBy;
+    }
+
+    public void setLastModifiedBy(final IdentityRef lastModifiedBy) {
+        this.lastModifiedBy = lastModifiedBy;
+    }
+
+    public Date getLastModifiedOn() {
+        return lastModifiedOn;
+    }
+
+    public void setLastModifiedOn(final Date lastModifiedOn) {
+        this.lastModifiedOn = lastModifiedOn;
+    }
+
+    public DeploymentOperationStatus getOperationStatus() {
+        return operationStatus;
+    }
+
+    public void setOperationStatus(final DeploymentOperationStatus operationStatus) {
+        this.operationStatus = operationStatus;
+    }
+
+    public ArrayList<ReleaseApproval> getPostDeployApprovals() {
+        return postDeployApprovals;
+    }
+
+    public void setPostDeployApprovals(final ArrayList<ReleaseApproval> postDeployApprovals) {
+        this.postDeployApprovals = postDeployApprovals;
+    }
+
+    public ArrayList<ReleaseApproval> getPreDeployApprovals() {
+        return preDeployApprovals;
+    }
+
+    public void setPreDeployApprovals(final ArrayList<ReleaseApproval> preDeployApprovals) {
+        this.preDeployApprovals = preDeployApprovals;
+    }
+
+    public DeploymentReason getReason() {
+        return reason;
+    }
+
+    public void setReason(final DeploymentReason reason) {
+        this.reason = reason;
+    }
+
+    public ReleaseReference getRelease() {
+        return release;
+    }
+
+    public void setRelease(final ReleaseReference release) {
+        this.release = release;
+    }
+
+    public ShallowReference getReleaseDefinition() {
+        return releaseDefinition;
+    }
+
+    public void setReleaseDefinition(final ShallowReference releaseDefinition) {
+        this.releaseDefinition = releaseDefinition;
+    }
+
+    public ShallowReference getReleaseEnvironment() {
+        return releaseEnvironment;
+    }
+
+    public void setReleaseEnvironment(final ShallowReference releaseEnvironment) {
+        this.releaseEnvironment = releaseEnvironment;
+    }
+
+    public IdentityRef getRequestedBy() {
+        return requestedBy;
+    }
+
+    public void setRequestedBy(final IdentityRef requestedBy) {
+        this.requestedBy = requestedBy;
+    }
+
+    public Date getStartedOn() {
+        return startedOn;
+    }
+
+    public void setStartedOn(final Date startedOn) {
+        this.startedOn = startedOn;
+    }
+}

--- a/Rest/alm-releasemanagement-client/src/main/generated/com/microsoft/alm/visualstudio/services/releasemanagement/webapi/DeploymentAttempt.java
+++ b/Rest/alm-releasemanagement-client/src/main/generated/com/microsoft/alm/visualstudio/services/releasemanagement/webapi/DeploymentAttempt.java
@@ -16,7 +16,10 @@
 package com.microsoft.alm.visualstudio.services.releasemanagement.webapi;
 
 import java.util.ArrayList;
+import java.util.Date;
 import java.util.UUID;
+import com.microsoft.alm.visualstudio.services.releasemanagement.webapi.contracts.ReleaseDeployPhase;
+import com.microsoft.alm.visualstudio.services.webapi.IdentityRef;
 
 /** 
  */
@@ -33,7 +36,15 @@ public class DeploymentAttempt {
     private boolean hasStarted;
     private int id;
     private ReleaseTask job;
+    private IdentityRef lastModifiedBy;
+    private Date lastModifiedOn;
+    private DeploymentOperationStatus operationStatus;
+    private Date queuedOn;
+    private DeploymentReason reason;
+    private ArrayList<ReleaseDeployPhase> releaseDeployPhases;
+    private IdentityRef requestedBy;
     private UUID runPlanId;
+    private DeploymentStatus status;
     private ArrayList<ReleaseTask> tasks;
 
     public int getAttempt() {
@@ -88,12 +99,76 @@ public class DeploymentAttempt {
         this.job = job;
     }
 
+    public IdentityRef getLastModifiedBy() {
+        return lastModifiedBy;
+    }
+
+    public void setLastModifiedBy(final IdentityRef lastModifiedBy) {
+        this.lastModifiedBy = lastModifiedBy;
+    }
+
+    public Date getLastModifiedOn() {
+        return lastModifiedOn;
+    }
+
+    public void setLastModifiedOn(final Date lastModifiedOn) {
+        this.lastModifiedOn = lastModifiedOn;
+    }
+
+    public DeploymentOperationStatus getOperationStatus() {
+        return operationStatus;
+    }
+
+    public void setOperationStatus(final DeploymentOperationStatus operationStatus) {
+        this.operationStatus = operationStatus;
+    }
+
+    public Date getQueuedOn() {
+        return queuedOn;
+    }
+
+    public void setQueuedOn(final Date queuedOn) {
+        this.queuedOn = queuedOn;
+    }
+
+    public DeploymentReason getReason() {
+        return reason;
+    }
+
+    public void setReason(final DeploymentReason reason) {
+        this.reason = reason;
+    }
+
+    public ArrayList<ReleaseDeployPhase> getReleaseDeployPhases() {
+        return releaseDeployPhases;
+    }
+
+    public void setReleaseDeployPhases(final ArrayList<ReleaseDeployPhase> releaseDeployPhases) {
+        this.releaseDeployPhases = releaseDeployPhases;
+    }
+
+    public IdentityRef getRequestedBy() {
+        return requestedBy;
+    }
+
+    public void setRequestedBy(final IdentityRef requestedBy) {
+        this.requestedBy = requestedBy;
+    }
+
     public UUID getRunPlanId() {
         return runPlanId;
     }
 
     public void setRunPlanId(final UUID runPlanId) {
         this.runPlanId = runPlanId;
+    }
+
+    public DeploymentStatus getStatus() {
+        return status;
+    }
+
+    public void setStatus(final DeploymentStatus status) {
+        this.status = status;
     }
 
     public ArrayList<ReleaseTask> getTasks() {

--- a/Rest/alm-releasemanagement-client/src/main/generated/com/microsoft/alm/visualstudio/services/releasemanagement/webapi/DeploymentOperationStatus.java
+++ b/Rest/alm-releasemanagement-client/src/main/generated/com/microsoft/alm/visualstudio/services/releasemanagement/webapi/DeploymentOperationStatus.java
@@ -1,0 +1,111 @@
+// @formatter:off
+/*
+* ---------------------------------------------------------
+* Copyright(C) Microsoft Corporation. All rights reserved.
+* Licensed under the MIT license. See License.txt in the project root.
+* ---------------------------------------------------------
+*
+* ---------------------------------------------------------
+* Generated file, DO NOT EDIT
+* ---------------------------------------------------------
+*
+* See following wiki page for instructions on how to regenerate:
+*   https://vsowiki.com/index.php?title=Rest_Client_Generation
+*/
+
+package com.microsoft.alm.visualstudio.services.releasemanagement.webapi;
+
+
+/** 
+ */
+public enum DeploymentOperationStatus {
+
+    UNDEFINED(0),
+    QUEUED(1),
+    SCHEDULED(2),
+    PENDING(4),
+    APPROVED(8),
+    REJECTED(16),
+    DEFERRED(32),
+    QUEUED_FOR_AGENT(64),
+    PHASE_IN_PROGRESS(128),
+    PHASE_SUCCEEDED(256),
+    PHASE_PARTIALLY_SUCCEEDED(512),
+    PHASE_FAILED(1024),
+    CANCELED(2048),
+    PHASE_CANCELED(4096),
+    ;
+
+    private int value;
+
+    private DeploymentOperationStatus(final int value) {
+        this.value = value;
+    }
+
+    public int getValue() {
+        return value;
+    }
+
+    @Override
+    public String toString() {
+        final String name = super.toString();
+
+        if (name.equals("UNDEFINED")) { //$NON-NLS-1$
+            return "undefined"; //$NON-NLS-1$
+        }
+
+        if (name.equals("QUEUED")) { //$NON-NLS-1$
+            return "queued"; //$NON-NLS-1$
+        }
+
+        if (name.equals("SCHEDULED")) { //$NON-NLS-1$
+            return "scheduled"; //$NON-NLS-1$
+        }
+
+        if (name.equals("PENDING")) { //$NON-NLS-1$
+            return "pending"; //$NON-NLS-1$
+        }
+
+        if (name.equals("APPROVED")) { //$NON-NLS-1$
+            return "approved"; //$NON-NLS-1$
+        }
+
+        if (name.equals("REJECTED")) { //$NON-NLS-1$
+            return "rejected"; //$NON-NLS-1$
+        }
+
+        if (name.equals("DEFERRED")) { //$NON-NLS-1$
+            return "deferred"; //$NON-NLS-1$
+        }
+
+        if (name.equals("QUEUED_FOR_AGENT")) { //$NON-NLS-1$
+            return "queuedForAgent"; //$NON-NLS-1$
+        }
+
+        if (name.equals("PHASE_IN_PROGRESS")) { //$NON-NLS-1$
+            return "phaseInProgress"; //$NON-NLS-1$
+        }
+
+        if (name.equals("PHASE_SUCCEEDED")) { //$NON-NLS-1$
+            return "phaseSucceeded"; //$NON-NLS-1$
+        }
+
+        if (name.equals("PHASE_PARTIALLY_SUCCEEDED")) { //$NON-NLS-1$
+            return "phasePartiallySucceeded"; //$NON-NLS-1$
+        }
+
+        if (name.equals("PHASE_FAILED")) { //$NON-NLS-1$
+            return "phaseFailed"; //$NON-NLS-1$
+        }
+
+        if (name.equals("CANCELED")) { //$NON-NLS-1$
+            return "canceled"; //$NON-NLS-1$
+        }
+
+        if (name.equals("PHASE_CANCELED")) { //$NON-NLS-1$
+            return "phaseCanceled"; //$NON-NLS-1$
+        }
+
+        return null;
+    }
+}

--- a/Rest/alm-releasemanagement-client/src/main/generated/com/microsoft/alm/visualstudio/services/releasemanagement/webapi/DeploymentReason.java
+++ b/Rest/alm-releasemanagement-client/src/main/generated/com/microsoft/alm/visualstudio/services/releasemanagement/webapi/DeploymentReason.java
@@ -1,0 +1,61 @@
+// @formatter:off
+/*
+* ---------------------------------------------------------
+* Copyright(C) Microsoft Corporation. All rights reserved.
+* Licensed under the MIT license. See License.txt in the project root.
+* ---------------------------------------------------------
+*
+* ---------------------------------------------------------
+* Generated file, DO NOT EDIT
+* ---------------------------------------------------------
+*
+* See following wiki page for instructions on how to regenerate:
+*   https://vsowiki.com/index.php?title=Rest_Client_Generation
+*/
+
+package com.microsoft.alm.visualstudio.services.releasemanagement.webapi;
+
+
+/** 
+ */
+public enum DeploymentReason {
+
+    NONE(0),
+    MANUAL(1),
+    AUTOMATED(2),
+    SCHEDULED(4),
+    ;
+
+    private int value;
+
+    private DeploymentReason(final int value) {
+        this.value = value;
+    }
+
+    public int getValue() {
+        return value;
+    }
+
+    @Override
+    public String toString() {
+        final String name = super.toString();
+
+        if (name.equals("NONE")) { //$NON-NLS-1$
+            return "none"; //$NON-NLS-1$
+        }
+
+        if (name.equals("MANUAL")) { //$NON-NLS-1$
+            return "manual"; //$NON-NLS-1$
+        }
+
+        if (name.equals("AUTOMATED")) { //$NON-NLS-1$
+            return "automated"; //$NON-NLS-1$
+        }
+
+        if (name.equals("SCHEDULED")) { //$NON-NLS-1$
+            return "scheduled"; //$NON-NLS-1$
+        }
+
+        return null;
+    }
+}

--- a/Rest/alm-releasemanagement-client/src/main/generated/com/microsoft/alm/visualstudio/services/releasemanagement/webapi/DeploymentStatus.java
+++ b/Rest/alm-releasemanagement-client/src/main/generated/com/microsoft/alm/visualstudio/services/releasemanagement/webapi/DeploymentStatus.java
@@ -1,0 +1,71 @@
+// @formatter:off
+/*
+* ---------------------------------------------------------
+* Copyright(C) Microsoft Corporation. All rights reserved.
+* Licensed under the MIT license. See License.txt in the project root.
+* ---------------------------------------------------------
+*
+* ---------------------------------------------------------
+* Generated file, DO NOT EDIT
+* ---------------------------------------------------------
+*
+* See following wiki page for instructions on how to regenerate:
+*   https://vsowiki.com/index.php?title=Rest_Client_Generation
+*/
+
+package com.microsoft.alm.visualstudio.services.releasemanagement.webapi;
+
+
+/** 
+ */
+public enum DeploymentStatus {
+
+    UNDEFINED(0),
+    NOT_DEPLOYED(1),
+    IN_PROGRESS(2),
+    SUCCEEDED(4),
+    PARTIALLY_SUCCEEDED(8),
+    FAILED(16),
+    ;
+
+    private int value;
+
+    private DeploymentStatus(final int value) {
+        this.value = value;
+    }
+
+    public int getValue() {
+        return value;
+    }
+
+    @Override
+    public String toString() {
+        final String name = super.toString();
+
+        if (name.equals("UNDEFINED")) { //$NON-NLS-1$
+            return "undefined"; //$NON-NLS-1$
+        }
+
+        if (name.equals("NOT_DEPLOYED")) { //$NON-NLS-1$
+            return "notDeployed"; //$NON-NLS-1$
+        }
+
+        if (name.equals("IN_PROGRESS")) { //$NON-NLS-1$
+            return "inProgress"; //$NON-NLS-1$
+        }
+
+        if (name.equals("SUCCEEDED")) { //$NON-NLS-1$
+            return "succeeded"; //$NON-NLS-1$
+        }
+
+        if (name.equals("PARTIALLY_SUCCEEDED")) { //$NON-NLS-1$
+            return "partiallySucceeded"; //$NON-NLS-1$
+        }
+
+        if (name.equals("FAILED")) { //$NON-NLS-1$
+            return "failed"; //$NON-NLS-1$
+        }
+
+        return null;
+    }
+}

--- a/Rest/alm-releasemanagement-client/src/main/generated/com/microsoft/alm/visualstudio/services/releasemanagement/webapi/ManualIntervention.java
+++ b/Rest/alm-releasemanagement-client/src/main/generated/com/microsoft/alm/visualstudio/services/releasemanagement/webapi/ManualIntervention.java
@@ -1,0 +1,135 @@
+// @formatter:off
+/*
+* ---------------------------------------------------------
+* Copyright(C) Microsoft Corporation. All rights reserved.
+* Licensed under the MIT license. See License.txt in the project root.
+* ---------------------------------------------------------
+*
+* ---------------------------------------------------------
+* Generated file, DO NOT EDIT
+* ---------------------------------------------------------
+*
+* See following wiki page for instructions on how to regenerate:
+*   https://vsowiki.com/index.php?title=Rest_Client_Generation
+*/
+
+package com.microsoft.alm.visualstudio.services.releasemanagement.webapi;
+
+import java.util.Date;
+import java.util.UUID;
+import com.microsoft.alm.visualstudio.services.releasemanagement.webapi.contracts.ShallowReference;
+import com.microsoft.alm.visualstudio.services.webapi.IdentityRef;
+
+/** 
+ */
+public class ManualIntervention {
+
+    private IdentityRef approver;
+    private String comments;
+    private Date createdOn;
+    private int id;
+    private String instructions;
+    private Date modifiedOn;
+    private ShallowReference release;
+    private ShallowReference releaseDefinition;
+    private ShallowReference releaseEnvironment;
+    private ManualInterventionStatus status;
+    private UUID taskInstanceId;
+    private String url;
+
+    public IdentityRef getApprover() {
+        return approver;
+    }
+
+    public void setApprover(final IdentityRef approver) {
+        this.approver = approver;
+    }
+
+    public String getComments() {
+        return comments;
+    }
+
+    public void setComments(final String comments) {
+        this.comments = comments;
+    }
+
+    public Date getCreatedOn() {
+        return createdOn;
+    }
+
+    public void setCreatedOn(final Date createdOn) {
+        this.createdOn = createdOn;
+    }
+
+    public int getId() {
+        return id;
+    }
+
+    public void setId(final int id) {
+        this.id = id;
+    }
+
+    public String getInstructions() {
+        return instructions;
+    }
+
+    public void setInstructions(final String instructions) {
+        this.instructions = instructions;
+    }
+
+    public Date getModifiedOn() {
+        return modifiedOn;
+    }
+
+    public void setModifiedOn(final Date modifiedOn) {
+        this.modifiedOn = modifiedOn;
+    }
+
+    public ShallowReference getRelease() {
+        return release;
+    }
+
+    public void setRelease(final ShallowReference release) {
+        this.release = release;
+    }
+
+    public ShallowReference getReleaseDefinition() {
+        return releaseDefinition;
+    }
+
+    public void setReleaseDefinition(final ShallowReference releaseDefinition) {
+        this.releaseDefinition = releaseDefinition;
+    }
+
+    public ShallowReference getReleaseEnvironment() {
+        return releaseEnvironment;
+    }
+
+    public void setReleaseEnvironment(final ShallowReference releaseEnvironment) {
+        this.releaseEnvironment = releaseEnvironment;
+    }
+
+    public ManualInterventionStatus getStatus() {
+        return status;
+    }
+
+    public void setStatus(final ManualInterventionStatus status) {
+        this.status = status;
+    }
+
+    public UUID getTaskInstanceId() {
+        return taskInstanceId;
+    }
+
+    public void setTaskInstanceId(final UUID taskInstanceId) {
+        this.taskInstanceId = taskInstanceId;
+    }
+
+    public String getUrl() {
+        return url;
+    }
+
+    public void setUrl(final String url) {
+        this.url = url;
+    }
+}

--- a/Rest/alm-releasemanagement-client/src/main/generated/com/microsoft/alm/visualstudio/services/releasemanagement/webapi/ManualInterventionStatus.java
+++ b/Rest/alm-releasemanagement-client/src/main/generated/com/microsoft/alm/visualstudio/services/releasemanagement/webapi/ManualInterventionStatus.java
@@ -1,0 +1,66 @@
+// @formatter:off
+/*
+* ---------------------------------------------------------
+* Copyright(C) Microsoft Corporation. All rights reserved.
+* Licensed under the MIT license. See License.txt in the project root.
+* ---------------------------------------------------------
+*
+* ---------------------------------------------------------
+* Generated file, DO NOT EDIT
+* ---------------------------------------------------------
+*
+* See following wiki page for instructions on how to regenerate:
+*   https://vsowiki.com/index.php?title=Rest_Client_Generation
+*/
+
+package com.microsoft.alm.visualstudio.services.releasemanagement.webapi;
+
+
+/** 
+ */
+public enum ManualInterventionStatus {
+
+    UNKNOWN(0),
+    PENDING(1),
+    REJECTED(2),
+    APPROVED(4),
+    CANCELED(8),
+    ;
+
+    private int value;
+
+    private ManualInterventionStatus(final int value) {
+        this.value = value;
+    }
+
+    public int getValue() {
+        return value;
+    }
+
+    @Override
+    public String toString() {
+        final String name = super.toString();
+
+        if (name.equals("UNKNOWN")) { //$NON-NLS-1$
+            return "unknown"; //$NON-NLS-1$
+        }
+
+        if (name.equals("PENDING")) { //$NON-NLS-1$
+            return "pending"; //$NON-NLS-1$
+        }
+
+        if (name.equals("REJECTED")) { //$NON-NLS-1$
+            return "rejected"; //$NON-NLS-1$
+        }
+
+        if (name.equals("APPROVED")) { //$NON-NLS-1$
+            return "approved"; //$NON-NLS-1$
+        }
+
+        if (name.equals("CANCELED")) { //$NON-NLS-1$
+            return "canceled"; //$NON-NLS-1$
+        }
+
+        return null;
+    }
+}

--- a/Rest/alm-releasemanagement-client/src/main/generated/com/microsoft/alm/visualstudio/services/releasemanagement/webapi/ManualInterventionUpdateMetadata.java
+++ b/Rest/alm-releasemanagement-client/src/main/generated/com/microsoft/alm/visualstudio/services/releasemanagement/webapi/ManualInterventionUpdateMetadata.java
@@ -1,0 +1,41 @@
+// @formatter:off
+/*
+* ---------------------------------------------------------
+* Copyright(C) Microsoft Corporation. All rights reserved.
+* Licensed under the MIT license. See License.txt in the project root.
+* ---------------------------------------------------------
+*
+* ---------------------------------------------------------
+* Generated file, DO NOT EDIT
+* ---------------------------------------------------------
+*
+* See following wiki page for instructions on how to regenerate:
+*   https://vsowiki.com/index.php?title=Rest_Client_Generation
+*/
+
+package com.microsoft.alm.visualstudio.services.releasemanagement.webapi;
+
+
+/** 
+ */
+public class ManualInterventionUpdateMetadata {
+
+    private String comment;
+    private ManualInterventionStatus status;
+
+    public String getComment() {
+        return comment;
+    }
+
+    public void setComment(final String comment) {
+        this.comment = comment;
+    }
+
+    public ManualInterventionStatus getStatus() {
+        return status;
+    }
+
+    public void setStatus(final ManualInterventionStatus status) {
+        this.status = status;
+    }
+}

--- a/Rest/alm-releasemanagement-client/src/main/generated/com/microsoft/alm/visualstudio/services/releasemanagement/webapi/Release.java
+++ b/Rest/alm-releasemanagement-client/src/main/generated/com/microsoft/alm/visualstudio/services/releasemanagement/webapi/Release.java
@@ -18,14 +18,17 @@ package com.microsoft.alm.visualstudio.services.releasemanagement.webapi;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.HashMap;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.microsoft.alm.visualstudio.services.releasemanagement.webapi.contracts.Artifact;
 import com.microsoft.alm.visualstudio.services.releasemanagement.webapi.contracts.ShallowReference;
 import com.microsoft.alm.visualstudio.services.webapi.IdentityRef;
+import com.microsoft.alm.visualstudio.services.webapi.ReferenceLinks;
 
 /** 
  */
 public class Release {
 
+    private ReferenceLinks _links;
     private ArrayList<Artifact> artifacts;
     private String comment;
     private IdentityRef createdBy;
@@ -46,6 +49,16 @@ public class Release {
     private ReleaseStatus status;
     private String url;
     private HashMap<String, ConfigurationVariableValue> variables;
+
+    @JsonProperty("_links")
+    public ReferenceLinks getLinks() {
+        return _links;
+    }
+
+    @JsonProperty("_links")
+    public void setLinks(final ReferenceLinks _links) {
+        this._links = _links;
+    }
 
     public ArrayList<Artifact> getArtifacts() {
         return artifacts;

--- a/Rest/alm-releasemanagement-client/src/main/generated/com/microsoft/alm/visualstudio/services/releasemanagement/webapi/ReleaseDefinition.java
+++ b/Rest/alm-releasemanagement-client/src/main/generated/com/microsoft/alm/visualstudio/services/releasemanagement/webapi/ReleaseDefinition.java
@@ -18,15 +18,18 @@ package com.microsoft.alm.visualstudio.services.releasemanagement.webapi;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.HashMap;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.microsoft.alm.visualstudio.services.releasemanagement.webapi.contracts.Artifact;
 import com.microsoft.alm.visualstudio.services.releasemanagement.webapi.contracts.ReleaseDefinitionEnvironment;
 import com.microsoft.alm.visualstudio.services.releasemanagement.webapi.contracts.RetentionPolicy;
 import com.microsoft.alm.visualstudio.services.webapi.IdentityRef;
+import com.microsoft.alm.visualstudio.services.webapi.ReferenceLinks;
 
 /** 
  */
 public class ReleaseDefinition {
 
+    private ReferenceLinks _links;
     private ArrayList<Artifact> artifacts;
     private String comment;
     private IdentityRef createdBy;
@@ -42,6 +45,16 @@ public class ReleaseDefinition {
     private ArrayList<ReleaseTriggerBase> triggers;
     private String url;
     private HashMap<String, ConfigurationVariableValue> variables;
+
+    @JsonProperty("_links")
+    public ReferenceLinks getLinks() {
+        return _links;
+    }
+
+    @JsonProperty("_links")
+    public void setLinks(final ReferenceLinks _links) {
+        this._links = _links;
+    }
 
     public ArrayList<Artifact> getArtifacts() {
         return artifacts;

--- a/Rest/alm-releasemanagement-client/src/main/generated/com/microsoft/alm/visualstudio/services/releasemanagement/webapi/ReleaseEnvironment.java
+++ b/Rest/alm-releasemanagement-client/src/main/generated/com/microsoft/alm/visualstudio/services/releasemanagement/webapi/ReleaseEnvironment.java
@@ -20,6 +20,7 @@ import java.util.Date;
 import java.util.HashMap;
 import com.microsoft.alm.visualstudio.services.releasemanagement.webapi.contracts.conditions.Condition;
 import com.microsoft.alm.visualstudio.services.releasemanagement.webapi.contracts.Demand;
+import com.microsoft.alm.visualstudio.services.releasemanagement.webapi.contracts.DeployPhase;
 import com.microsoft.alm.visualstudio.services.releasemanagement.webapi.contracts.ReleaseDefinitionApprovals;
 import com.microsoft.alm.visualstudio.services.releasemanagement.webapi.contracts.ShallowReference;
 import com.microsoft.alm.visualstudio.services.releasemanagement.webapi.contracts.WorkflowTask;
@@ -33,6 +34,7 @@ public class ReleaseEnvironment {
     private Date createdOn;
     private int definitionEnvironmentId;
     private ArrayList<Demand> demands;
+    private ArrayList<DeployPhase> deployPhasesSnapshot;
     private ArrayList<DeploymentAttempt> deploySteps;
     private EnvironmentOptions environmentOptions;
     private int id;
@@ -90,6 +92,14 @@ public class ReleaseEnvironment {
 
     public void setDemands(final ArrayList<Demand> demands) {
         this.demands = demands;
+    }
+
+    public ArrayList<DeployPhase> getDeployPhasesSnapshot() {
+        return deployPhasesSnapshot;
+    }
+
+    public void setDeployPhasesSnapshot(final ArrayList<DeployPhase> deployPhasesSnapshot) {
+        this.deployPhasesSnapshot = deployPhasesSnapshot;
     }
 
     public ArrayList<DeploymentAttempt> getDeploySteps() {

--- a/Rest/alm-releasemanagement-client/src/main/generated/com/microsoft/alm/visualstudio/services/releasemanagement/webapi/ReleaseHttpClientBase.java
+++ b/Rest/alm-releasemanagement-client/src/main/generated/com/microsoft/alm/visualstudio/services/releasemanagement/webapi/ReleaseHttpClientBase.java
@@ -24,8 +24,12 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import com.fasterxml.jackson.core.type.TypeReference;
+import com.microsoft.alm.client.HttpMethod;
 import com.microsoft.alm.client.model.NameValueCollection;
 import com.microsoft.alm.client.VssHttpClientBase;
+import com.microsoft.alm.client.VssMediaTypes;
+import com.microsoft.alm.client.VssRestClientHandler;
+import com.microsoft.alm.client.VssRestRequest;
 import com.microsoft.alm.visualstudio.services.forminput.InputValuesQuery;
 import com.microsoft.alm.visualstudio.services.releasemanagement.webapi.ApprovalStatus;
 import com.microsoft.alm.visualstudio.services.releasemanagement.webapi.ApprovalType;
@@ -41,7 +45,11 @@ import com.microsoft.alm.visualstudio.services.releasemanagement.webapi.contract
 import com.microsoft.alm.visualstudio.services.releasemanagement.webapi.contracts.ReleaseExpands;
 import com.microsoft.alm.visualstudio.services.releasemanagement.webapi.contracts.ReleaseRevision;
 import com.microsoft.alm.visualstudio.services.releasemanagement.webapi.contracts.ReleaseWorkItemRef;
+import com.microsoft.alm.visualstudio.services.releasemanagement.webapi.Deployment;
+import com.microsoft.alm.visualstudio.services.releasemanagement.webapi.DeploymentStatus;
 import com.microsoft.alm.visualstudio.services.releasemanagement.webapi.MailMessage;
+import com.microsoft.alm.visualstudio.services.releasemanagement.webapi.ManualIntervention;
+import com.microsoft.alm.visualstudio.services.releasemanagement.webapi.ManualInterventionUpdateMetadata;
 import com.microsoft.alm.visualstudio.services.releasemanagement.webapi.Release;
 import com.microsoft.alm.visualstudio.services.releasemanagement.webapi.ReleaseApproval;
 import com.microsoft.alm.visualstudio.services.releasemanagement.webapi.ReleaseDefinition;
@@ -68,22 +76,13 @@ public abstract class ReleaseHttpClientBase
     * Create a new instance of ReleaseHttpClientBase
     *
     * @param jaxrsClient
-    *            an initialized instance of a JAX-RS Client implementation
+    *            a DefaultRestClientHandler initialized with an instance of a JAX-RS Client implementation or
+    *            a TEERestClientHamdler initialized with TEE HTTP client implementation
     * @param baseUrl
-    *            a TFS project collection URL
+    *            a TFS services URL
     */
-    protected ReleaseHttpClientBase(final Object jaxrsClient, final URI baseUrl) {
-        super(jaxrsClient, baseUrl);
-    }
-
-    /**
-    * Create a new instance of ReleaseHttpClientBase
-    *
-    * @param tfsConnection
-    *            an initialized instance of a TfsTeamProjectCollection
-    */
-    protected ReleaseHttpClientBase(final Object tfsConnection) {
-        super(tfsConnection);
+    protected ReleaseHttpClientBase(final VssRestClientHandler clientHandler, final URI baseUrl) {
+        super(clientHandler, baseUrl);
     }
 
     @Override
@@ -111,11 +110,11 @@ public abstract class ReleaseHttpClientBase
         routeValues.put("project", project); //$NON-NLS-1$
         routeValues.put("releaseId", releaseId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<AgentArtifactDefinition>>() {});
     }
@@ -140,11 +139,11 @@ public abstract class ReleaseHttpClientBase
         routeValues.put("project", project); //$NON-NLS-1$
         routeValues.put("releaseId", releaseId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<AgentArtifactDefinition>>() {});
     }
@@ -169,11 +168,11 @@ public abstract class ReleaseHttpClientBase
         routeValues.put("project", project); //$NON-NLS-1$
         routeValues.put("approvalStepId", approvalStepId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, ReleaseApproval.class);
     }
@@ -198,11 +197,11 @@ public abstract class ReleaseHttpClientBase
         routeValues.put("project", project); //$NON-NLS-1$
         routeValues.put("approvalStepId", approvalStepId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, ReleaseApproval.class);
     }
@@ -233,12 +232,12 @@ public abstract class ReleaseHttpClientBase
         final NameValueCollection queryParameters = new NameValueCollection();
         queryParameters.addIfNotNull("includeHistory", includeHistory); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, ReleaseApproval.class);
     }
@@ -269,12 +268,12 @@ public abstract class ReleaseHttpClientBase
         final NameValueCollection queryParameters = new NameValueCollection();
         queryParameters.addIfNotNull("includeHistory", includeHistory); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, ReleaseApproval.class);
     }
@@ -302,13 +301,13 @@ public abstract class ReleaseHttpClientBase
         routeValues.put("project", project); //$NON-NLS-1$
         routeValues.put("approvalId", approvalId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.PATCH,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       approval,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.PATCH,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               approval,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, ReleaseApproval.class);
     }
@@ -336,13 +335,13 @@ public abstract class ReleaseHttpClientBase
         routeValues.put("project", project); //$NON-NLS-1$
         routeValues.put("approvalId", approvalId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.PATCH,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       approval,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.PATCH,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               approval,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, ReleaseApproval.class);
     }
@@ -397,12 +396,12 @@ public abstract class ReleaseHttpClientBase
         queryParameters.addIfNotNull("queryOrder", queryOrder); //$NON-NLS-1$
         queryParameters.addIfNotNull("includeMyGroupApprovals", includeMyGroupApprovals); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<ReleaseApproval>>() {});
     }
@@ -457,12 +456,12 @@ public abstract class ReleaseHttpClientBase
         queryParameters.addIfNotNull("queryOrder", queryOrder); //$NON-NLS-1$
         queryParameters.addIfNotNull("includeMyGroupApprovals", includeMyGroupApprovals); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<ReleaseApproval>>() {});
     }
@@ -497,12 +496,12 @@ public abstract class ReleaseHttpClientBase
         queryParameters.addIfNotNull("baseReleaseId", baseReleaseId); //$NON-NLS-1$
         queryParameters.addIfNotNull("$top", top); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<Change>>() {});
     }
@@ -537,18 +536,18 @@ public abstract class ReleaseHttpClientBase
         queryParameters.addIfNotNull("baseReleaseId", baseReleaseId); //$NON-NLS-1$
         queryParameters.addIfNotNull("$top", top); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<Change>>() {});
     }
 
     /** 
-     * [Preview API 3.0-preview.2]
+     * [Preview API 3.0-preview.3]
      * 
      * @param releaseDefinition 
      *            
@@ -561,24 +560,24 @@ public abstract class ReleaseHttpClientBase
         final String project) { 
 
         final UUID locationId = UUID.fromString("d8f96f24-8ea7-4cb6-baab-2df8fc515665"); //$NON-NLS-1$
-        final ApiResourceVersion apiVersion = new ApiResourceVersion("3.0-preview.2"); //$NON-NLS-1$
+        final ApiResourceVersion apiVersion = new ApiResourceVersion("3.0-preview.3"); //$NON-NLS-1$
 
         final Map<String, Object> routeValues = new HashMap<String, Object>();
         routeValues.put("project", project); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.POST,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       releaseDefinition,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.POST,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               releaseDefinition,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, ReleaseDefinition.class);
     }
 
     /** 
-     * [Preview API 3.0-preview.2]
+     * [Preview API 3.0-preview.3]
      * 
      * @param releaseDefinition 
      *            
@@ -591,24 +590,24 @@ public abstract class ReleaseHttpClientBase
         final UUID project) { 
 
         final UUID locationId = UUID.fromString("d8f96f24-8ea7-4cb6-baab-2df8fc515665"); //$NON-NLS-1$
-        final ApiResourceVersion apiVersion = new ApiResourceVersion("3.0-preview.2"); //$NON-NLS-1$
+        final ApiResourceVersion apiVersion = new ApiResourceVersion("3.0-preview.3"); //$NON-NLS-1$
 
         final Map<String, Object> routeValues = new HashMap<String, Object>();
         routeValues.put("project", project); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.POST,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       releaseDefinition,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.POST,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               releaseDefinition,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, ReleaseDefinition.class);
     }
 
     /** 
-     * [Preview API 3.0-preview.2]
+     * [Preview API 3.0-preview.3]
      * 
      * @param project 
      *            Project ID or project name
@@ -620,23 +619,23 @@ public abstract class ReleaseHttpClientBase
         final int definitionId) { 
 
         final UUID locationId = UUID.fromString("d8f96f24-8ea7-4cb6-baab-2df8fc515665"); //$NON-NLS-1$
-        final ApiResourceVersion apiVersion = new ApiResourceVersion("3.0-preview.2"); //$NON-NLS-1$
+        final ApiResourceVersion apiVersion = new ApiResourceVersion("3.0-preview.3"); //$NON-NLS-1$
 
         final Map<String, Object> routeValues = new HashMap<String, Object>();
         routeValues.put("project", project); //$NON-NLS-1$
         routeValues.put("definitionId", definitionId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.DELETE,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.DELETE,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         super.sendRequest(httpRequest);
     }
 
     /** 
-     * [Preview API 3.0-preview.2]
+     * [Preview API 3.0-preview.3]
      * 
      * @param project 
      *            Project ID
@@ -648,23 +647,23 @@ public abstract class ReleaseHttpClientBase
         final int definitionId) { 
 
         final UUID locationId = UUID.fromString("d8f96f24-8ea7-4cb6-baab-2df8fc515665"); //$NON-NLS-1$
-        final ApiResourceVersion apiVersion = new ApiResourceVersion("3.0-preview.2"); //$NON-NLS-1$
+        final ApiResourceVersion apiVersion = new ApiResourceVersion("3.0-preview.3"); //$NON-NLS-1$
 
         final Map<String, Object> routeValues = new HashMap<String, Object>();
         routeValues.put("project", project); //$NON-NLS-1$
         routeValues.put("definitionId", definitionId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.DELETE,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.DELETE,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         super.sendRequest(httpRequest);
     }
 
     /** 
-     * [Preview API 3.0-preview.2]
+     * [Preview API 3.0-preview.3]
      * 
      * @param project 
      *            Project ID or project name
@@ -677,23 +676,23 @@ public abstract class ReleaseHttpClientBase
         final int definitionId) { 
 
         final UUID locationId = UUID.fromString("d8f96f24-8ea7-4cb6-baab-2df8fc515665"); //$NON-NLS-1$
-        final ApiResourceVersion apiVersion = new ApiResourceVersion("3.0-preview.2"); //$NON-NLS-1$
+        final ApiResourceVersion apiVersion = new ApiResourceVersion("3.0-preview.3"); //$NON-NLS-1$
 
         final Map<String, Object> routeValues = new HashMap<String, Object>();
         routeValues.put("project", project); //$NON-NLS-1$
         routeValues.put("definitionId", definitionId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, ReleaseDefinition.class);
     }
 
     /** 
-     * [Preview API 3.0-preview.2]
+     * [Preview API 3.0-preview.3]
      * 
      * @param project 
      *            Project ID
@@ -706,23 +705,95 @@ public abstract class ReleaseHttpClientBase
         final int definitionId) { 
 
         final UUID locationId = UUID.fromString("d8f96f24-8ea7-4cb6-baab-2df8fc515665"); //$NON-NLS-1$
-        final ApiResourceVersion apiVersion = new ApiResourceVersion("3.0-preview.2"); //$NON-NLS-1$
+        final ApiResourceVersion apiVersion = new ApiResourceVersion("3.0-preview.3"); //$NON-NLS-1$
 
         final Map<String, Object> routeValues = new HashMap<String, Object>();
         routeValues.put("project", project); //$NON-NLS-1$
         routeValues.put("definitionId", definitionId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, ReleaseDefinition.class);
     }
 
     /** 
-     * [Preview API 3.0-preview.2]
+     * [Preview API 3.0-preview.3]
+     * 
+     * @param project 
+     *            Project ID or project name
+     * @param definitionId 
+     *            
+     * @param revision 
+     *            
+     * @return InputStream
+     */
+    public InputStream getReleaseDefinitionRevision(
+        final String project, 
+        final int definitionId, 
+        final int revision) { 
+
+        final UUID locationId = UUID.fromString("d8f96f24-8ea7-4cb6-baab-2df8fc515665"); //$NON-NLS-1$
+        final ApiResourceVersion apiVersion = new ApiResourceVersion("3.0-preview.3"); //$NON-NLS-1$
+
+        final Map<String, Object> routeValues = new HashMap<String, Object>();
+        routeValues.put("project", project); //$NON-NLS-1$
+        routeValues.put("definitionId", definitionId); //$NON-NLS-1$
+
+        final NameValueCollection queryParameters = new NameValueCollection();
+        queryParameters.put("revision", String.valueOf(revision)); //$NON-NLS-1$
+
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.TEXT_PLAIN_TYPE);
+
+        return super.sendRequest(httpRequest, InputStream.class);
+    }
+
+    /** 
+     * [Preview API 3.0-preview.3]
+     * 
+     * @param project 
+     *            Project ID
+     * @param definitionId 
+     *            
+     * @param revision 
+     *            
+     * @return InputStream
+     */
+    public InputStream getReleaseDefinitionRevision(
+        final UUID project, 
+        final int definitionId, 
+        final int revision) { 
+
+        final UUID locationId = UUID.fromString("d8f96f24-8ea7-4cb6-baab-2df8fc515665"); //$NON-NLS-1$
+        final ApiResourceVersion apiVersion = new ApiResourceVersion("3.0-preview.3"); //$NON-NLS-1$
+
+        final Map<String, Object> routeValues = new HashMap<String, Object>();
+        routeValues.put("project", project); //$NON-NLS-1$
+        routeValues.put("definitionId", definitionId); //$NON-NLS-1$
+
+        final NameValueCollection queryParameters = new NameValueCollection();
+        queryParameters.put("revision", String.valueOf(revision)); //$NON-NLS-1$
+
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.TEXT_PLAIN_TYPE);
+
+        return super.sendRequest(httpRequest, InputStream.class);
+    }
+
+    /** 
+     * [Preview API 3.0-preview.3]
      * 
      * @param project 
      *            Project ID or project name
@@ -738,7 +809,7 @@ public abstract class ReleaseHttpClientBase
         final ReleaseDefinitionExpands expand) { 
 
         final UUID locationId = UUID.fromString("d8f96f24-8ea7-4cb6-baab-2df8fc515665"); //$NON-NLS-1$
-        final ApiResourceVersion apiVersion = new ApiResourceVersion("3.0-preview.2"); //$NON-NLS-1$
+        final ApiResourceVersion apiVersion = new ApiResourceVersion("3.0-preview.3"); //$NON-NLS-1$
 
         final Map<String, Object> routeValues = new HashMap<String, Object>();
         routeValues.put("project", project); //$NON-NLS-1$
@@ -747,18 +818,18 @@ public abstract class ReleaseHttpClientBase
         queryParameters.addIfNotEmpty("searchText", searchText); //$NON-NLS-1$
         queryParameters.addIfNotNull("$expand", expand); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<ReleaseDefinition>>() {});
     }
 
     /** 
-     * [Preview API 3.0-preview.2]
+     * [Preview API 3.0-preview.3]
      * 
      * @param project 
      *            Project ID
@@ -774,7 +845,7 @@ public abstract class ReleaseHttpClientBase
         final ReleaseDefinitionExpands expand) { 
 
         final UUID locationId = UUID.fromString("d8f96f24-8ea7-4cb6-baab-2df8fc515665"); //$NON-NLS-1$
-        final ApiResourceVersion apiVersion = new ApiResourceVersion("3.0-preview.2"); //$NON-NLS-1$
+        final ApiResourceVersion apiVersion = new ApiResourceVersion("3.0-preview.3"); //$NON-NLS-1$
 
         final Map<String, Object> routeValues = new HashMap<String, Object>();
         routeValues.put("project", project); //$NON-NLS-1$
@@ -783,18 +854,18 @@ public abstract class ReleaseHttpClientBase
         queryParameters.addIfNotEmpty("searchText", searchText); //$NON-NLS-1$
         queryParameters.addIfNotNull("$expand", expand); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<ReleaseDefinition>>() {});
     }
 
     /** 
-     * [Preview API 3.0-preview.2]
+     * [Preview API 3.0-preview.3]
      * 
      * @param project 
      *            Project ID or project name
@@ -813,7 +884,7 @@ public abstract class ReleaseHttpClientBase
         final ReleaseDefinitionExpands expand) { 
 
         final UUID locationId = UUID.fromString("d8f96f24-8ea7-4cb6-baab-2df8fc515665"); //$NON-NLS-1$
-        final ApiResourceVersion apiVersion = new ApiResourceVersion("3.0-preview.2"); //$NON-NLS-1$
+        final ApiResourceVersion apiVersion = new ApiResourceVersion("3.0-preview.3"); //$NON-NLS-1$
 
         final Map<String, Object> routeValues = new HashMap<String, Object>();
         routeValues.put("project", project); //$NON-NLS-1$
@@ -823,18 +894,18 @@ public abstract class ReleaseHttpClientBase
         queryParameters.addIfNotEmpty("artifactSourceId", artifactSourceId); //$NON-NLS-1$
         queryParameters.addIfNotNull("$expand", expand); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<ReleaseDefinition>>() {});
     }
 
     /** 
-     * [Preview API 3.0-preview.2]
+     * [Preview API 3.0-preview.3]
      * 
      * @param project 
      *            Project ID
@@ -853,7 +924,7 @@ public abstract class ReleaseHttpClientBase
         final ReleaseDefinitionExpands expand) { 
 
         final UUID locationId = UUID.fromString("d8f96f24-8ea7-4cb6-baab-2df8fc515665"); //$NON-NLS-1$
-        final ApiResourceVersion apiVersion = new ApiResourceVersion("3.0-preview.2"); //$NON-NLS-1$
+        final ApiResourceVersion apiVersion = new ApiResourceVersion("3.0-preview.3"); //$NON-NLS-1$
 
         final Map<String, Object> routeValues = new HashMap<String, Object>();
         routeValues.put("project", project); //$NON-NLS-1$
@@ -863,18 +934,18 @@ public abstract class ReleaseHttpClientBase
         queryParameters.addIfNotEmpty("artifactSourceId", artifactSourceId); //$NON-NLS-1$
         queryParameters.addIfNotNull("$expand", expand); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<ReleaseDefinition>>() {});
     }
 
     /** 
-     * [Preview API 3.0-preview.2]
+     * [Preview API 3.0-preview.3]
      * 
      * @param releaseDefinition 
      *            
@@ -887,24 +958,24 @@ public abstract class ReleaseHttpClientBase
         final String project) { 
 
         final UUID locationId = UUID.fromString("d8f96f24-8ea7-4cb6-baab-2df8fc515665"); //$NON-NLS-1$
-        final ApiResourceVersion apiVersion = new ApiResourceVersion("3.0-preview.2"); //$NON-NLS-1$
+        final ApiResourceVersion apiVersion = new ApiResourceVersion("3.0-preview.3"); //$NON-NLS-1$
 
         final Map<String, Object> routeValues = new HashMap<String, Object>();
         routeValues.put("project", project); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.PUT,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       releaseDefinition,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.PUT,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               releaseDefinition,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, ReleaseDefinition.class);
     }
 
     /** 
-     * [Preview API 3.0-preview.2]
+     * [Preview API 3.0-preview.3]
      * 
      * @param releaseDefinition 
      *            
@@ -917,24 +988,144 @@ public abstract class ReleaseHttpClientBase
         final UUID project) { 
 
         final UUID locationId = UUID.fromString("d8f96f24-8ea7-4cb6-baab-2df8fc515665"); //$NON-NLS-1$
-        final ApiResourceVersion apiVersion = new ApiResourceVersion("3.0-preview.2"); //$NON-NLS-1$
+        final ApiResourceVersion apiVersion = new ApiResourceVersion("3.0-preview.3"); //$NON-NLS-1$
 
         final Map<String, Object> routeValues = new HashMap<String, Object>();
         routeValues.put("project", project); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.PUT,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       releaseDefinition,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.PUT,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               releaseDefinition,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, ReleaseDefinition.class);
     }
 
     /** 
-     * [Preview API 3.0-preview.3]
+     * [Preview API 3.0-preview.1]
+     * 
+     * @param project 
+     *            Project ID or project name
+     * @param definitionId 
+     *            
+     * @param definitionEnvironmentId 
+     *            
+     * @param createdBy 
+     *            
+     * @param operationStatus 
+     *            
+     * @param deploymentStatus 
+     *            
+     * @param queryOrder 
+     *            
+     * @param top 
+     *            
+     * @param continuationToken 
+     *            
+     * @return ArrayList&lt;Deployment&gt;
+     */
+    public ArrayList<Deployment> getDeployments(
+        final String project, 
+        final Integer definitionId, 
+        final Integer definitionEnvironmentId, 
+        final String createdBy, 
+        final DeploymentStatus operationStatus, 
+        final DeploymentStatus deploymentStatus, 
+        final ReleaseQueryOrder queryOrder, 
+        final Integer top, 
+        final Integer continuationToken) { 
+
+        final UUID locationId = UUID.fromString("b005ef73-cddc-448e-9ba2-5193bf36b19f"); //$NON-NLS-1$
+        final ApiResourceVersion apiVersion = new ApiResourceVersion("3.0-preview.1"); //$NON-NLS-1$
+
+        final Map<String, Object> routeValues = new HashMap<String, Object>();
+        routeValues.put("project", project); //$NON-NLS-1$
+
+        final NameValueCollection queryParameters = new NameValueCollection();
+        queryParameters.addIfNotNull("definitionId", definitionId); //$NON-NLS-1$
+        queryParameters.addIfNotNull("definitionEnvironmentId", definitionEnvironmentId); //$NON-NLS-1$
+        queryParameters.addIfNotEmpty("createdBy", createdBy); //$NON-NLS-1$
+        queryParameters.addIfNotNull("operationStatus", operationStatus); //$NON-NLS-1$
+        queryParameters.addIfNotNull("deploymentStatus", deploymentStatus); //$NON-NLS-1$
+        queryParameters.addIfNotNull("queryOrder", queryOrder); //$NON-NLS-1$
+        queryParameters.addIfNotNull("$top", top); //$NON-NLS-1$
+        queryParameters.addIfNotNull("continuationToken", continuationToken); //$NON-NLS-1$
+
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
+
+        return super.sendRequest(httpRequest, new TypeReference<ArrayList<Deployment>>() {});
+    }
+
+    /** 
+     * [Preview API 3.0-preview.1]
+     * 
+     * @param project 
+     *            Project ID
+     * @param definitionId 
+     *            
+     * @param definitionEnvironmentId 
+     *            
+     * @param createdBy 
+     *            
+     * @param operationStatus 
+     *            
+     * @param deploymentStatus 
+     *            
+     * @param queryOrder 
+     *            
+     * @param top 
+     *            
+     * @param continuationToken 
+     *            
+     * @return ArrayList&lt;Deployment&gt;
+     */
+    public ArrayList<Deployment> getDeployments(
+        final UUID project, 
+        final Integer definitionId, 
+        final Integer definitionEnvironmentId, 
+        final String createdBy, 
+        final DeploymentStatus operationStatus, 
+        final DeploymentStatus deploymentStatus, 
+        final ReleaseQueryOrder queryOrder, 
+        final Integer top, 
+        final Integer continuationToken) { 
+
+        final UUID locationId = UUID.fromString("b005ef73-cddc-448e-9ba2-5193bf36b19f"); //$NON-NLS-1$
+        final ApiResourceVersion apiVersion = new ApiResourceVersion("3.0-preview.1"); //$NON-NLS-1$
+
+        final Map<String, Object> routeValues = new HashMap<String, Object>();
+        routeValues.put("project", project); //$NON-NLS-1$
+
+        final NameValueCollection queryParameters = new NameValueCollection();
+        queryParameters.addIfNotNull("definitionId", definitionId); //$NON-NLS-1$
+        queryParameters.addIfNotNull("definitionEnvironmentId", definitionEnvironmentId); //$NON-NLS-1$
+        queryParameters.addIfNotEmpty("createdBy", createdBy); //$NON-NLS-1$
+        queryParameters.addIfNotNull("operationStatus", operationStatus); //$NON-NLS-1$
+        queryParameters.addIfNotNull("deploymentStatus", deploymentStatus); //$NON-NLS-1$
+        queryParameters.addIfNotNull("queryOrder", queryOrder); //$NON-NLS-1$
+        queryParameters.addIfNotNull("$top", top); //$NON-NLS-1$
+        queryParameters.addIfNotNull("continuationToken", continuationToken); //$NON-NLS-1$
+
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
+
+        return super.sendRequest(httpRequest, new TypeReference<ArrayList<Deployment>>() {});
+    }
+
+    /** 
+     * [Preview API 3.0-preview.4]
      * 
      * @param project 
      *            Project ID or project name
@@ -950,24 +1141,24 @@ public abstract class ReleaseHttpClientBase
         final int environmentId) { 
 
         final UUID locationId = UUID.fromString("a7e426b1-03dc-48af-9dfe-c98bac612dcb"); //$NON-NLS-1$
-        final ApiResourceVersion apiVersion = new ApiResourceVersion("3.0-preview.3"); //$NON-NLS-1$
+        final ApiResourceVersion apiVersion = new ApiResourceVersion("3.0-preview.4"); //$NON-NLS-1$
 
         final Map<String, Object> routeValues = new HashMap<String, Object>();
         routeValues.put("project", project); //$NON-NLS-1$
         routeValues.put("releaseId", releaseId); //$NON-NLS-1$
         routeValues.put("environmentId", environmentId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, ReleaseEnvironment.class);
     }
 
     /** 
-     * [Preview API 3.0-preview.3]
+     * [Preview API 3.0-preview.4]
      * 
      * @param project 
      *            Project ID
@@ -983,24 +1174,24 @@ public abstract class ReleaseHttpClientBase
         final int environmentId) { 
 
         final UUID locationId = UUID.fromString("a7e426b1-03dc-48af-9dfe-c98bac612dcb"); //$NON-NLS-1$
-        final ApiResourceVersion apiVersion = new ApiResourceVersion("3.0-preview.3"); //$NON-NLS-1$
+        final ApiResourceVersion apiVersion = new ApiResourceVersion("3.0-preview.4"); //$NON-NLS-1$
 
         final Map<String, Object> routeValues = new HashMap<String, Object>();
         routeValues.put("project", project); //$NON-NLS-1$
         routeValues.put("releaseId", releaseId); //$NON-NLS-1$
         routeValues.put("environmentId", environmentId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, ReleaseEnvironment.class);
     }
 
     /** 
-     * [Preview API 3.0-preview.3]
+     * [Preview API 3.0-preview.4]
      * 
      * @param environmentUpdateData 
      *            
@@ -1019,26 +1210,26 @@ public abstract class ReleaseHttpClientBase
         final int environmentId) { 
 
         final UUID locationId = UUID.fromString("a7e426b1-03dc-48af-9dfe-c98bac612dcb"); //$NON-NLS-1$
-        final ApiResourceVersion apiVersion = new ApiResourceVersion("3.0-preview.3"); //$NON-NLS-1$
+        final ApiResourceVersion apiVersion = new ApiResourceVersion("3.0-preview.4"); //$NON-NLS-1$
 
         final Map<String, Object> routeValues = new HashMap<String, Object>();
         routeValues.put("project", project); //$NON-NLS-1$
         routeValues.put("releaseId", releaseId); //$NON-NLS-1$
         routeValues.put("environmentId", environmentId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.PATCH,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       environmentUpdateData,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.PATCH,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               environmentUpdateData,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, ReleaseEnvironment.class);
     }
 
     /** 
-     * [Preview API 3.0-preview.3]
+     * [Preview API 3.0-preview.4]
      * 
      * @param environmentUpdateData 
      *            
@@ -1057,26 +1248,26 @@ public abstract class ReleaseHttpClientBase
         final int environmentId) { 
 
         final UUID locationId = UUID.fromString("a7e426b1-03dc-48af-9dfe-c98bac612dcb"); //$NON-NLS-1$
-        final ApiResourceVersion apiVersion = new ApiResourceVersion("3.0-preview.3"); //$NON-NLS-1$
+        final ApiResourceVersion apiVersion = new ApiResourceVersion("3.0-preview.4"); //$NON-NLS-1$
 
         final Map<String, Object> routeValues = new HashMap<String, Object>();
         routeValues.put("project", project); //$NON-NLS-1$
         routeValues.put("releaseId", releaseId); //$NON-NLS-1$
         routeValues.put("environmentId", environmentId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.PATCH,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       environmentUpdateData,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.PATCH,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               environmentUpdateData,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, ReleaseEnvironment.class);
     }
 
     /** 
-     * [Preview API 3.0-preview.1]
+     * [Preview API 3.0-preview.2]
      * 
      * @param template 
      *            
@@ -1089,24 +1280,24 @@ public abstract class ReleaseHttpClientBase
         final String project) { 
 
         final UUID locationId = UUID.fromString("6b03b696-824e-4479-8eb2-6644a51aba89"); //$NON-NLS-1$
-        final ApiResourceVersion apiVersion = new ApiResourceVersion("3.0-preview.1"); //$NON-NLS-1$
+        final ApiResourceVersion apiVersion = new ApiResourceVersion("3.0-preview.2"); //$NON-NLS-1$
 
         final Map<String, Object> routeValues = new HashMap<String, Object>();
         routeValues.put("project", project); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.POST,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       template,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.POST,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               template,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, ReleaseDefinitionEnvironmentTemplate.class);
     }
 
     /** 
-     * [Preview API 3.0-preview.1]
+     * [Preview API 3.0-preview.2]
      * 
      * @param template 
      *            
@@ -1119,24 +1310,24 @@ public abstract class ReleaseHttpClientBase
         final UUID project) { 
 
         final UUID locationId = UUID.fromString("6b03b696-824e-4479-8eb2-6644a51aba89"); //$NON-NLS-1$
-        final ApiResourceVersion apiVersion = new ApiResourceVersion("3.0-preview.1"); //$NON-NLS-1$
+        final ApiResourceVersion apiVersion = new ApiResourceVersion("3.0-preview.2"); //$NON-NLS-1$
 
         final Map<String, Object> routeValues = new HashMap<String, Object>();
         routeValues.put("project", project); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.POST,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       template,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.POST,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               template,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, ReleaseDefinitionEnvironmentTemplate.class);
     }
 
     /** 
-     * [Preview API 3.0-preview.1]
+     * [Preview API 3.0-preview.2]
      * 
      * @param project 
      *            Project ID or project name
@@ -1148,7 +1339,7 @@ public abstract class ReleaseHttpClientBase
         final UUID templateId) { 
 
         final UUID locationId = UUID.fromString("6b03b696-824e-4479-8eb2-6644a51aba89"); //$NON-NLS-1$
-        final ApiResourceVersion apiVersion = new ApiResourceVersion("3.0-preview.1"); //$NON-NLS-1$
+        final ApiResourceVersion apiVersion = new ApiResourceVersion("3.0-preview.2"); //$NON-NLS-1$
 
         final Map<String, Object> routeValues = new HashMap<String, Object>();
         routeValues.put("project", project); //$NON-NLS-1$
@@ -1156,18 +1347,18 @@ public abstract class ReleaseHttpClientBase
         final NameValueCollection queryParameters = new NameValueCollection();
         queryParameters.addIfNotNull("templateId", templateId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.DELETE,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.DELETE,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         super.sendRequest(httpRequest);
     }
 
     /** 
-     * [Preview API 3.0-preview.1]
+     * [Preview API 3.0-preview.2]
      * 
      * @param project 
      *            Project ID
@@ -1179,7 +1370,7 @@ public abstract class ReleaseHttpClientBase
         final UUID templateId) { 
 
         final UUID locationId = UUID.fromString("6b03b696-824e-4479-8eb2-6644a51aba89"); //$NON-NLS-1$
-        final ApiResourceVersion apiVersion = new ApiResourceVersion("3.0-preview.1"); //$NON-NLS-1$
+        final ApiResourceVersion apiVersion = new ApiResourceVersion("3.0-preview.2"); //$NON-NLS-1$
 
         final Map<String, Object> routeValues = new HashMap<String, Object>();
         routeValues.put("project", project); //$NON-NLS-1$
@@ -1187,18 +1378,18 @@ public abstract class ReleaseHttpClientBase
         final NameValueCollection queryParameters = new NameValueCollection();
         queryParameters.addIfNotNull("templateId", templateId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.DELETE,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.DELETE,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         super.sendRequest(httpRequest);
     }
 
     /** 
-     * [Preview API 3.0-preview.1]
+     * [Preview API 3.0-preview.2]
      * 
      * @param project 
      *            Project ID or project name
@@ -1211,7 +1402,7 @@ public abstract class ReleaseHttpClientBase
         final UUID templateId) { 
 
         final UUID locationId = UUID.fromString("6b03b696-824e-4479-8eb2-6644a51aba89"); //$NON-NLS-1$
-        final ApiResourceVersion apiVersion = new ApiResourceVersion("3.0-preview.1"); //$NON-NLS-1$
+        final ApiResourceVersion apiVersion = new ApiResourceVersion("3.0-preview.2"); //$NON-NLS-1$
 
         final Map<String, Object> routeValues = new HashMap<String, Object>();
         routeValues.put("project", project); //$NON-NLS-1$
@@ -1219,18 +1410,18 @@ public abstract class ReleaseHttpClientBase
         final NameValueCollection queryParameters = new NameValueCollection();
         queryParameters.addIfNotNull("templateId", templateId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, ReleaseDefinitionEnvironmentTemplate.class);
     }
 
     /** 
-     * [Preview API 3.0-preview.1]
+     * [Preview API 3.0-preview.2]
      * 
      * @param project 
      *            Project ID
@@ -1243,7 +1434,7 @@ public abstract class ReleaseHttpClientBase
         final UUID templateId) { 
 
         final UUID locationId = UUID.fromString("6b03b696-824e-4479-8eb2-6644a51aba89"); //$NON-NLS-1$
-        final ApiResourceVersion apiVersion = new ApiResourceVersion("3.0-preview.1"); //$NON-NLS-1$
+        final ApiResourceVersion apiVersion = new ApiResourceVersion("3.0-preview.2"); //$NON-NLS-1$
 
         final Map<String, Object> routeValues = new HashMap<String, Object>();
         routeValues.put("project", project); //$NON-NLS-1$
@@ -1251,18 +1442,18 @@ public abstract class ReleaseHttpClientBase
         final NameValueCollection queryParameters = new NameValueCollection();
         queryParameters.addIfNotNull("templateId", templateId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, ReleaseDefinitionEnvironmentTemplate.class);
     }
 
     /** 
-     * [Preview API 3.0-preview.1]
+     * [Preview API 3.0-preview.2]
      * 
      * @param project 
      *            Project ID or project name
@@ -1271,22 +1462,22 @@ public abstract class ReleaseHttpClientBase
     public ArrayList<ReleaseDefinitionEnvironmentTemplate> listDefinitionEnvironmentTemplates(final String project) { 
 
         final UUID locationId = UUID.fromString("6b03b696-824e-4479-8eb2-6644a51aba89"); //$NON-NLS-1$
-        final ApiResourceVersion apiVersion = new ApiResourceVersion("3.0-preview.1"); //$NON-NLS-1$
+        final ApiResourceVersion apiVersion = new ApiResourceVersion("3.0-preview.2"); //$NON-NLS-1$
 
         final Map<String, Object> routeValues = new HashMap<String, Object>();
         routeValues.put("project", project); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<ReleaseDefinitionEnvironmentTemplate>>() {});
     }
 
     /** 
-     * [Preview API 3.0-preview.1]
+     * [Preview API 3.0-preview.2]
      * 
      * @param project 
      *            Project ID
@@ -1295,16 +1486,16 @@ public abstract class ReleaseHttpClientBase
     public ArrayList<ReleaseDefinitionEnvironmentTemplate> listDefinitionEnvironmentTemplates(final UUID project) { 
 
         final UUID locationId = UUID.fromString("6b03b696-824e-4479-8eb2-6644a51aba89"); //$NON-NLS-1$
-        final ApiResourceVersion apiVersion = new ApiResourceVersion("3.0-preview.1"); //$NON-NLS-1$
+        final ApiResourceVersion apiVersion = new ApiResourceVersion("3.0-preview.2"); //$NON-NLS-1$
 
         final Map<String, Object> routeValues = new HashMap<String, Object>();
         routeValues.put("project", project); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<ReleaseDefinitionEnvironmentTemplate>>() {});
     }
@@ -1329,11 +1520,11 @@ public abstract class ReleaseHttpClientBase
         routeValues.put("project", project); //$NON-NLS-1$
         routeValues.put("releaseId", releaseId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<ReleaseRevision>>() {});
     }
@@ -1358,11 +1549,11 @@ public abstract class ReleaseHttpClientBase
         routeValues.put("project", project); //$NON-NLS-1$
         routeValues.put("releaseId", releaseId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<ReleaseRevision>>() {});
     }
@@ -1386,13 +1577,13 @@ public abstract class ReleaseHttpClientBase
         final Map<String, Object> routeValues = new HashMap<String, Object>();
         routeValues.put("project", project); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.POST,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       query,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.POST,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               query,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, InputValuesQuery.class);
     }
@@ -1416,13 +1607,13 @@ public abstract class ReleaseHttpClientBase
         final Map<String, Object> routeValues = new HashMap<String, Object>();
         routeValues.put("project", project); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.POST,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       query,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.POST,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               query,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, InputValuesQuery.class);
     }
@@ -1434,6 +1625,94 @@ public abstract class ReleaseHttpClientBase
      *            Project ID or project name
      * @param releaseId 
      *            
+     * @param environmentId 
+     *            
+     * @param taskId 
+     *            
+     * @param attemptId 
+     *            
+     * @return InputStream
+     */
+    public InputStream getLog(
+        final String project, 
+        final int releaseId, 
+        final int environmentId, 
+        final int taskId, 
+        final Integer attemptId) { 
+
+        final UUID locationId = UUID.fromString("e71ba1ed-c0a4-4a28-a61f-2dd5f68cf3fd"); //$NON-NLS-1$
+        final ApiResourceVersion apiVersion = new ApiResourceVersion("3.0-preview.1"); //$NON-NLS-1$
+
+        final Map<String, Object> routeValues = new HashMap<String, Object>();
+        routeValues.put("project", project); //$NON-NLS-1$
+        routeValues.put("releaseId", releaseId); //$NON-NLS-1$
+        routeValues.put("environmentId", environmentId); //$NON-NLS-1$
+        routeValues.put("taskId", taskId); //$NON-NLS-1$
+
+        final NameValueCollection queryParameters = new NameValueCollection();
+        queryParameters.addIfNotNull("attemptId", attemptId); //$NON-NLS-1$
+
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.TEXT_PLAIN_TYPE);
+
+        return super.sendRequest(httpRequest, InputStream.class);
+    }
+
+    /** 
+     * [Preview API 3.0-preview.1]
+     * 
+     * @param project 
+     *            Project ID
+     * @param releaseId 
+     *            
+     * @param environmentId 
+     *            
+     * @param taskId 
+     *            
+     * @param attemptId 
+     *            
+     * @return InputStream
+     */
+    public InputStream getLog(
+        final UUID project, 
+        final int releaseId, 
+        final int environmentId, 
+        final int taskId, 
+        final Integer attemptId) { 
+
+        final UUID locationId = UUID.fromString("e71ba1ed-c0a4-4a28-a61f-2dd5f68cf3fd"); //$NON-NLS-1$
+        final ApiResourceVersion apiVersion = new ApiResourceVersion("3.0-preview.1"); //$NON-NLS-1$
+
+        final Map<String, Object> routeValues = new HashMap<String, Object>();
+        routeValues.put("project", project); //$NON-NLS-1$
+        routeValues.put("releaseId", releaseId); //$NON-NLS-1$
+        routeValues.put("environmentId", environmentId); //$NON-NLS-1$
+        routeValues.put("taskId", taskId); //$NON-NLS-1$
+
+        final NameValueCollection queryParameters = new NameValueCollection();
+        queryParameters.addIfNotNull("attemptId", attemptId); //$NON-NLS-1$
+
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.TEXT_PLAIN_TYPE);
+
+        return super.sendRequest(httpRequest, InputStream.class);
+    }
+
+    /** 
+     * [Preview API 3.0-preview.2]
+     * 
+     * @param project 
+     *            Project ID or project name
+     * @param releaseId 
+     *            
      * @return InputStream
      */
     public InputStream getLogs(
@@ -1441,23 +1720,23 @@ public abstract class ReleaseHttpClientBase
         final int releaseId) { 
 
         final UUID locationId = UUID.fromString("c37fbab5-214b-48e4-a55b-cb6b4f6e4038"); //$NON-NLS-1$
-        final ApiResourceVersion apiVersion = new ApiResourceVersion("3.0-preview.1"); //$NON-NLS-1$
+        final ApiResourceVersion apiVersion = new ApiResourceVersion("3.0-preview.2"); //$NON-NLS-1$
 
         final Map<String, Object> routeValues = new HashMap<String, Object>();
         routeValues.put("project", project); //$NON-NLS-1$
         routeValues.put("releaseId", releaseId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_ZIP_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_ZIP_TYPE);
 
         return super.sendRequest(httpRequest, InputStream.class);
     }
 
     /** 
-     * [Preview API 3.0-preview.1]
+     * [Preview API 3.0-preview.2]
      * 
      * @param project 
      *            Project ID
@@ -1470,17 +1749,99 @@ public abstract class ReleaseHttpClientBase
         final int releaseId) { 
 
         final UUID locationId = UUID.fromString("c37fbab5-214b-48e4-a55b-cb6b4f6e4038"); //$NON-NLS-1$
-        final ApiResourceVersion apiVersion = new ApiResourceVersion("3.0-preview.1"); //$NON-NLS-1$
+        final ApiResourceVersion apiVersion = new ApiResourceVersion("3.0-preview.2"); //$NON-NLS-1$
 
         final Map<String, Object> routeValues = new HashMap<String, Object>();
         routeValues.put("project", project); //$NON-NLS-1$
         routeValues.put("releaseId", releaseId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_ZIP_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_ZIP_TYPE);
+
+        return super.sendRequest(httpRequest, InputStream.class);
+    }
+
+    /** 
+     * [Preview API 3.0-preview.2]
+     * 
+     * @param project 
+     *            Project ID or project name
+     * @param releaseId 
+     *            
+     * @param environmentId 
+     *            
+     * @param taskGroupId 
+     *            
+     * @param taskId 
+     *            
+     * @return InputStream
+     */
+    public InputStream getTaskLog(
+        final String project, 
+        final int releaseId, 
+        final int environmentId, 
+        final int taskGroupId, 
+        final int taskId) { 
+
+        final UUID locationId = UUID.fromString("17c91af7-09fd-4256-bff1-c24ee4f73bc0"); //$NON-NLS-1$
+        final ApiResourceVersion apiVersion = new ApiResourceVersion("3.0-preview.2"); //$NON-NLS-1$
+
+        final Map<String, Object> routeValues = new HashMap<String, Object>();
+        routeValues.put("project", project); //$NON-NLS-1$
+        routeValues.put("releaseId", releaseId); //$NON-NLS-1$
+        routeValues.put("environmentId", environmentId); //$NON-NLS-1$
+        routeValues.put("taskGroupId", taskGroupId); //$NON-NLS-1$
+        routeValues.put("taskId", taskId); //$NON-NLS-1$
+
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.TEXT_PLAIN_TYPE);
+
+        return super.sendRequest(httpRequest, InputStream.class);
+    }
+
+    /** 
+     * [Preview API 3.0-preview.2]
+     * 
+     * @param project 
+     *            Project ID
+     * @param releaseId 
+     *            
+     * @param environmentId 
+     *            
+     * @param taskGroupId 
+     *            
+     * @param taskId 
+     *            
+     * @return InputStream
+     */
+    public InputStream getTaskLog(
+        final UUID project, 
+        final int releaseId, 
+        final int environmentId, 
+        final int taskGroupId, 
+        final int taskId) { 
+
+        final UUID locationId = UUID.fromString("17c91af7-09fd-4256-bff1-c24ee4f73bc0"); //$NON-NLS-1$
+        final ApiResourceVersion apiVersion = new ApiResourceVersion("3.0-preview.2"); //$NON-NLS-1$
+
+        final Map<String, Object> routeValues = new HashMap<String, Object>();
+        routeValues.put("project", project); //$NON-NLS-1$
+        routeValues.put("releaseId", releaseId); //$NON-NLS-1$
+        routeValues.put("environmentId", environmentId); //$NON-NLS-1$
+        routeValues.put("taskGroupId", taskGroupId); //$NON-NLS-1$
+        routeValues.put("taskId", taskId); //$NON-NLS-1$
+
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.TEXT_PLAIN_TYPE);
 
         return super.sendRequest(httpRequest, InputStream.class);
     }
@@ -1492,41 +1853,30 @@ public abstract class ReleaseHttpClientBase
      *            Project ID or project name
      * @param releaseId 
      *            
-     * @param environmentId 
+     * @param manualInterventionId 
      *            
-     * @param taskId 
-     *            
-     * @param attemptId 
-     *            
-     * @return InputStream
+     * @return ManualIntervention
      */
-    public InputStream getLog(
+    public ManualIntervention getManualIntervention(
         final String project, 
         final int releaseId, 
-        final int environmentId, 
-        final int taskId, 
-        final Integer attemptId) { 
+        final int manualInterventionId) { 
 
-        final UUID locationId = UUID.fromString("e71ba1ed-c0a4-4a28-a61f-2dd5f68cf3fd"); //$NON-NLS-1$
+        final UUID locationId = UUID.fromString("616c46e4-f370-4456-adaa-fbaf79c7b79e"); //$NON-NLS-1$
         final ApiResourceVersion apiVersion = new ApiResourceVersion("3.0-preview.1"); //$NON-NLS-1$
 
         final Map<String, Object> routeValues = new HashMap<String, Object>();
         routeValues.put("project", project); //$NON-NLS-1$
         routeValues.put("releaseId", releaseId); //$NON-NLS-1$
-        routeValues.put("environmentId", environmentId); //$NON-NLS-1$
-        routeValues.put("taskId", taskId); //$NON-NLS-1$
+        routeValues.put("manualInterventionId", manualInterventionId); //$NON-NLS-1$
 
-        final NameValueCollection queryParameters = new NameValueCollection();
-        queryParameters.addIfNotNull("attemptId", attemptId); //$NON-NLS-1$
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       TEXT_PLAIN_TYPE);
-
-        return super.sendRequest(httpRequest, InputStream.class);
+        return super.sendRequest(httpRequest, ManualIntervention.class);
     }
 
     /** 
@@ -1536,45 +1886,168 @@ public abstract class ReleaseHttpClientBase
      *            Project ID
      * @param releaseId 
      *            
-     * @param environmentId 
+     * @param manualInterventionId 
      *            
-     * @param taskId 
-     *            
-     * @param attemptId 
-     *            
-     * @return InputStream
+     * @return ManualIntervention
      */
-    public InputStream getLog(
+    public ManualIntervention getManualIntervention(
         final UUID project, 
         final int releaseId, 
-        final int environmentId, 
-        final int taskId, 
-        final Integer attemptId) { 
+        final int manualInterventionId) { 
 
-        final UUID locationId = UUID.fromString("e71ba1ed-c0a4-4a28-a61f-2dd5f68cf3fd"); //$NON-NLS-1$
+        final UUID locationId = UUID.fromString("616c46e4-f370-4456-adaa-fbaf79c7b79e"); //$NON-NLS-1$
         final ApiResourceVersion apiVersion = new ApiResourceVersion("3.0-preview.1"); //$NON-NLS-1$
 
         final Map<String, Object> routeValues = new HashMap<String, Object>();
         routeValues.put("project", project); //$NON-NLS-1$
         routeValues.put("releaseId", releaseId); //$NON-NLS-1$
-        routeValues.put("environmentId", environmentId); //$NON-NLS-1$
-        routeValues.put("taskId", taskId); //$NON-NLS-1$
+        routeValues.put("manualInterventionId", manualInterventionId); //$NON-NLS-1$
 
-        final NameValueCollection queryParameters = new NameValueCollection();
-        queryParameters.addIfNotNull("attemptId", attemptId); //$NON-NLS-1$
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       TEXT_PLAIN_TYPE);
-
-        return super.sendRequest(httpRequest, InputStream.class);
+        return super.sendRequest(httpRequest, ManualIntervention.class);
     }
 
     /** 
-     * [Preview API 3.0-preview.3]
+     * [Preview API 3.0-preview.1]
+     * 
+     * @param project 
+     *            Project ID or project name
+     * @param releaseId 
+     *            
+     * @return ArrayList&lt;ManualIntervention&gt;
+     */
+    public ArrayList<ManualIntervention> getManualInterventions(
+        final String project, 
+        final int releaseId) { 
+
+        final UUID locationId = UUID.fromString("616c46e4-f370-4456-adaa-fbaf79c7b79e"); //$NON-NLS-1$
+        final ApiResourceVersion apiVersion = new ApiResourceVersion("3.0-preview.1"); //$NON-NLS-1$
+
+        final Map<String, Object> routeValues = new HashMap<String, Object>();
+        routeValues.put("project", project); //$NON-NLS-1$
+        routeValues.put("releaseId", releaseId); //$NON-NLS-1$
+
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
+
+        return super.sendRequest(httpRequest, new TypeReference<ArrayList<ManualIntervention>>() {});
+    }
+
+    /** 
+     * [Preview API 3.0-preview.1]
+     * 
+     * @param project 
+     *            Project ID
+     * @param releaseId 
+     *            
+     * @return ArrayList&lt;ManualIntervention&gt;
+     */
+    public ArrayList<ManualIntervention> getManualInterventions(
+        final UUID project, 
+        final int releaseId) { 
+
+        final UUID locationId = UUID.fromString("616c46e4-f370-4456-adaa-fbaf79c7b79e"); //$NON-NLS-1$
+        final ApiResourceVersion apiVersion = new ApiResourceVersion("3.0-preview.1"); //$NON-NLS-1$
+
+        final Map<String, Object> routeValues = new HashMap<String, Object>();
+        routeValues.put("project", project); //$NON-NLS-1$
+        routeValues.put("releaseId", releaseId); //$NON-NLS-1$
+
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
+
+        return super.sendRequest(httpRequest, new TypeReference<ArrayList<ManualIntervention>>() {});
+    }
+
+    /** 
+     * [Preview API 3.0-preview.1]
+     * 
+     * @param manualInterventionUpdateMetadata 
+     *            
+     * @param project 
+     *            Project ID or project name
+     * @param releaseId 
+     *            
+     * @param manualInterventionId 
+     *            
+     * @return ManualIntervention
+     */
+    public ManualIntervention updateManualIntervention(
+        final ManualInterventionUpdateMetadata manualInterventionUpdateMetadata, 
+        final String project, 
+        final int releaseId, 
+        final int manualInterventionId) { 
+
+        final UUID locationId = UUID.fromString("616c46e4-f370-4456-adaa-fbaf79c7b79e"); //$NON-NLS-1$
+        final ApiResourceVersion apiVersion = new ApiResourceVersion("3.0-preview.1"); //$NON-NLS-1$
+
+        final Map<String, Object> routeValues = new HashMap<String, Object>();
+        routeValues.put("project", project); //$NON-NLS-1$
+        routeValues.put("releaseId", releaseId); //$NON-NLS-1$
+        routeValues.put("manualInterventionId", manualInterventionId); //$NON-NLS-1$
+
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.PATCH,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               manualInterventionUpdateMetadata,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
+
+        return super.sendRequest(httpRequest, ManualIntervention.class);
+    }
+
+    /** 
+     * [Preview API 3.0-preview.1]
+     * 
+     * @param manualInterventionUpdateMetadata 
+     *            
+     * @param project 
+     *            Project ID
+     * @param releaseId 
+     *            
+     * @param manualInterventionId 
+     *            
+     * @return ManualIntervention
+     */
+    public ManualIntervention updateManualIntervention(
+        final ManualInterventionUpdateMetadata manualInterventionUpdateMetadata, 
+        final UUID project, 
+        final int releaseId, 
+        final int manualInterventionId) { 
+
+        final UUID locationId = UUID.fromString("616c46e4-f370-4456-adaa-fbaf79c7b79e"); //$NON-NLS-1$
+        final ApiResourceVersion apiVersion = new ApiResourceVersion("3.0-preview.1"); //$NON-NLS-1$
+
+        final Map<String, Object> routeValues = new HashMap<String, Object>();
+        routeValues.put("project", project); //$NON-NLS-1$
+        routeValues.put("releaseId", releaseId); //$NON-NLS-1$
+        routeValues.put("manualInterventionId", manualInterventionId); //$NON-NLS-1$
+
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.PATCH,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               manualInterventionUpdateMetadata,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
+
+        return super.sendRequest(httpRequest, ManualIntervention.class);
+    }
+
+    /** 
+     * [Preview API 3.0-preview.4]
      * 
      * @param releaseStartMetadata 
      *            
@@ -1587,24 +2060,24 @@ public abstract class ReleaseHttpClientBase
         final String project) { 
 
         final UUID locationId = UUID.fromString("a166fde7-27ad-408e-ba75-703c2cc9d500"); //$NON-NLS-1$
-        final ApiResourceVersion apiVersion = new ApiResourceVersion("3.0-preview.3"); //$NON-NLS-1$
+        final ApiResourceVersion apiVersion = new ApiResourceVersion("3.0-preview.4"); //$NON-NLS-1$
 
         final Map<String, Object> routeValues = new HashMap<String, Object>();
         routeValues.put("project", project); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.POST,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       releaseStartMetadata,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.POST,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               releaseStartMetadata,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, Release.class);
     }
 
     /** 
-     * [Preview API 3.0-preview.3]
+     * [Preview API 3.0-preview.4]
      * 
      * @param releaseStartMetadata 
      *            
@@ -1617,80 +2090,94 @@ public abstract class ReleaseHttpClientBase
         final UUID project) { 
 
         final UUID locationId = UUID.fromString("a166fde7-27ad-408e-ba75-703c2cc9d500"); //$NON-NLS-1$
-        final ApiResourceVersion apiVersion = new ApiResourceVersion("3.0-preview.3"); //$NON-NLS-1$
+        final ApiResourceVersion apiVersion = new ApiResourceVersion("3.0-preview.4"); //$NON-NLS-1$
 
         final Map<String, Object> routeValues = new HashMap<String, Object>();
         routeValues.put("project", project); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.POST,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       releaseStartMetadata,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.POST,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               releaseStartMetadata,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, Release.class);
     }
 
     /** 
-     * [Preview API 3.0-preview.3]
+     * [Preview API 3.0-preview.4]
      * 
      * @param project 
      *            Project ID or project name
      * @param releaseId 
      *            
+     * @param comment 
+     *            
      */
     public void deleteRelease(
         final String project, 
-        final int releaseId) { 
+        final int releaseId, 
+        final String comment) { 
 
         final UUID locationId = UUID.fromString("a166fde7-27ad-408e-ba75-703c2cc9d500"); //$NON-NLS-1$
-        final ApiResourceVersion apiVersion = new ApiResourceVersion("3.0-preview.3"); //$NON-NLS-1$
+        final ApiResourceVersion apiVersion = new ApiResourceVersion("3.0-preview.4"); //$NON-NLS-1$
 
         final Map<String, Object> routeValues = new HashMap<String, Object>();
         routeValues.put("project", project); //$NON-NLS-1$
         routeValues.put("releaseId", releaseId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.DELETE,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final NameValueCollection queryParameters = new NameValueCollection();
+        queryParameters.addIfNotEmpty("comment", comment); //$NON-NLS-1$
+
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.DELETE,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         super.sendRequest(httpRequest);
     }
 
     /** 
-     * [Preview API 3.0-preview.3]
+     * [Preview API 3.0-preview.4]
      * 
      * @param project 
      *            Project ID
      * @param releaseId 
      *            
+     * @param comment 
+     *            
      */
     public void deleteRelease(
         final UUID project, 
-        final int releaseId) { 
+        final int releaseId, 
+        final String comment) { 
 
         final UUID locationId = UUID.fromString("a166fde7-27ad-408e-ba75-703c2cc9d500"); //$NON-NLS-1$
-        final ApiResourceVersion apiVersion = new ApiResourceVersion("3.0-preview.3"); //$NON-NLS-1$
+        final ApiResourceVersion apiVersion = new ApiResourceVersion("3.0-preview.4"); //$NON-NLS-1$
 
         final Map<String, Object> routeValues = new HashMap<String, Object>();
         routeValues.put("project", project); //$NON-NLS-1$
         routeValues.put("releaseId", releaseId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.DELETE,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final NameValueCollection queryParameters = new NameValueCollection();
+        queryParameters.addIfNotEmpty("comment", comment); //$NON-NLS-1$
+
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.DELETE,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         super.sendRequest(httpRequest);
     }
 
     /** 
-     * [Preview API 3.0-preview.3]
+     * [Preview API 3.0-preview.4]
      * 
      * @param project 
      *            Project ID or project name
@@ -1706,7 +2193,7 @@ public abstract class ReleaseHttpClientBase
         final Boolean includeAllApprovals) { 
 
         final UUID locationId = UUID.fromString("a166fde7-27ad-408e-ba75-703c2cc9d500"); //$NON-NLS-1$
-        final ApiResourceVersion apiVersion = new ApiResourceVersion("3.0-preview.3"); //$NON-NLS-1$
+        final ApiResourceVersion apiVersion = new ApiResourceVersion("3.0-preview.4"); //$NON-NLS-1$
 
         final Map<String, Object> routeValues = new HashMap<String, Object>();
         routeValues.put("project", project); //$NON-NLS-1$
@@ -1715,18 +2202,18 @@ public abstract class ReleaseHttpClientBase
         final NameValueCollection queryParameters = new NameValueCollection();
         queryParameters.addIfNotNull("includeAllApprovals", includeAllApprovals); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, Release.class);
     }
 
     /** 
-     * [Preview API 3.0-preview.3]
+     * [Preview API 3.0-preview.4]
      * 
      * @param project 
      *            Project ID
@@ -1742,7 +2229,7 @@ public abstract class ReleaseHttpClientBase
         final Boolean includeAllApprovals) { 
 
         final UUID locationId = UUID.fromString("a166fde7-27ad-408e-ba75-703c2cc9d500"); //$NON-NLS-1$
-        final ApiResourceVersion apiVersion = new ApiResourceVersion("3.0-preview.3"); //$NON-NLS-1$
+        final ApiResourceVersion apiVersion = new ApiResourceVersion("3.0-preview.4"); //$NON-NLS-1$
 
         final Map<String, Object> routeValues = new HashMap<String, Object>();
         routeValues.put("project", project); //$NON-NLS-1$
@@ -1751,18 +2238,18 @@ public abstract class ReleaseHttpClientBase
         final NameValueCollection queryParameters = new NameValueCollection();
         queryParameters.addIfNotNull("includeAllApprovals", includeAllApprovals); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, Release.class);
     }
 
     /** 
-     * [Preview API 3.0-preview.3]
+     * [Preview API 3.0-preview.4]
      * 
      * @param project 
      *            Project ID or project name
@@ -1781,7 +2268,7 @@ public abstract class ReleaseHttpClientBase
         final Boolean includeArtifact) { 
 
         final UUID locationId = UUID.fromString("a166fde7-27ad-408e-ba75-703c2cc9d500"); //$NON-NLS-1$
-        final ApiResourceVersion apiVersion = new ApiResourceVersion("3.0-preview.3"); //$NON-NLS-1$
+        final ApiResourceVersion apiVersion = new ApiResourceVersion("3.0-preview.4"); //$NON-NLS-1$
 
         final Map<String, Object> routeValues = new HashMap<String, Object>();
         routeValues.put("project", project); //$NON-NLS-1$
@@ -1791,18 +2278,18 @@ public abstract class ReleaseHttpClientBase
         queryParameters.put("releaseCount", String.valueOf(releaseCount)); //$NON-NLS-1$
         queryParameters.addIfNotNull("includeArtifact", includeArtifact); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, ReleaseDefinitionSummary.class);
     }
 
     /** 
-     * [Preview API 3.0-preview.3]
+     * [Preview API 3.0-preview.4]
      * 
      * @param project 
      *            Project ID
@@ -1821,7 +2308,7 @@ public abstract class ReleaseHttpClientBase
         final Boolean includeArtifact) { 
 
         final UUID locationId = UUID.fromString("a166fde7-27ad-408e-ba75-703c2cc9d500"); //$NON-NLS-1$
-        final ApiResourceVersion apiVersion = new ApiResourceVersion("3.0-preview.3"); //$NON-NLS-1$
+        final ApiResourceVersion apiVersion = new ApiResourceVersion("3.0-preview.4"); //$NON-NLS-1$
 
         final Map<String, Object> routeValues = new HashMap<String, Object>();
         routeValues.put("project", project); //$NON-NLS-1$
@@ -1831,18 +2318,18 @@ public abstract class ReleaseHttpClientBase
         queryParameters.put("releaseCount", String.valueOf(releaseCount)); //$NON-NLS-1$
         queryParameters.addIfNotNull("includeArtifact", includeArtifact); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, ReleaseDefinitionSummary.class);
     }
 
     /** 
-     * [Preview API 3.0-preview.3]
+     * [Preview API 3.0-preview.4]
      * 
      * @param project 
      *            Project ID or project name
@@ -1858,7 +2345,7 @@ public abstract class ReleaseHttpClientBase
         final int definitionSnapshotRevision) { 
 
         final UUID locationId = UUID.fromString("a166fde7-27ad-408e-ba75-703c2cc9d500"); //$NON-NLS-1$
-        final ApiResourceVersion apiVersion = new ApiResourceVersion("3.0-preview.3"); //$NON-NLS-1$
+        final ApiResourceVersion apiVersion = new ApiResourceVersion("3.0-preview.4"); //$NON-NLS-1$
 
         final Map<String, Object> routeValues = new HashMap<String, Object>();
         routeValues.put("project", project); //$NON-NLS-1$
@@ -1867,18 +2354,18 @@ public abstract class ReleaseHttpClientBase
         final NameValueCollection queryParameters = new NameValueCollection();
         queryParameters.put("definitionSnapshotRevision", String.valueOf(definitionSnapshotRevision)); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       TEXT_PLAIN_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.TEXT_PLAIN_TYPE);
 
         return super.sendRequest(httpRequest, InputStream.class);
     }
 
     /** 
-     * [Preview API 3.0-preview.3]
+     * [Preview API 3.0-preview.4]
      * 
      * @param project 
      *            Project ID
@@ -1894,7 +2381,7 @@ public abstract class ReleaseHttpClientBase
         final int definitionSnapshotRevision) { 
 
         final UUID locationId = UUID.fromString("a166fde7-27ad-408e-ba75-703c2cc9d500"); //$NON-NLS-1$
-        final ApiResourceVersion apiVersion = new ApiResourceVersion("3.0-preview.3"); //$NON-NLS-1$
+        final ApiResourceVersion apiVersion = new ApiResourceVersion("3.0-preview.4"); //$NON-NLS-1$
 
         final Map<String, Object> routeValues = new HashMap<String, Object>();
         routeValues.put("project", project); //$NON-NLS-1$
@@ -1903,18 +2390,18 @@ public abstract class ReleaseHttpClientBase
         final NameValueCollection queryParameters = new NameValueCollection();
         queryParameters.put("definitionSnapshotRevision", String.valueOf(definitionSnapshotRevision)); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       TEXT_PLAIN_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.TEXT_PLAIN_TYPE);
 
         return super.sendRequest(httpRequest, InputStream.class);
     }
 
     /** 
-     * [Preview API 3.0-preview.3]
+     * [Preview API 3.0-preview.4]
      * 
      * @param project 
      *            Project ID or project name
@@ -1950,6 +2437,8 @@ public abstract class ReleaseHttpClientBase
      *            
      * @param sourceBranchFilter 
      *            
+     * @param isDeleted 
+     *            
      * @return ArrayList&lt;Release&gt;
      */
     public ArrayList<Release> getReleases(
@@ -1969,10 +2458,11 @@ public abstract class ReleaseHttpClientBase
         final String artifactTypeId, 
         final String sourceId, 
         final String artifactVersionId, 
-        final String sourceBranchFilter) { 
+        final String sourceBranchFilter, 
+        final Boolean isDeleted) { 
 
         final UUID locationId = UUID.fromString("a166fde7-27ad-408e-ba75-703c2cc9d500"); //$NON-NLS-1$
-        final ApiResourceVersion apiVersion = new ApiResourceVersion("3.0-preview.3"); //$NON-NLS-1$
+        final ApiResourceVersion apiVersion = new ApiResourceVersion("3.0-preview.4"); //$NON-NLS-1$
 
         final Map<String, Object> routeValues = new HashMap<String, Object>();
         routeValues.put("project", project); //$NON-NLS-1$
@@ -1994,19 +2484,20 @@ public abstract class ReleaseHttpClientBase
         queryParameters.addIfNotEmpty("sourceId", sourceId); //$NON-NLS-1$
         queryParameters.addIfNotEmpty("artifactVersionId", artifactVersionId); //$NON-NLS-1$
         queryParameters.addIfNotEmpty("sourceBranchFilter", sourceBranchFilter); //$NON-NLS-1$
+        queryParameters.addIfNotNull("isDeleted", isDeleted); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<Release>>() {});
     }
 
     /** 
-     * [Preview API 3.0-preview.3]
+     * [Preview API 3.0-preview.4]
      * 
      * @param project 
      *            Project ID
@@ -2042,6 +2533,8 @@ public abstract class ReleaseHttpClientBase
      *            
      * @param sourceBranchFilter 
      *            
+     * @param isDeleted 
+     *            
      * @return ArrayList&lt;Release&gt;
      */
     public ArrayList<Release> getReleases(
@@ -2061,10 +2554,11 @@ public abstract class ReleaseHttpClientBase
         final String artifactTypeId, 
         final String sourceId, 
         final String artifactVersionId, 
-        final String sourceBranchFilter) { 
+        final String sourceBranchFilter, 
+        final Boolean isDeleted) { 
 
         final UUID locationId = UUID.fromString("a166fde7-27ad-408e-ba75-703c2cc9d500"); //$NON-NLS-1$
-        final ApiResourceVersion apiVersion = new ApiResourceVersion("3.0-preview.3"); //$NON-NLS-1$
+        final ApiResourceVersion apiVersion = new ApiResourceVersion("3.0-preview.4"); //$NON-NLS-1$
 
         final Map<String, Object> routeValues = new HashMap<String, Object>();
         routeValues.put("project", project); //$NON-NLS-1$
@@ -2086,19 +2580,90 @@ public abstract class ReleaseHttpClientBase
         queryParameters.addIfNotEmpty("sourceId", sourceId); //$NON-NLS-1$
         queryParameters.addIfNotEmpty("artifactVersionId", artifactVersionId); //$NON-NLS-1$
         queryParameters.addIfNotEmpty("sourceBranchFilter", sourceBranchFilter); //$NON-NLS-1$
+        queryParameters.addIfNotNull("isDeleted", isDeleted); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<Release>>() {});
     }
 
     /** 
-     * [Preview API 3.0-preview.3]
+     * [Preview API 3.0-preview.4]
+     * 
+     * @param project 
+     *            Project ID or project name
+     * @param releaseId 
+     *            
+     * @param comment 
+     *            
+     */
+    public void undeleteRelease(
+        final String project, 
+        final int releaseId, 
+        final String comment) { 
+
+        final UUID locationId = UUID.fromString("a166fde7-27ad-408e-ba75-703c2cc9d500"); //$NON-NLS-1$
+        final ApiResourceVersion apiVersion = new ApiResourceVersion("3.0-preview.4"); //$NON-NLS-1$
+
+        final Map<String, Object> routeValues = new HashMap<String, Object>();
+        routeValues.put("project", project); //$NON-NLS-1$
+        routeValues.put("releaseId", releaseId); //$NON-NLS-1$
+
+        final NameValueCollection queryParameters = new NameValueCollection();
+        queryParameters.addIfNotEmpty("comment", comment); //$NON-NLS-1$
+
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.PUT,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
+
+        super.sendRequest(httpRequest);
+    }
+
+    /** 
+     * [Preview API 3.0-preview.4]
+     * 
+     * @param project 
+     *            Project ID
+     * @param releaseId 
+     *            
+     * @param comment 
+     *            
+     */
+    public void undeleteRelease(
+        final UUID project, 
+        final int releaseId, 
+        final String comment) { 
+
+        final UUID locationId = UUID.fromString("a166fde7-27ad-408e-ba75-703c2cc9d500"); //$NON-NLS-1$
+        final ApiResourceVersion apiVersion = new ApiResourceVersion("3.0-preview.4"); //$NON-NLS-1$
+
+        final Map<String, Object> routeValues = new HashMap<String, Object>();
+        routeValues.put("project", project); //$NON-NLS-1$
+        routeValues.put("releaseId", releaseId); //$NON-NLS-1$
+
+        final NameValueCollection queryParameters = new NameValueCollection();
+        queryParameters.addIfNotEmpty("comment", comment); //$NON-NLS-1$
+
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.PUT,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
+
+        super.sendRequest(httpRequest);
+    }
+
+    /** 
+     * [Preview API 3.0-preview.4]
      * 
      * @param release 
      *            
@@ -2114,25 +2679,25 @@ public abstract class ReleaseHttpClientBase
         final int releaseId) { 
 
         final UUID locationId = UUID.fromString("a166fde7-27ad-408e-ba75-703c2cc9d500"); //$NON-NLS-1$
-        final ApiResourceVersion apiVersion = new ApiResourceVersion("3.0-preview.3"); //$NON-NLS-1$
+        final ApiResourceVersion apiVersion = new ApiResourceVersion("3.0-preview.4"); //$NON-NLS-1$
 
         final Map<String, Object> routeValues = new HashMap<String, Object>();
         routeValues.put("project", project); //$NON-NLS-1$
         routeValues.put("releaseId", releaseId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.PUT,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       release,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.PUT,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               release,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, Release.class);
     }
 
     /** 
-     * [Preview API 3.0-preview.3]
+     * [Preview API 3.0-preview.4]
      * 
      * @param release 
      *            
@@ -2148,25 +2713,25 @@ public abstract class ReleaseHttpClientBase
         final int releaseId) { 
 
         final UUID locationId = UUID.fromString("a166fde7-27ad-408e-ba75-703c2cc9d500"); //$NON-NLS-1$
-        final ApiResourceVersion apiVersion = new ApiResourceVersion("3.0-preview.3"); //$NON-NLS-1$
+        final ApiResourceVersion apiVersion = new ApiResourceVersion("3.0-preview.4"); //$NON-NLS-1$
 
         final Map<String, Object> routeValues = new HashMap<String, Object>();
         routeValues.put("project", project); //$NON-NLS-1$
         routeValues.put("releaseId", releaseId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.PUT,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       release,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.PUT,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               release,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, Release.class);
     }
 
     /** 
-     * [Preview API 3.0-preview.3]
+     * [Preview API 3.0-preview.4]
      * 
      * @param releaseUpdateMetadata 
      *            
@@ -2182,25 +2747,25 @@ public abstract class ReleaseHttpClientBase
         final int releaseId) { 
 
         final UUID locationId = UUID.fromString("a166fde7-27ad-408e-ba75-703c2cc9d500"); //$NON-NLS-1$
-        final ApiResourceVersion apiVersion = new ApiResourceVersion("3.0-preview.3"); //$NON-NLS-1$
+        final ApiResourceVersion apiVersion = new ApiResourceVersion("3.0-preview.4"); //$NON-NLS-1$
 
         final Map<String, Object> routeValues = new HashMap<String, Object>();
         routeValues.put("project", project); //$NON-NLS-1$
         routeValues.put("releaseId", releaseId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.PATCH,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       releaseUpdateMetadata,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.PATCH,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               releaseUpdateMetadata,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, Release.class);
     }
 
     /** 
-     * [Preview API 3.0-preview.3]
+     * [Preview API 3.0-preview.4]
      * 
      * @param releaseUpdateMetadata 
      *            
@@ -2216,21 +2781,87 @@ public abstract class ReleaseHttpClientBase
         final int releaseId) { 
 
         final UUID locationId = UUID.fromString("a166fde7-27ad-408e-ba75-703c2cc9d500"); //$NON-NLS-1$
-        final ApiResourceVersion apiVersion = new ApiResourceVersion("3.0-preview.3"); //$NON-NLS-1$
+        final ApiResourceVersion apiVersion = new ApiResourceVersion("3.0-preview.4"); //$NON-NLS-1$
 
         final Map<String, Object> routeValues = new HashMap<String, Object>();
         routeValues.put("project", project); //$NON-NLS-1$
         routeValues.put("releaseId", releaseId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.PATCH,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       releaseUpdateMetadata,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.PATCH,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               releaseUpdateMetadata,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, Release.class);
+    }
+
+    /** 
+     * [Preview API 3.0-preview.1]
+     * 
+     * @param project 
+     *            Project ID or project name
+     * @param definitionId 
+     *            
+     * @param revision 
+     *            
+     * @return InputStream
+     */
+    public InputStream getDefinitionRevision(
+        final String project, 
+        final int definitionId, 
+        final int revision) { 
+
+        final UUID locationId = UUID.fromString("258b82e0-9d41-43f3-86d6-fef14ddd44bc"); //$NON-NLS-1$
+        final ApiResourceVersion apiVersion = new ApiResourceVersion("3.0-preview.1"); //$NON-NLS-1$
+
+        final Map<String, Object> routeValues = new HashMap<String, Object>();
+        routeValues.put("project", project); //$NON-NLS-1$
+        routeValues.put("definitionId", definitionId); //$NON-NLS-1$
+        routeValues.put("revision", revision); //$NON-NLS-1$
+
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.TEXT_PLAIN_TYPE);
+
+        return super.sendRequest(httpRequest, InputStream.class);
+    }
+
+    /** 
+     * [Preview API 3.0-preview.1]
+     * 
+     * @param project 
+     *            Project ID
+     * @param definitionId 
+     *            
+     * @param revision 
+     *            
+     * @return InputStream
+     */
+    public InputStream getDefinitionRevision(
+        final UUID project, 
+        final int definitionId, 
+        final int revision) { 
+
+        final UUID locationId = UUID.fromString("258b82e0-9d41-43f3-86d6-fef14ddd44bc"); //$NON-NLS-1$
+        final ApiResourceVersion apiVersion = new ApiResourceVersion("3.0-preview.1"); //$NON-NLS-1$
+
+        final Map<String, Object> routeValues = new HashMap<String, Object>();
+        routeValues.put("project", project); //$NON-NLS-1$
+        routeValues.put("definitionId", definitionId); //$NON-NLS-1$
+        routeValues.put("revision", revision); //$NON-NLS-1$
+
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.TEXT_PLAIN_TYPE);
+
+        return super.sendRequest(httpRequest, InputStream.class);
     }
 
     /** 
@@ -2253,11 +2884,11 @@ public abstract class ReleaseHttpClientBase
         routeValues.put("project", project); //$NON-NLS-1$
         routeValues.put("definitionId", definitionId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<ReleaseDefinitionRevision>>() {});
     }
@@ -2282,79 +2913,13 @@ public abstract class ReleaseHttpClientBase
         routeValues.put("project", project); //$NON-NLS-1$
         routeValues.put("definitionId", definitionId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<ReleaseDefinitionRevision>>() {});
-    }
-
-    /** 
-     * [Preview API 3.0-preview.1]
-     * 
-     * @param project 
-     *            Project ID or project name
-     * @param definitionId 
-     *            
-     * @param revision 
-     *            
-     * @return InputStream
-     */
-    public InputStream getReleaseDefinitionRevision(
-        final String project, 
-        final int definitionId, 
-        final int revision) { 
-
-        final UUID locationId = UUID.fromString("258b82e0-9d41-43f3-86d6-fef14ddd44bc"); //$NON-NLS-1$
-        final ApiResourceVersion apiVersion = new ApiResourceVersion("3.0-preview.1"); //$NON-NLS-1$
-
-        final Map<String, Object> routeValues = new HashMap<String, Object>();
-        routeValues.put("project", project); //$NON-NLS-1$
-        routeValues.put("definitionId", definitionId); //$NON-NLS-1$
-        routeValues.put("revision", revision); //$NON-NLS-1$
-
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       TEXT_PLAIN_TYPE);
-
-        return super.sendRequest(httpRequest, InputStream.class);
-    }
-
-    /** 
-     * [Preview API 3.0-preview.1]
-     * 
-     * @param project 
-     *            Project ID
-     * @param definitionId 
-     *            
-     * @param revision 
-     *            
-     * @return InputStream
-     */
-    public InputStream getReleaseDefinitionRevision(
-        final UUID project, 
-        final int definitionId, 
-        final int revision) { 
-
-        final UUID locationId = UUID.fromString("258b82e0-9d41-43f3-86d6-fef14ddd44bc"); //$NON-NLS-1$
-        final ApiResourceVersion apiVersion = new ApiResourceVersion("3.0-preview.1"); //$NON-NLS-1$
-
-        final Map<String, Object> routeValues = new HashMap<String, Object>();
-        routeValues.put("project", project); //$NON-NLS-1$
-        routeValues.put("definitionId", definitionId); //$NON-NLS-1$
-        routeValues.put("revision", revision); //$NON-NLS-1$
-
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       TEXT_PLAIN_TYPE);
-
-        return super.sendRequest(httpRequest, InputStream.class);
     }
 
     /** 
@@ -2377,11 +2942,11 @@ public abstract class ReleaseHttpClientBase
         routeValues.put("project", project); //$NON-NLS-1$
         routeValues.put("releaseId", releaseId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<SummaryMailSection>>() {});
     }
@@ -2406,11 +2971,11 @@ public abstract class ReleaseHttpClientBase
         routeValues.put("project", project); //$NON-NLS-1$
         routeValues.put("releaseId", releaseId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<SummaryMailSection>>() {});
     }
@@ -2437,13 +3002,13 @@ public abstract class ReleaseHttpClientBase
         routeValues.put("project", project); //$NON-NLS-1$
         routeValues.put("releaseId", releaseId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.POST,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       mailMessage,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.POST,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               mailMessage,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         super.sendRequest(httpRequest);
     }
@@ -2470,13 +3035,13 @@ public abstract class ReleaseHttpClientBase
         routeValues.put("project", project); //$NON-NLS-1$
         routeValues.put("releaseId", releaseId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.POST,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       mailMessage,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.POST,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               mailMessage,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         super.sendRequest(httpRequest);
     }
@@ -2501,11 +3066,11 @@ public abstract class ReleaseHttpClientBase
         routeValues.put("project", project); //$NON-NLS-1$
         routeValues.put("definitionId", definitionId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<String>>() {});
     }
@@ -2530,11 +3095,11 @@ public abstract class ReleaseHttpClientBase
         routeValues.put("project", project); //$NON-NLS-1$
         routeValues.put("definitionId", definitionId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<String>>() {});
     }
@@ -2569,12 +3134,12 @@ public abstract class ReleaseHttpClientBase
         final NameValueCollection queryParameters = new NameValueCollection();
         queryParameters.addIfNotNull("attemptId", attemptId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<ReleaseTask>>() {});
     }
@@ -2609,12 +3174,86 @@ public abstract class ReleaseHttpClientBase
         final NameValueCollection queryParameters = new NameValueCollection();
         queryParameters.addIfNotNull("attemptId", attemptId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
+
+        return super.sendRequest(httpRequest, new TypeReference<ArrayList<ReleaseTask>>() {});
+    }
+
+    /** 
+     * [Preview API 3.0-preview.2]
+     * 
+     * @param project 
+     *            Project ID or project name
+     * @param releaseId 
+     *            
+     * @param environmentId 
+     *            
+     * @param taskGroupId 
+     *            
+     * @return ArrayList&lt;ReleaseTask&gt;
+     */
+    public ArrayList<ReleaseTask> getTasksForTaskGroup(
+        final String project, 
+        final int releaseId, 
+        final int environmentId, 
+        final int taskGroupId) { 
+
+        final UUID locationId = UUID.fromString("4259191d-4b0a-4409-9fb3-09f22ab9bc47"); //$NON-NLS-1$
+        final ApiResourceVersion apiVersion = new ApiResourceVersion("3.0-preview.2"); //$NON-NLS-1$
+
+        final Map<String, Object> routeValues = new HashMap<String, Object>();
+        routeValues.put("project", project); //$NON-NLS-1$
+        routeValues.put("releaseId", releaseId); //$NON-NLS-1$
+        routeValues.put("environmentId", environmentId); //$NON-NLS-1$
+        routeValues.put("taskGroupId", taskGroupId); //$NON-NLS-1$
+
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
+
+        return super.sendRequest(httpRequest, new TypeReference<ArrayList<ReleaseTask>>() {});
+    }
+
+    /** 
+     * [Preview API 3.0-preview.2]
+     * 
+     * @param project 
+     *            Project ID
+     * @param releaseId 
+     *            
+     * @param environmentId 
+     *            
+     * @param taskGroupId 
+     *            
+     * @return ArrayList&lt;ReleaseTask&gt;
+     */
+    public ArrayList<ReleaseTask> getTasksForTaskGroup(
+        final UUID project, 
+        final int releaseId, 
+        final int environmentId, 
+        final int taskGroupId) { 
+
+        final UUID locationId = UUID.fromString("4259191d-4b0a-4409-9fb3-09f22ab9bc47"); //$NON-NLS-1$
+        final ApiResourceVersion apiVersion = new ApiResourceVersion("3.0-preview.2"); //$NON-NLS-1$
+
+        final Map<String, Object> routeValues = new HashMap<String, Object>();
+        routeValues.put("project", project); //$NON-NLS-1$
+        routeValues.put("releaseId", releaseId); //$NON-NLS-1$
+        routeValues.put("environmentId", environmentId); //$NON-NLS-1$
+        routeValues.put("taskGroupId", taskGroupId); //$NON-NLS-1$
+
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<ReleaseTask>>() {});
     }
@@ -2634,11 +3273,11 @@ public abstract class ReleaseHttpClientBase
         final Map<String, Object> routeValues = new HashMap<String, Object>();
         routeValues.put("project", project); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<ArtifactTypeDefinition>>() {});
     }
@@ -2658,11 +3297,11 @@ public abstract class ReleaseHttpClientBase
         final Map<String, Object> routeValues = new HashMap<String, Object>();
         routeValues.put("project", project); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<ArtifactTypeDefinition>>() {});
     }
@@ -2689,12 +3328,12 @@ public abstract class ReleaseHttpClientBase
         final NameValueCollection queryParameters = new NameValueCollection();
         queryParameters.put("releaseDefinitionId", String.valueOf(releaseDefinitionId)); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, ArtifactVersionQueryResult.class);
     }
@@ -2721,12 +3360,12 @@ public abstract class ReleaseHttpClientBase
         final NameValueCollection queryParameters = new NameValueCollection();
         queryParameters.put("releaseDefinitionId", String.valueOf(releaseDefinitionId)); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, ArtifactVersionQueryResult.class);
     }
@@ -2750,13 +3389,13 @@ public abstract class ReleaseHttpClientBase
         final Map<String, Object> routeValues = new HashMap<String, Object>();
         routeValues.put("project", project); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.POST,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       artifacts,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.POST,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               artifacts,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, ArtifactVersionQueryResult.class);
     }
@@ -2780,13 +3419,13 @@ public abstract class ReleaseHttpClientBase
         final Map<String, Object> routeValues = new HashMap<String, Object>();
         routeValues.put("project", project); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.POST,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       artifacts,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.POST,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               artifacts,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, ArtifactVersionQueryResult.class);
     }
@@ -2821,12 +3460,12 @@ public abstract class ReleaseHttpClientBase
         queryParameters.addIfNotNull("baseReleaseId", baseReleaseId); //$NON-NLS-1$
         queryParameters.addIfNotNull("$top", top); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<ReleaseWorkItemRef>>() {});
     }
@@ -2861,12 +3500,12 @@ public abstract class ReleaseHttpClientBase
         queryParameters.addIfNotNull("baseReleaseId", baseReleaseId); //$NON-NLS-1$
         queryParameters.addIfNotNull("$top", top); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<ReleaseWorkItemRef>>() {});
     }

--- a/Rest/alm-releasemanagement-client/src/main/generated/com/microsoft/alm/visualstudio/services/releasemanagement/webapi/ReleaseReference.java
+++ b/Rest/alm-releasemanagement-client/src/main/generated/com/microsoft/alm/visualstudio/services/releasemanagement/webapi/ReleaseReference.java
@@ -1,0 +1,61 @@
+// @formatter:off
+/*
+* ---------------------------------------------------------
+* Copyright(C) Microsoft Corporation. All rights reserved.
+* Licensed under the MIT license. See License.txt in the project root.
+* ---------------------------------------------------------
+*
+* ---------------------------------------------------------
+* Generated file, DO NOT EDIT
+* ---------------------------------------------------------
+*
+* See following wiki page for instructions on how to regenerate:
+*   https://vsowiki.com/index.php?title=Rest_Client_Generation
+*/
+
+package com.microsoft.alm.visualstudio.services.releasemanagement.webapi;
+
+import java.util.ArrayList;
+import com.microsoft.alm.visualstudio.services.releasemanagement.webapi.contracts.Artifact;
+
+/** 
+ */
+public class ReleaseReference {
+
+    private ArrayList<Artifact> artifacts;
+    private int id;
+    private String name;
+    private String url;
+
+    public ArrayList<Artifact> getArtifacts() {
+        return artifacts;
+    }
+
+    public void setArtifacts(final ArrayList<Artifact> artifacts) {
+        this.artifacts = artifacts;
+    }
+
+    public int getId() {
+        return id;
+    }
+
+    public void setId(final int id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(final String name) {
+        this.name = name;
+    }
+
+    public String getUrl() {
+        return url;
+    }
+
+    public void setUrl(final String url) {
+        this.url = url;
+    }
+}

--- a/Rest/alm-releasemanagement-client/src/main/generated/com/microsoft/alm/visualstudio/services/releasemanagement/webapi/contracts/AgentBasedDeployPhase.java
+++ b/Rest/alm-releasemanagement-client/src/main/generated/com/microsoft/alm/visualstudio/services/releasemanagement/webapi/contracts/AgentBasedDeployPhase.java
@@ -1,0 +1,39 @@
+// @formatter:off
+/*
+* ---------------------------------------------------------
+* Copyright(C) Microsoft Corporation. All rights reserved.
+* Licensed under the MIT license. See License.txt in the project root.
+* ---------------------------------------------------------
+*
+* ---------------------------------------------------------
+* Generated file, DO NOT EDIT
+* ---------------------------------------------------------
+*
+* See following wiki page for instructions on how to regenerate:
+*   https://vsowiki.com/index.php?title=Rest_Client_Generation
+*/
+
+package com.microsoft.alm.visualstudio.services.releasemanagement.webapi.contracts;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.JsonSerializer;
+
+/** 
+ */
+@JsonDeserialize(using = JsonDeserializer.None.class)
+@JsonSerialize(using = JsonSerializer.None.class)
+public class AgentBasedDeployPhase
+    extends DeployPhase {
+
+    private AgentDeploymentInput deploymentInput;
+
+    public AgentDeploymentInput getDeploymentInput() {
+        return deploymentInput;
+    }
+
+    public void setDeploymentInput(final AgentDeploymentInput deploymentInput) {
+        this.deploymentInput = deploymentInput;
+    }
+}

--- a/Rest/alm-releasemanagement-client/src/main/generated/com/microsoft/alm/visualstudio/services/releasemanagement/webapi/contracts/AgentDeploymentInput.java
+++ b/Rest/alm-releasemanagement-client/src/main/generated/com/microsoft/alm/visualstudio/services/releasemanagement/webapi/contracts/AgentDeploymentInput.java
@@ -1,0 +1,70 @@
+// @formatter:off
+/*
+* ---------------------------------------------------------
+* Copyright(C) Microsoft Corporation. All rights reserved.
+* Licensed under the MIT license. See License.txt in the project root.
+* ---------------------------------------------------------
+*
+* ---------------------------------------------------------
+* Generated file, DO NOT EDIT
+* ---------------------------------------------------------
+*
+* See following wiki page for instructions on how to regenerate:
+*   https://vsowiki.com/index.php?title=Rest_Client_Generation
+*/
+
+package com.microsoft.alm.visualstudio.services.releasemanagement.webapi.contracts;
+
+import java.util.ArrayList;
+
+/** 
+ */
+public class AgentDeploymentInput
+    extends BaseDeploymentInput {
+
+    private ArrayList<Demand> demands;
+    private boolean enableAccessToken;
+    private int queueId;
+    private boolean skipArtifactsDownload;
+    private int timeoutInMinutes;
+
+    public ArrayList<Demand> getDemands() {
+        return demands;
+    }
+
+    public void setDemands(final ArrayList<Demand> demands) {
+        this.demands = demands;
+    }
+
+    public boolean getEnableAccessToken() {
+        return enableAccessToken;
+    }
+
+    public void setEnableAccessToken(final boolean enableAccessToken) {
+        this.enableAccessToken = enableAccessToken;
+    }
+
+    public int getQueueId() {
+        return queueId;
+    }
+
+    public void setQueueId(final int queueId) {
+        this.queueId = queueId;
+    }
+
+    public boolean getSkipArtifactsDownload() {
+        return skipArtifactsDownload;
+    }
+
+    public void setSkipArtifactsDownload(final boolean skipArtifactsDownload) {
+        this.skipArtifactsDownload = skipArtifactsDownload;
+    }
+
+    public int getTimeoutInMinutes() {
+        return timeoutInMinutes;
+    }
+
+    public void setTimeoutInMinutes(final int timeoutInMinutes) {
+        this.timeoutInMinutes = timeoutInMinutes;
+    }
+}

--- a/Rest/alm-releasemanagement-client/src/main/generated/com/microsoft/alm/visualstudio/services/releasemanagement/webapi/contracts/ArtifactContributionDefinition.java
+++ b/Rest/alm-releasemanagement-client/src/main/generated/com/microsoft/alm/visualstudio/services/releasemanagement/webapi/contracts/ArtifactContributionDefinition.java
@@ -1,0 +1,116 @@
+// @formatter:off
+/*
+* ---------------------------------------------------------
+* Copyright(C) Microsoft Corporation. All rights reserved.
+* Licensed under the MIT license. See License.txt in the project root.
+* ---------------------------------------------------------
+*
+* ---------------------------------------------------------
+* Generated file, DO NOT EDIT
+* ---------------------------------------------------------
+*
+* See following wiki page for instructions on how to regenerate:
+*   https://vsowiki.com/index.php?title=Rest_Client_Generation
+*/
+
+package com.microsoft.alm.visualstudio.services.releasemanagement.webapi.contracts;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import com.microsoft.alm.visualstudio.services.forminput.InputDescriptor;
+
+/** 
+ */
+public class ArtifactContributionDefinition {
+
+    private String artifactType;
+    private HashMap<String, String> artifactTypeStreamMapping;
+    private HashMap<String, String> browsableArtifactTypeMapping;
+    private ArrayList<DataSourceBinding> dataSourceBindings;
+    private String displayName;
+    private String downloadTaskId;
+    private String endpointTypeId;
+    private ArrayList<InputDescriptor> inputDescriptors;
+    private String name;
+    private String uniqueSourceIdentifier;
+
+    public String getArtifactType() {
+        return artifactType;
+    }
+
+    public void setArtifactType(final String artifactType) {
+        this.artifactType = artifactType;
+    }
+
+    public HashMap<String, String> getArtifactTypeStreamMapping() {
+        return artifactTypeStreamMapping;
+    }
+
+    public void setArtifactTypeStreamMapping(final HashMap<String, String> artifactTypeStreamMapping) {
+        this.artifactTypeStreamMapping = artifactTypeStreamMapping;
+    }
+
+    public HashMap<String, String> getBrowsableArtifactTypeMapping() {
+        return browsableArtifactTypeMapping;
+    }
+
+    public void setBrowsableArtifactTypeMapping(final HashMap<String, String> browsableArtifactTypeMapping) {
+        this.browsableArtifactTypeMapping = browsableArtifactTypeMapping;
+    }
+
+    public ArrayList<DataSourceBinding> getDataSourceBindings() {
+        return dataSourceBindings;
+    }
+
+    public void setDataSourceBindings(final ArrayList<DataSourceBinding> dataSourceBindings) {
+        this.dataSourceBindings = dataSourceBindings;
+    }
+
+    public String getDisplayName() {
+        return displayName;
+    }
+
+    public void setDisplayName(final String displayName) {
+        this.displayName = displayName;
+    }
+
+    public String getDownloadTaskId() {
+        return downloadTaskId;
+    }
+
+    public void setDownloadTaskId(final String downloadTaskId) {
+        this.downloadTaskId = downloadTaskId;
+    }
+
+    public String getEndpointTypeId() {
+        return endpointTypeId;
+    }
+
+    public void setEndpointTypeId(final String endpointTypeId) {
+        this.endpointTypeId = endpointTypeId;
+    }
+
+    public ArrayList<InputDescriptor> getInputDescriptors() {
+        return inputDescriptors;
+    }
+
+    public void setInputDescriptors(final ArrayList<InputDescriptor> inputDescriptors) {
+        this.inputDescriptors = inputDescriptors;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(final String name) {
+        this.name = name;
+    }
+
+    public String getUniqueSourceIdentifier() {
+        return uniqueSourceIdentifier;
+    }
+
+    public void setUniqueSourceIdentifier(final String uniqueSourceIdentifier) {
+        this.uniqueSourceIdentifier = uniqueSourceIdentifier;
+    }
+}

--- a/Rest/alm-releasemanagement-client/src/main/generated/com/microsoft/alm/visualstudio/services/releasemanagement/webapi/contracts/BaseDeploymentInput.java
+++ b/Rest/alm-releasemanagement-client/src/main/generated/com/microsoft/alm/visualstudio/services/releasemanagement/webapi/contracts/BaseDeploymentInput.java
@@ -1,0 +1,23 @@
+// @formatter:off
+/*
+* ---------------------------------------------------------
+* Copyright(C) Microsoft Corporation. All rights reserved.
+* Licensed under the MIT license. See License.txt in the project root.
+* ---------------------------------------------------------
+*
+* ---------------------------------------------------------
+* Generated file, DO NOT EDIT
+* ---------------------------------------------------------
+*
+* See following wiki page for instructions on how to regenerate:
+*   https://vsowiki.com/index.php?title=Rest_Client_Generation
+*/
+
+package com.microsoft.alm.visualstudio.services.releasemanagement.webapi.contracts;
+
+
+/** 
+ */
+public class BaseDeploymentInput {
+
+}

--- a/Rest/alm-releasemanagement-client/src/main/generated/com/microsoft/alm/visualstudio/services/releasemanagement/webapi/contracts/ControlOptions.java
+++ b/Rest/alm-releasemanagement-client/src/main/generated/com/microsoft/alm/visualstudio/services/releasemanagement/webapi/contracts/ControlOptions.java
@@ -1,0 +1,50 @@
+// @formatter:off
+/*
+* ---------------------------------------------------------
+* Copyright(C) Microsoft Corporation. All rights reserved.
+* Licensed under the MIT license. See License.txt in the project root.
+* ---------------------------------------------------------
+*
+* ---------------------------------------------------------
+* Generated file, DO NOT EDIT
+* ---------------------------------------------------------
+*
+* See following wiki page for instructions on how to regenerate:
+*   https://vsowiki.com/index.php?title=Rest_Client_Generation
+*/
+
+package com.microsoft.alm.visualstudio.services.releasemanagement.webapi.contracts;
+
+
+/** 
+ */
+public class ControlOptions {
+
+    private boolean alwaysRun;
+    private boolean continueOnError;
+    private boolean enabled;
+
+    public boolean getAlwaysRun() {
+        return alwaysRun;
+    }
+
+    public void setAlwaysRun(final boolean alwaysRun) {
+        this.alwaysRun = alwaysRun;
+    }
+
+    public boolean getContinueOnError() {
+        return continueOnError;
+    }
+
+    public void setContinueOnError(final boolean continueOnError) {
+        this.continueOnError = continueOnError;
+    }
+
+    public boolean getEnabled() {
+        return enabled;
+    }
+
+    public void setEnabled(final boolean enabled) {
+        this.enabled = enabled;
+    }
+}

--- a/Rest/alm-releasemanagement-client/src/main/generated/com/microsoft/alm/visualstudio/services/releasemanagement/webapi/contracts/DataSourceBinding.java
+++ b/Rest/alm-releasemanagement-client/src/main/generated/com/microsoft/alm/visualstudio/services/releasemanagement/webapi/contracts/DataSourceBinding.java
@@ -1,0 +1,96 @@
+// @formatter:off
+/*
+* ---------------------------------------------------------
+* Copyright(C) Microsoft Corporation. All rights reserved.
+* Licensed under the MIT license. See License.txt in the project root.
+* ---------------------------------------------------------
+*
+* ---------------------------------------------------------
+* Generated file, DO NOT EDIT
+* ---------------------------------------------------------
+*
+* See following wiki page for instructions on how to regenerate:
+*   https://vsowiki.com/index.php?title=Rest_Client_Generation
+*/
+
+package com.microsoft.alm.visualstudio.services.releasemanagement.webapi.contracts;
+
+import java.util.HashMap;
+
+/** 
+ */
+public class DataSourceBinding {
+
+    private String dataSourceName;
+    private String endpointId;
+    private String endpointUrl;
+    private HashMap<String, String> parameters;
+    private String resultSelector;
+    private String resultTemplate;
+    private String target;
+    private String transformationTemplate;
+
+    public String getDataSourceName() {
+        return dataSourceName;
+    }
+
+    public void setDataSourceName(final String dataSourceName) {
+        this.dataSourceName = dataSourceName;
+    }
+
+    public String getEndpointId() {
+        return endpointId;
+    }
+
+    public void setEndpointId(final String endpointId) {
+        this.endpointId = endpointId;
+    }
+
+    public String getEndpointUrl() {
+        return endpointUrl;
+    }
+
+    public void setEndpointUrl(final String endpointUrl) {
+        this.endpointUrl = endpointUrl;
+    }
+
+    public HashMap<String, String> getParameters() {
+        return parameters;
+    }
+
+    public void setParameters(final HashMap<String, String> parameters) {
+        this.parameters = parameters;
+    }
+
+    public String getResultSelector() {
+        return resultSelector;
+    }
+
+    public void setResultSelector(final String resultSelector) {
+        this.resultSelector = resultSelector;
+    }
+
+    public String getResultTemplate() {
+        return resultTemplate;
+    }
+
+    public void setResultTemplate(final String resultTemplate) {
+        this.resultTemplate = resultTemplate;
+    }
+
+    public String getTarget() {
+        return target;
+    }
+
+    public void setTarget(final String target) {
+        this.target = target;
+    }
+
+    public String getTransformationTemplate() {
+        return transformationTemplate;
+    }
+
+    public void setTransformationTemplate(final String transformationTemplate) {
+        this.transformationTemplate = transformationTemplate;
+    }
+}

--- a/Rest/alm-releasemanagement-client/src/main/generated/com/microsoft/alm/visualstudio/services/releasemanagement/webapi/contracts/DeployPhase.java
+++ b/Rest/alm-releasemanagement-client/src/main/generated/com/microsoft/alm/visualstudio/services/releasemanagement/webapi/contracts/DeployPhase.java
@@ -1,0 +1,74 @@
+// @formatter:off
+/*
+* ---------------------------------------------------------
+* Copyright(C) Microsoft Corporation. All rights reserved.
+* Licensed under the MIT license. See License.txt in the project root.
+* ---------------------------------------------------------
+*
+* ---------------------------------------------------------
+* Generated file, DO NOT EDIT
+* ---------------------------------------------------------
+*
+* See following wiki page for instructions on how to regenerate:
+*   https://vsowiki.com/index.php?title=Rest_Client_Generation
+*/
+
+package com.microsoft.alm.visualstudio.services.releasemanagement.webapi.contracts;
+
+import java.util.ArrayList;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.microsoft.alm.visualstudio.services.releasemanagement.webapi.DeployPhaseTypes;
+
+/** 
+ */
+@JsonDeserialize(using = DeployPhaseDeserializer.class)
+@JsonSerialize(using = DeployPhaseSerializer.class)
+public class DeployPhase {
+
+    private ControlOptions controlOptions;
+    private String name;
+    private DeployPhaseTypes phaseType;
+    private int rank;
+    private ArrayList<WorkflowTask> workflowTasks;
+
+    public ControlOptions getControlOptions() {
+        return controlOptions;
+    }
+
+    public void setControlOptions(final ControlOptions controlOptions) {
+        this.controlOptions = controlOptions;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(final String name) {
+        this.name = name;
+    }
+
+    public DeployPhaseTypes getPhaseType() {
+        return phaseType;
+    }
+
+    public void setPhaseType(final DeployPhaseTypes phaseType) {
+        this.phaseType = phaseType;
+    }
+
+    public int getRank() {
+        return rank;
+    }
+
+    public void setRank(final int rank) {
+        this.rank = rank;
+    }
+
+    public ArrayList<WorkflowTask> getWorkflowTasks() {
+        return workflowTasks;
+    }
+
+    public void setWorkflowTasks(final ArrayList<WorkflowTask> workflowTasks) {
+        this.workflowTasks = workflowTasks;
+    }
+}

--- a/Rest/alm-releasemanagement-client/src/main/generated/com/microsoft/alm/visualstudio/services/releasemanagement/webapi/contracts/DeploymentJob.java
+++ b/Rest/alm-releasemanagement-client/src/main/generated/com/microsoft/alm/visualstudio/services/releasemanagement/webapi/contracts/DeploymentJob.java
@@ -1,0 +1,43 @@
+// @formatter:off
+/*
+* ---------------------------------------------------------
+* Copyright(C) Microsoft Corporation. All rights reserved.
+* Licensed under the MIT license. See License.txt in the project root.
+* ---------------------------------------------------------
+*
+* ---------------------------------------------------------
+* Generated file, DO NOT EDIT
+* ---------------------------------------------------------
+*
+* See following wiki page for instructions on how to regenerate:
+*   https://vsowiki.com/index.php?title=Rest_Client_Generation
+*/
+
+package com.microsoft.alm.visualstudio.services.releasemanagement.webapi.contracts;
+
+import java.util.ArrayList;
+import com.microsoft.alm.visualstudio.services.releasemanagement.webapi.ReleaseTask;
+
+/** 
+ */
+public class DeploymentJob {
+
+    private ReleaseTask job;
+    private ArrayList<ReleaseTask> tasks;
+
+    public ReleaseTask getJob() {
+        return job;
+    }
+
+    public void setJob(final ReleaseTask job) {
+        this.job = job;
+    }
+
+    public ArrayList<ReleaseTask> getTasks() {
+        return tasks;
+    }
+
+    public void setTasks(final ArrayList<ReleaseTask> tasks) {
+        this.tasks = tasks;
+    }
+}

--- a/Rest/alm-releasemanagement-client/src/main/generated/com/microsoft/alm/visualstudio/services/releasemanagement/webapi/contracts/MachineGroupBasedDeployPhase.java
+++ b/Rest/alm-releasemanagement-client/src/main/generated/com/microsoft/alm/visualstudio/services/releasemanagement/webapi/contracts/MachineGroupBasedDeployPhase.java
@@ -1,0 +1,39 @@
+// @formatter:off
+/*
+* ---------------------------------------------------------
+* Copyright(C) Microsoft Corporation. All rights reserved.
+* Licensed under the MIT license. See License.txt in the project root.
+* ---------------------------------------------------------
+*
+* ---------------------------------------------------------
+* Generated file, DO NOT EDIT
+* ---------------------------------------------------------
+*
+* See following wiki page for instructions on how to regenerate:
+*   https://vsowiki.com/index.php?title=Rest_Client_Generation
+*/
+
+package com.microsoft.alm.visualstudio.services.releasemanagement.webapi.contracts;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.JsonSerializer;
+
+/** 
+ */
+@JsonDeserialize(using = JsonDeserializer.None.class)
+@JsonSerialize(using = JsonSerializer.None.class)
+public class MachineGroupBasedDeployPhase
+    extends DeployPhase {
+
+    private MachineGroupDeploymentInput deploymentInput;
+
+    public MachineGroupDeploymentInput getDeploymentInput() {
+        return deploymentInput;
+    }
+
+    public void setDeploymentInput(final MachineGroupDeploymentInput deploymentInput) {
+        this.deploymentInput = deploymentInput;
+    }
+}

--- a/Rest/alm-releasemanagement-client/src/main/generated/com/microsoft/alm/visualstudio/services/releasemanagement/webapi/contracts/MachineGroupDeploymentInput.java
+++ b/Rest/alm-releasemanagement-client/src/main/generated/com/microsoft/alm/visualstudio/services/releasemanagement/webapi/contracts/MachineGroupDeploymentInput.java
@@ -1,0 +1,33 @@
+// @formatter:off
+/*
+* ---------------------------------------------------------
+* Copyright(C) Microsoft Corporation. All rights reserved.
+* Licensed under the MIT license. See License.txt in the project root.
+* ---------------------------------------------------------
+*
+* ---------------------------------------------------------
+* Generated file, DO NOT EDIT
+* ---------------------------------------------------------
+*
+* See following wiki page for instructions on how to regenerate:
+*   https://vsowiki.com/index.php?title=Rest_Client_Generation
+*/
+
+package com.microsoft.alm.visualstudio.services.releasemanagement.webapi.contracts;
+
+
+/** 
+ */
+public class MachineGroupDeploymentInput
+    extends AgentDeploymentInput {
+
+    private int healthPercent;
+
+    public int getHealthPercent() {
+        return healthPercent;
+    }
+
+    public void setHealthPercent(final int healthPercent) {
+        this.healthPercent = healthPercent;
+    }
+}

--- a/Rest/alm-releasemanagement-client/src/main/generated/com/microsoft/alm/visualstudio/services/releasemanagement/webapi/contracts/ReleaseDefinitionEnvironment.java
+++ b/Rest/alm-releasemanagement-client/src/main/generated/com/microsoft/alm/visualstudio/services/releasemanagement/webapi/contracts/ReleaseDefinitionEnvironment.java
@@ -29,6 +29,7 @@ public class ReleaseDefinitionEnvironment {
 
     private ArrayList<Condition> conditions;
     private ArrayList<Demand> demands;
+    private ArrayList<DeployPhase> deployPhases;
     private ReleaseDefinitionDeployStep deployStep;
     private EnvironmentOptions environmentOptions;
     private EnvironmentExecutionPolicy executionPolicy;
@@ -58,6 +59,14 @@ public class ReleaseDefinitionEnvironment {
 
     public void setDemands(final ArrayList<Demand> demands) {
         this.demands = demands;
+    }
+
+    public ArrayList<DeployPhase> getDeployPhases() {
+        return deployPhases;
+    }
+
+    public void setDeployPhases(final ArrayList<DeployPhase> deployPhases) {
+        this.deployPhases = deployPhases;
     }
 
     public ReleaseDefinitionDeployStep getDeployStep() {

--- a/Rest/alm-releasemanagement-client/src/main/generated/com/microsoft/alm/visualstudio/services/releasemanagement/webapi/contracts/ReleaseDeployPhase.java
+++ b/Rest/alm-releasemanagement-client/src/main/generated/com/microsoft/alm/visualstudio/services/releasemanagement/webapi/contracts/ReleaseDeployPhase.java
@@ -1,0 +1,100 @@
+// @formatter:off
+/*
+* ---------------------------------------------------------
+* Copyright(C) Microsoft Corporation. All rights reserved.
+* Licensed under the MIT license. See License.txt in the project root.
+* ---------------------------------------------------------
+*
+* ---------------------------------------------------------
+* Generated file, DO NOT EDIT
+* ---------------------------------------------------------
+*
+* See following wiki page for instructions on how to regenerate:
+*   https://vsowiki.com/index.php?title=Rest_Client_Generation
+*/
+
+package com.microsoft.alm.visualstudio.services.releasemanagement.webapi.contracts;
+
+import java.util.ArrayList;
+import java.util.UUID;
+import com.microsoft.alm.visualstudio.services.releasemanagement.webapi.DeployPhaseStatus;
+import com.microsoft.alm.visualstudio.services.releasemanagement.webapi.DeployPhaseTypes;
+import com.microsoft.alm.visualstudio.services.releasemanagement.webapi.ManualIntervention;
+
+/** 
+ */
+public class ReleaseDeployPhase {
+
+    private ArrayList<DeploymentJob> deploymentJobs;
+    private String errorLog;
+    private int id;
+    private ArrayList<ManualIntervention> manualInterventions;
+    private DeployPhaseTypes phaseType;
+    private int rank;
+    private UUID runPlanId;
+    private DeployPhaseStatus status;
+
+    public ArrayList<DeploymentJob> getDeploymentJobs() {
+        return deploymentJobs;
+    }
+
+    public void setDeploymentJobs(final ArrayList<DeploymentJob> deploymentJobs) {
+        this.deploymentJobs = deploymentJobs;
+    }
+
+    public String getErrorLog() {
+        return errorLog;
+    }
+
+    public void setErrorLog(final String errorLog) {
+        this.errorLog = errorLog;
+    }
+
+    public int getId() {
+        return id;
+    }
+
+    public void setId(final int id) {
+        this.id = id;
+    }
+
+    public ArrayList<ManualIntervention> getManualInterventions() {
+        return manualInterventions;
+    }
+
+    public void setManualInterventions(final ArrayList<ManualIntervention> manualInterventions) {
+        this.manualInterventions = manualInterventions;
+    }
+
+    public DeployPhaseTypes getPhaseType() {
+        return phaseType;
+    }
+
+    public void setPhaseType(final DeployPhaseTypes phaseType) {
+        this.phaseType = phaseType;
+    }
+
+    public int getRank() {
+        return rank;
+    }
+
+    public void setRank(final int rank) {
+        this.rank = rank;
+    }
+
+    public UUID getRunPlanId() {
+        return runPlanId;
+    }
+
+    public void setRunPlanId(final UUID runPlanId) {
+        this.runPlanId = runPlanId;
+    }
+
+    public DeployPhaseStatus getStatus() {
+        return status;
+    }
+
+    public void setStatus(final DeployPhaseStatus status) {
+        this.status = status;
+    }
+}

--- a/Rest/alm-releasemanagement-client/src/main/generated/com/microsoft/alm/visualstudio/services/releasemanagement/webapi/contracts/ReleaseExpands.java
+++ b/Rest/alm-releasemanagement-client/src/main/generated/com/microsoft/alm/visualstudio/services/releasemanagement/webapi/contracts/ReleaseExpands.java
@@ -24,6 +24,7 @@ public enum ReleaseExpands {
     ENVIRONMENTS(2),
     ARTIFACTS(4),
     APPROVALS(8),
+    MANUAL_INTERVENTIONS(16),
     ;
 
     private int value;
@@ -54,6 +55,10 @@ public enum ReleaseExpands {
 
         if (name.equals("APPROVALS")) { //$NON-NLS-1$
             return "approvals"; //$NON-NLS-1$
+        }
+
+        if (name.equals("MANUAL_INTERVENTIONS")) { //$NON-NLS-1$
+            return "manualInterventions"; //$NON-NLS-1$
         }
 
         return null;

--- a/Rest/alm-releasemanagement-client/src/main/generated/com/microsoft/alm/visualstudio/services/releasemanagement/webapi/contracts/RunOnServerDeployPhase.java
+++ b/Rest/alm-releasemanagement-client/src/main/generated/com/microsoft/alm/visualstudio/services/releasemanagement/webapi/contracts/RunOnServerDeployPhase.java
@@ -1,0 +1,30 @@
+// @formatter:off
+/*
+* ---------------------------------------------------------
+* Copyright(C) Microsoft Corporation. All rights reserved.
+* Licensed under the MIT license. See License.txt in the project root.
+* ---------------------------------------------------------
+*
+* ---------------------------------------------------------
+* Generated file, DO NOT EDIT
+* ---------------------------------------------------------
+*
+* See following wiki page for instructions on how to regenerate:
+*   https://vsowiki.com/index.php?title=Rest_Client_Generation
+*/
+
+package com.microsoft.alm.visualstudio.services.releasemanagement.webapi.contracts;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.JsonSerializer;
+
+/** 
+ */
+@JsonDeserialize(using = JsonDeserializer.None.class)
+@JsonSerialize(using = JsonSerializer.None.class)
+public class RunOnServerDeployPhase
+    extends DeployPhase {
+
+}

--- a/Rest/alm-releasemanagement-client/src/main/generated/com/microsoft/alm/visualstudio/services/releasemanagement/webapi/events/ReleaseEnvironmentCompletedEvent.java
+++ b/Rest/alm-releasemanagement-client/src/main/generated/com/microsoft/alm/visualstudio/services/releasemanagement/webapi/events/ReleaseEnvironmentCompletedEvent.java
@@ -15,6 +15,9 @@
 
 package com.microsoft.alm.visualstudio.services.releasemanagement.webapi.events;
 
+import java.util.ArrayList;
+import com.microsoft.alm.visualstudio.services.releasemanagement.webapi.contracts.conditions.Condition;
+import com.microsoft.alm.visualstudio.services.releasemanagement.webapi.DeploymentReason;
 import com.microsoft.alm.visualstudio.services.releasemanagement.webapi.ReleaseEnvironment;
 import com.microsoft.alm.visualstudio.services.webapi.IdentityRef;
 
@@ -22,18 +25,28 @@ import com.microsoft.alm.visualstudio.services.webapi.IdentityRef;
  */
 public class ReleaseEnvironmentCompletedEvent {
 
+    private ArrayList<Condition> conditions;
     private String createdByName;
     private int definitionId;
     private String definitionName;
     private ReleaseEnvironment environment;
     private int environmentId;
     private String projectName;
+    private DeploymentReason reason;
     private IdentityRef releaseCreatedBy;
     private String releaseLogsUri;
     private String releaseName;
     private String status;
     private String title;
     private String webAccessUri;
+
+    public ArrayList<Condition> getConditions() {
+        return conditions;
+    }
+
+    public void setConditions(final ArrayList<Condition> conditions) {
+        this.conditions = conditions;
+    }
 
     public String getCreatedByName() {
         return createdByName;
@@ -81,6 +94,14 @@ public class ReleaseEnvironmentCompletedEvent {
 
     public void setProjectName(final String projectName) {
         this.projectName = projectName;
+    }
+
+    public DeploymentReason getReason() {
+        return reason;
+    }
+
+    public void setReason(final DeploymentReason reason) {
+        this.reason = reason;
     }
 
     public IdentityRef getReleaseCreatedBy() {

--- a/Rest/alm-releasemanagement-client/src/main/java/com/microsoft/alm/visualstudio/services/releasemanagement/webapi/ReleaseHttpClient.java
+++ b/Rest/alm-releasemanagement-client/src/main/java/com/microsoft/alm/visualstudio/services/releasemanagement/webapi/ReleaseHttpClient.java
@@ -3,12 +3,13 @@
 
 package com.microsoft.alm.visualstudio.services.releasemanagement.webapi;
 
-import javax.ws.rs.client.Client;
 import java.net.URI;
+
+import com.microsoft.alm.client.VssRestClientHandler;
 
 public class ReleaseHttpClient extends ReleaseHttpClientBase {
 
-    public ReleaseHttpClient(final Client jaxrsClient, final URI baseUrl) {
-        super(jaxrsClient, baseUrl);
+    public ReleaseHttpClient(final VssRestClientHandler clientHandler, final URI baseUrl) {
+        super(clientHandler, baseUrl);
     }
 }

--- a/Rest/alm-releasemanagement-client/src/main/java/com/microsoft/alm/visualstudio/services/releasemanagement/webapi/contracts/DeployPhaseDeserializer.java
+++ b/Rest/alm-releasemanagement-client/src/main/java/com/microsoft/alm/visualstudio/services/releasemanagement/webapi/contracts/DeployPhaseDeserializer.java
@@ -1,0 +1,63 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root.
+
+package com.microsoft.alm.visualstudio.services.releasemanagement.webapi.contracts;
+
+import java.io.IOException;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.microsoft.alm.visualstudio.services.releasemanagement.webapi.DeployPhaseTypes;
+
+public class DeployPhaseDeserializer extends JsonDeserializer<DeployPhase> {
+
+    @Override
+    public DeployPhase deserialize(JsonParser parser, DeserializationContext context)
+        throws IOException,
+            JsonProcessingException {
+        final ObjectMapper mapper = (ObjectMapper) parser.getCodec();
+        final JsonNode rootNode = (JsonNode) mapper.readTree(parser);
+
+        final JsonNode typeNode = rootNode.findValue("PhaseType"); //$NON-NLS-1$
+
+        if (typeNode != null) {
+            DeployPhaseTypes triggerType = null;
+
+            if (typeNode.isInt() && typeNode.asInt() == DeployPhaseTypes.AGENT_BASED_DEPLOYMENT.getValue()) {
+                triggerType = DeployPhaseTypes.AGENT_BASED_DEPLOYMENT;
+            } else if (typeNode.isInt() && typeNode.asInt() == DeployPhaseTypes.RUN_ON_SERVER.getValue()) {
+                triggerType = DeployPhaseTypes.RUN_ON_SERVER;
+            } else if (typeNode.isInt()
+                && typeNode.asInt() == DeployPhaseTypes.MACHINE_GROUP_BASED_DEPLOYMENT.getValue()) {
+                triggerType = DeployPhaseTypes.MACHINE_GROUP_BASED_DEPLOYMENT;
+            } else if (typeNode.isTextual()
+                && DeployPhaseTypes.AGENT_BASED_DEPLOYMENT.toString().equalsIgnoreCase(typeNode.asText())) {
+                triggerType = DeployPhaseTypes.AGENT_BASED_DEPLOYMENT;
+            } else if (typeNode.isTextual()
+                && DeployPhaseTypes.RUN_ON_SERVER.toString().equalsIgnoreCase(typeNode.asText())) {
+                triggerType = DeployPhaseTypes.RUN_ON_SERVER;
+            } else if (typeNode.isTextual()
+                && DeployPhaseTypes.MACHINE_GROUP_BASED_DEPLOYMENT.toString().equalsIgnoreCase(typeNode.asText())) {
+                triggerType = DeployPhaseTypes.MACHINE_GROUP_BASED_DEPLOYMENT;
+            }
+
+            if (DeployPhaseTypes.AGENT_BASED_DEPLOYMENT == triggerType) {
+                return rootNode.traverse(mapper).readValueAs(AgentBasedDeployPhase.class);
+            }
+
+            if (DeployPhaseTypes.RUN_ON_SERVER == triggerType) {
+                return rootNode.traverse(mapper).readValueAs(RunOnServerDeployPhase.class);
+            }
+
+            if (DeployPhaseTypes.MACHINE_GROUP_BASED_DEPLOYMENT == triggerType) {
+                return rootNode.traverse(mapper).readValueAs(MachineGroupBasedDeployPhase.class);
+            }
+        }
+
+        return null;
+    }
+}

--- a/Rest/alm-releasemanagement-client/src/main/java/com/microsoft/alm/visualstudio/services/releasemanagement/webapi/contracts/DeployPhaseSerializer.java
+++ b/Rest/alm-releasemanagement-client/src/main/java/com/microsoft/alm/visualstudio/services/releasemanagement/webapi/contracts/DeployPhaseSerializer.java
@@ -1,0 +1,26 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root.
+
+package com.microsoft.alm.visualstudio.services.releasemanagement.webapi.contracts;
+
+import java.io.IOException;
+import java.text.MessageFormat;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.microsoft.alm.client.Messages;
+
+public class DeployPhaseSerializer extends JsonSerializer<DeployPhase> {
+
+    @Override
+    public void serialize(DeployPhase value, JsonGenerator writer, SerializerProvider serializer)
+        throws IOException,
+            JsonProcessingException {
+        throw new UnsupportedOperationException(
+            MessageFormat.format(
+                Messages.getString("Serializer.NotImplementedFormat"), //$NON-NLS-1$
+                value.getClass().getName()));
+    }
+}

--- a/Rest/alm-tfs-client/src/main/generated/com/microsoft/alm/teamfoundation/build/webapi/BuildHttpClientBase.java
+++ b/Rest/alm-tfs-client/src/main/generated/com/microsoft/alm/teamfoundation/build/webapi/BuildHttpClientBase.java
@@ -24,8 +24,12 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import com.fasterxml.jackson.core.type.TypeReference;
+import com.microsoft.alm.client.HttpMethod;
 import com.microsoft.alm.client.model.NameValueCollection;
 import com.microsoft.alm.client.VssHttpClientBase;
+import com.microsoft.alm.client.VssMediaTypes;
+import com.microsoft.alm.client.VssRestClientHandler;
+import com.microsoft.alm.client.VssRestRequest;
 import com.microsoft.alm.teamfoundation.build.webapi.Build;
 import com.microsoft.alm.teamfoundation.build.webapi.BuildArtifact;
 import com.microsoft.alm.teamfoundation.build.webapi.BuildBadge;
@@ -66,22 +70,13 @@ public abstract class BuildHttpClientBase
     * Create a new instance of BuildHttpClientBase
     *
     * @param jaxrsClient
-    *            an initialized instance of a JAX-RS Client implementation
+    *            a DefaultRestClientHandler initialized with an instance of a JAX-RS Client implementation or
+    *            a TEERestClientHamdler initialized with TEE HTTP client implementation
     * @param baseUrl
-    *            a TFS project collection URL
+    *            a TFS services URL
     */
-    protected BuildHttpClientBase(final Object jaxrsClient, final URI baseUrl) {
-        super(jaxrsClient, baseUrl);
-    }
-
-    /**
-    * Create a new instance of BuildHttpClientBase
-    *
-    * @param tfsConnection
-    *            an initialized instance of a TfsTeamProjectCollection
-    */
-    protected BuildHttpClientBase(final Object tfsConnection) {
-        super(tfsConnection);
+    protected BuildHttpClientBase(final VssRestClientHandler clientHandler, final URI baseUrl) {
+        super(clientHandler, baseUrl);
     }
 
     @Override
@@ -108,13 +103,13 @@ public abstract class BuildHttpClientBase
         final Map<String, Object> routeValues = new HashMap<String, Object>();
         routeValues.put("buildId", buildId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.POST,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       artifact,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.POST,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               artifact,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, BuildArtifact.class);
     }
@@ -142,13 +137,13 @@ public abstract class BuildHttpClientBase
         routeValues.put("project", project); //$NON-NLS-1$
         routeValues.put("buildId", buildId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.POST,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       artifact,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.POST,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               artifact,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, BuildArtifact.class);
     }
@@ -176,13 +171,13 @@ public abstract class BuildHttpClientBase
         routeValues.put("project", project); //$NON-NLS-1$
         routeValues.put("buildId", buildId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.POST,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       artifact,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.POST,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               artifact,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, BuildArtifact.class);
     }
@@ -213,12 +208,12 @@ public abstract class BuildHttpClientBase
         final NameValueCollection queryParameters = new NameValueCollection();
         queryParameters.addIfNotEmpty("artifactName", artifactName); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, BuildArtifact.class);
     }
@@ -249,12 +244,12 @@ public abstract class BuildHttpClientBase
         final NameValueCollection queryParameters = new NameValueCollection();
         queryParameters.addIfNotEmpty("artifactName", artifactName); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, BuildArtifact.class);
     }
@@ -281,12 +276,12 @@ public abstract class BuildHttpClientBase
         final NameValueCollection queryParameters = new NameValueCollection();
         queryParameters.addIfNotEmpty("artifactName", artifactName); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, BuildArtifact.class);
     }
@@ -317,12 +312,12 @@ public abstract class BuildHttpClientBase
         final NameValueCollection queryParameters = new NameValueCollection();
         queryParameters.addIfNotEmpty("artifactName", artifactName); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_ZIP_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_ZIP_TYPE);
 
         return super.sendRequest(httpRequest, InputStream.class);
     }
@@ -353,12 +348,12 @@ public abstract class BuildHttpClientBase
         final NameValueCollection queryParameters = new NameValueCollection();
         queryParameters.addIfNotEmpty("artifactName", artifactName); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_ZIP_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_ZIP_TYPE);
 
         return super.sendRequest(httpRequest, InputStream.class);
     }
@@ -385,12 +380,12 @@ public abstract class BuildHttpClientBase
         final NameValueCollection queryParameters = new NameValueCollection();
         queryParameters.addIfNotEmpty("artifactName", artifactName); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_ZIP_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_ZIP_TYPE);
 
         return super.sendRequest(httpRequest, InputStream.class);
     }
@@ -410,11 +405,11 @@ public abstract class BuildHttpClientBase
         final Map<String, Object> routeValues = new HashMap<String, Object>();
         routeValues.put("buildId", buildId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<BuildArtifact>>() {});
     }
@@ -439,11 +434,11 @@ public abstract class BuildHttpClientBase
         routeValues.put("project", project); //$NON-NLS-1$
         routeValues.put("buildId", buildId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<BuildArtifact>>() {});
     }
@@ -468,11 +463,11 @@ public abstract class BuildHttpClientBase
         routeValues.put("project", project); //$NON-NLS-1$
         routeValues.put("buildId", buildId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<BuildArtifact>>() {});
     }
@@ -503,12 +498,12 @@ public abstract class BuildHttpClientBase
         final NameValueCollection queryParameters = new NameValueCollection();
         queryParameters.addIfNotEmpty("branchName", branchName); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, String.class);
     }
@@ -543,12 +538,12 @@ public abstract class BuildHttpClientBase
         queryParameters.addIfNotEmpty("repoId", repoId); //$NON-NLS-1$
         queryParameters.addIfNotEmpty("branchName", branchName); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, BuildBadge.class);
     }
@@ -583,12 +578,12 @@ public abstract class BuildHttpClientBase
         queryParameters.addIfNotEmpty("repoId", repoId); //$NON-NLS-1$
         queryParameters.addIfNotEmpty("branchName", branchName); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, BuildBadge.class);
     }
@@ -623,12 +618,12 @@ public abstract class BuildHttpClientBase
         queryParameters.addIfNotEmpty("repoId", repoId); //$NON-NLS-1$
         queryParameters.addIfNotEmpty("branchName", branchName); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, String.class);
     }
@@ -663,12 +658,12 @@ public abstract class BuildHttpClientBase
         queryParameters.addIfNotEmpty("repoId", repoId); //$NON-NLS-1$
         queryParameters.addIfNotEmpty("branchName", branchName); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, String.class);
     }
@@ -687,11 +682,11 @@ public abstract class BuildHttpClientBase
         final Map<String, Object> routeValues = new HashMap<String, Object>();
         routeValues.put("buildId", buildId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.DELETE,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.DELETE,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         super.sendRequest(httpRequest);
     }
@@ -715,11 +710,11 @@ public abstract class BuildHttpClientBase
         routeValues.put("project", project); //$NON-NLS-1$
         routeValues.put("buildId", buildId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.DELETE,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.DELETE,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         super.sendRequest(httpRequest);
     }
@@ -743,11 +738,11 @@ public abstract class BuildHttpClientBase
         routeValues.put("project", project); //$NON-NLS-1$
         routeValues.put("buildId", buildId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.DELETE,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.DELETE,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         super.sendRequest(httpRequest);
     }
@@ -778,12 +773,12 @@ public abstract class BuildHttpClientBase
         final NameValueCollection queryParameters = new NameValueCollection();
         queryParameters.addIfNotEmpty("propertyFilters", propertyFilters); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, Build.class);
     }
@@ -814,12 +809,12 @@ public abstract class BuildHttpClientBase
         final NameValueCollection queryParameters = new NameValueCollection();
         queryParameters.addIfNotEmpty("propertyFilters", propertyFilters); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, Build.class);
     }
@@ -846,12 +841,12 @@ public abstract class BuildHttpClientBase
         final NameValueCollection queryParameters = new NameValueCollection();
         queryParameters.addIfNotEmpty("propertyFilters", propertyFilters); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, Build.class);
     }
@@ -954,12 +949,12 @@ public abstract class BuildHttpClientBase
         queryParameters.addIfNotEmpty("repositoryId", repositoryId); //$NON-NLS-1$
         queryParameters.addIfNotEmpty("repositoryType", repositoryType); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<Build>>() {});
     }
@@ -1062,12 +1057,12 @@ public abstract class BuildHttpClientBase
         queryParameters.addIfNotEmpty("repositoryId", repositoryId); //$NON-NLS-1$
         queryParameters.addIfNotEmpty("repositoryType", repositoryType); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<Build>>() {});
     }
@@ -1164,11 +1159,11 @@ public abstract class BuildHttpClientBase
         queryParameters.addIfNotEmpty("repositoryId", repositoryId); //$NON-NLS-1$
         queryParameters.addIfNotEmpty("repositoryType", repositoryType); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<Build>>() {});
     }
@@ -1196,13 +1191,13 @@ public abstract class BuildHttpClientBase
         queryParameters.addIfNotNull("ignoreWarnings", ignoreWarnings); //$NON-NLS-1$
         queryParameters.addIfNotEmpty("checkInTicket", checkInTicket); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.POST,
-                                                       locationId,
-                                                       apiVersion,
-                                                       build,
-                                                       APPLICATION_JSON_TYPE,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.POST,
+                                                               locationId,
+                                                               apiVersion,
+                                                               build,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, Build.class);
     }
@@ -1236,14 +1231,14 @@ public abstract class BuildHttpClientBase
         queryParameters.addIfNotNull("ignoreWarnings", ignoreWarnings); //$NON-NLS-1$
         queryParameters.addIfNotEmpty("checkInTicket", checkInTicket); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.POST,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       build,
-                                                       APPLICATION_JSON_TYPE,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.POST,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               build,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, Build.class);
     }
@@ -1277,14 +1272,14 @@ public abstract class BuildHttpClientBase
         queryParameters.addIfNotNull("ignoreWarnings", ignoreWarnings); //$NON-NLS-1$
         queryParameters.addIfNotEmpty("checkInTicket", checkInTicket); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.POST,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       build,
-                                                       APPLICATION_JSON_TYPE,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.POST,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               build,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, Build.class);
     }
@@ -1308,13 +1303,13 @@ public abstract class BuildHttpClientBase
         final Map<String, Object> routeValues = new HashMap<String, Object>();
         routeValues.put("buildId", buildId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.PATCH,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       build,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.PATCH,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               build,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, Build.class);
     }
@@ -1342,13 +1337,13 @@ public abstract class BuildHttpClientBase
         routeValues.put("project", project); //$NON-NLS-1$
         routeValues.put("buildId", buildId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.PATCH,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       build,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.PATCH,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               build,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, Build.class);
     }
@@ -1376,13 +1371,13 @@ public abstract class BuildHttpClientBase
         routeValues.put("project", project); //$NON-NLS-1$
         routeValues.put("buildId", buildId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.PATCH,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       build,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.PATCH,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               build,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, Build.class);
     }
@@ -1399,12 +1394,12 @@ public abstract class BuildHttpClientBase
         final UUID locationId = UUID.fromString("0cd358e1-9217-4d94-8269-1c1ee6f93dcf"); //$NON-NLS-1$
         final ApiResourceVersion apiVersion = new ApiResourceVersion("3.0-preview.3"); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.PATCH,
-                                                       locationId,
-                                                       apiVersion,
-                                                       builds,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.PATCH,
+                                                               locationId,
+                                                               apiVersion,
+                                                               builds,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<Build>>() {});
     }
@@ -1428,13 +1423,13 @@ public abstract class BuildHttpClientBase
         final Map<String, Object> routeValues = new HashMap<String, Object>();
         routeValues.put("project", project); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.PATCH,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       builds,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.PATCH,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               builds,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<Build>>() {});
     }
@@ -1458,13 +1453,13 @@ public abstract class BuildHttpClientBase
         final Map<String, Object> routeValues = new HashMap<String, Object>();
         routeValues.put("project", project); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.PATCH,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       builds,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.PATCH,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               builds,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<Build>>() {});
     }
@@ -1503,12 +1498,12 @@ public abstract class BuildHttpClientBase
         queryParameters.addIfNotNull("$top", top); //$NON-NLS-1$
         queryParameters.addIfNotNull("includeSourceChange", includeSourceChange); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<Change>>() {});
     }
@@ -1547,12 +1542,12 @@ public abstract class BuildHttpClientBase
         queryParameters.addIfNotNull("$top", top); //$NON-NLS-1$
         queryParameters.addIfNotNull("includeSourceChange", includeSourceChange); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<Change>>() {});
     }
@@ -1587,12 +1582,12 @@ public abstract class BuildHttpClientBase
         queryParameters.addIfNotNull("toBuildId", toBuildId); //$NON-NLS-1$
         queryParameters.addIfNotNull("$top", top); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<Change>>() {});
     }
@@ -1627,12 +1622,12 @@ public abstract class BuildHttpClientBase
         queryParameters.addIfNotNull("toBuildId", toBuildId); //$NON-NLS-1$
         queryParameters.addIfNotNull("$top", top); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<Change>>() {});
     }
@@ -1652,11 +1647,11 @@ public abstract class BuildHttpClientBase
         final Map<String, Object> routeValues = new HashMap<String, Object>();
         routeValues.put("controllerId", controllerId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, BuildController.class);
     }
@@ -1676,11 +1671,11 @@ public abstract class BuildHttpClientBase
         final NameValueCollection queryParameters = new NameValueCollection();
         queryParameters.addIfNotEmpty("name", name); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<BuildController>>() {});
     }
@@ -1708,13 +1703,13 @@ public abstract class BuildHttpClientBase
         queryParameters.addIfNotNull("definitionToCloneId", definitionToCloneId); //$NON-NLS-1$
         queryParameters.addIfNotNull("definitionToCloneRevision", definitionToCloneRevision); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.POST,
-                                                       locationId,
-                                                       apiVersion,
-                                                       definition,
-                                                       APPLICATION_JSON_TYPE,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.POST,
+                                                               locationId,
+                                                               apiVersion,
+                                                               definition,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, BuildDefinition.class);
     }
@@ -1748,14 +1743,14 @@ public abstract class BuildHttpClientBase
         queryParameters.addIfNotNull("definitionToCloneId", definitionToCloneId); //$NON-NLS-1$
         queryParameters.addIfNotNull("definitionToCloneRevision", definitionToCloneRevision); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.POST,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       definition,
-                                                       APPLICATION_JSON_TYPE,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.POST,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               definition,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, BuildDefinition.class);
     }
@@ -1789,14 +1784,14 @@ public abstract class BuildHttpClientBase
         queryParameters.addIfNotNull("definitionToCloneId", definitionToCloneId); //$NON-NLS-1$
         queryParameters.addIfNotNull("definitionToCloneRevision", definitionToCloneRevision); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.POST,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       definition,
-                                                       APPLICATION_JSON_TYPE,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.POST,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               definition,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, BuildDefinition.class);
     }
@@ -1815,11 +1810,11 @@ public abstract class BuildHttpClientBase
         final Map<String, Object> routeValues = new HashMap<String, Object>();
         routeValues.put("definitionId", definitionId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.DELETE,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.DELETE,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         super.sendRequest(httpRequest);
     }
@@ -1843,11 +1838,11 @@ public abstract class BuildHttpClientBase
         routeValues.put("project", project); //$NON-NLS-1$
         routeValues.put("definitionId", definitionId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.DELETE,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.DELETE,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         super.sendRequest(httpRequest);
     }
@@ -1871,11 +1866,11 @@ public abstract class BuildHttpClientBase
         routeValues.put("project", project); //$NON-NLS-1$
         routeValues.put("definitionId", definitionId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.DELETE,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.DELETE,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         super.sendRequest(httpRequest);
     }
@@ -1910,12 +1905,12 @@ public abstract class BuildHttpClientBase
         queryParameters.addIfNotNull("revision", revision); //$NON-NLS-1$
         queryParameters.addIfNotNull("propertyFilters", propertyFilters); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, BuildDefinition.class);
     }
@@ -1950,12 +1945,12 @@ public abstract class BuildHttpClientBase
         queryParameters.addIfNotNull("revision", revision); //$NON-NLS-1$
         queryParameters.addIfNotNull("propertyFilters", propertyFilters); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, BuildDefinition.class);
     }
@@ -1986,12 +1981,12 @@ public abstract class BuildHttpClientBase
         queryParameters.addIfNotNull("revision", revision); //$NON-NLS-1$
         queryParameters.addIfNotNull("propertyFilters", propertyFilters); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, BuildDefinition.class);
     }
@@ -2058,12 +2053,12 @@ public abstract class BuildHttpClientBase
         queryParameters.addIfNotNull("builtAfter", builtAfter); //$NON-NLS-1$
         queryParameters.addIfNotNull("notBuiltAfter", notBuiltAfter); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<BuildDefinitionReference>>() {});
     }
@@ -2130,12 +2125,12 @@ public abstract class BuildHttpClientBase
         queryParameters.addIfNotNull("builtAfter", builtAfter); //$NON-NLS-1$
         queryParameters.addIfNotNull("notBuiltAfter", notBuiltAfter); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<BuildDefinitionReference>>() {});
     }
@@ -2196,11 +2191,11 @@ public abstract class BuildHttpClientBase
         queryParameters.addIfNotNull("builtAfter", builtAfter); //$NON-NLS-1$
         queryParameters.addIfNotNull("notBuiltAfter", notBuiltAfter); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<BuildDefinitionReference>>() {});
     }
@@ -2234,14 +2229,14 @@ public abstract class BuildHttpClientBase
         queryParameters.addIfNotNull("secretsSourceDefinitionId", secretsSourceDefinitionId); //$NON-NLS-1$
         queryParameters.addIfNotNull("secretsSourceDefinitionRevision", secretsSourceDefinitionRevision); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.PUT,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       definition,
-                                                       APPLICATION_JSON_TYPE,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.PUT,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               definition,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, BuildDefinition.class);
     }
@@ -2279,14 +2274,14 @@ public abstract class BuildHttpClientBase
         queryParameters.addIfNotNull("secretsSourceDefinitionId", secretsSourceDefinitionId); //$NON-NLS-1$
         queryParameters.addIfNotNull("secretsSourceDefinitionRevision", secretsSourceDefinitionRevision); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.PUT,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       definition,
-                                                       APPLICATION_JSON_TYPE,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.PUT,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               definition,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, BuildDefinition.class);
     }
@@ -2324,14 +2319,14 @@ public abstract class BuildHttpClientBase
         queryParameters.addIfNotNull("secretsSourceDefinitionId", secretsSourceDefinitionId); //$NON-NLS-1$
         queryParameters.addIfNotNull("secretsSourceDefinitionRevision", secretsSourceDefinitionRevision); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.PUT,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       definition,
-                                                       APPLICATION_JSON_TYPE,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.PUT,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               definition,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, BuildDefinition.class);
     }
@@ -2359,13 +2354,13 @@ public abstract class BuildHttpClientBase
         routeValues.put("project", project); //$NON-NLS-1$
         routeValues.put("path", path); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.PUT,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       folder,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.PUT,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               folder,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, Folder.class);
     }
@@ -2393,13 +2388,13 @@ public abstract class BuildHttpClientBase
         routeValues.put("project", project); //$NON-NLS-1$
         routeValues.put("path", path); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.PUT,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       folder,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.PUT,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               folder,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, Folder.class);
     }
@@ -2423,11 +2418,11 @@ public abstract class BuildHttpClientBase
         routeValues.put("project", project); //$NON-NLS-1$
         routeValues.put("path", path); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.DELETE,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.DELETE,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         super.sendRequest(httpRequest);
     }
@@ -2451,11 +2446,11 @@ public abstract class BuildHttpClientBase
         routeValues.put("project", project); //$NON-NLS-1$
         routeValues.put("path", path); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.DELETE,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.DELETE,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         super.sendRequest(httpRequest);
     }
@@ -2486,12 +2481,12 @@ public abstract class BuildHttpClientBase
         final NameValueCollection queryParameters = new NameValueCollection();
         queryParameters.addIfNotNull("queryOrder", queryOrder); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<Folder>>() {});
     }
@@ -2522,12 +2517,12 @@ public abstract class BuildHttpClientBase
         final NameValueCollection queryParameters = new NameValueCollection();
         queryParameters.addIfNotNull("queryOrder", queryOrder); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<Folder>>() {});
     }
@@ -2555,13 +2550,13 @@ public abstract class BuildHttpClientBase
         routeValues.put("project", project); //$NON-NLS-1$
         routeValues.put("path", path); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.POST,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       folder,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.POST,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               folder,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, Folder.class);
     }
@@ -2589,13 +2584,13 @@ public abstract class BuildHttpClientBase
         routeValues.put("project", project); //$NON-NLS-1$
         routeValues.put("path", path); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.POST,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       folder,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.POST,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               folder,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, Folder.class);
     }
@@ -2634,12 +2629,12 @@ public abstract class BuildHttpClientBase
         queryParameters.addIfNotNull("startLine", startLine); //$NON-NLS-1$
         queryParameters.addIfNotNull("endLine", endLine); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       TEXT_PLAIN_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.TEXT_PLAIN_TYPE);
 
         return super.sendRequest(httpRequest, InputStream.class);
     }
@@ -2678,12 +2673,12 @@ public abstract class BuildHttpClientBase
         queryParameters.addIfNotNull("startLine", startLine); //$NON-NLS-1$
         queryParameters.addIfNotNull("endLine", endLine); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       TEXT_PLAIN_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.TEXT_PLAIN_TYPE);
 
         return super.sendRequest(httpRequest, InputStream.class);
     }
@@ -2722,12 +2717,12 @@ public abstract class BuildHttpClientBase
         queryParameters.addIfNotNull("startLine", startLine); //$NON-NLS-1$
         queryParameters.addIfNotNull("endLine", endLine); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<String>>() {});
     }
@@ -2766,12 +2761,12 @@ public abstract class BuildHttpClientBase
         queryParameters.addIfNotNull("startLine", startLine); //$NON-NLS-1$
         queryParameters.addIfNotNull("endLine", endLine); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<String>>() {});
     }
@@ -2796,11 +2791,11 @@ public abstract class BuildHttpClientBase
         routeValues.put("project", project); //$NON-NLS-1$
         routeValues.put("buildId", buildId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<BuildLog>>() {});
     }
@@ -2825,11 +2820,11 @@ public abstract class BuildHttpClientBase
         routeValues.put("project", project); //$NON-NLS-1$
         routeValues.put("buildId", buildId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<BuildLog>>() {});
     }
@@ -2854,11 +2849,11 @@ public abstract class BuildHttpClientBase
         routeValues.put("project", project); //$NON-NLS-1$
         routeValues.put("buildId", buildId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_ZIP_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_ZIP_TYPE);
 
         return super.sendRequest(httpRequest, InputStream.class);
     }
@@ -2883,11 +2878,11 @@ public abstract class BuildHttpClientBase
         routeValues.put("project", project); //$NON-NLS-1$
         routeValues.put("buildId", buildId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_ZIP_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_ZIP_TYPE);
 
         return super.sendRequest(httpRequest, InputStream.class);
     }
@@ -2918,12 +2913,12 @@ public abstract class BuildHttpClientBase
         final NameValueCollection queryParameters = new NameValueCollection();
         queryParameters.addIfNotNull("minMetricsTime", minMetricsTime); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<BuildMetric>>() {});
     }
@@ -2954,12 +2949,12 @@ public abstract class BuildHttpClientBase
         final NameValueCollection queryParameters = new NameValueCollection();
         queryParameters.addIfNotNull("minMetricsTime", minMetricsTime); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<BuildMetric>>() {});
     }
@@ -2974,10 +2969,10 @@ public abstract class BuildHttpClientBase
         final UUID locationId = UUID.fromString("591cb5a4-2d46-4f3a-a697-5cd42b6bd332"); //$NON-NLS-1$
         final ApiResourceVersion apiVersion = new ApiResourceVersion("3.0-preview.2"); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<BuildOptionDefinition>>() {});
     }
@@ -2997,11 +2992,11 @@ public abstract class BuildHttpClientBase
         final Map<String, Object> routeValues = new HashMap<String, Object>();
         routeValues.put("project", project); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<BuildOptionDefinition>>() {});
     }
@@ -3021,11 +3016,11 @@ public abstract class BuildHttpClientBase
         final Map<String, Object> routeValues = new HashMap<String, Object>();
         routeValues.put("project", project); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<BuildOptionDefinition>>() {});
     }
@@ -3056,12 +3051,12 @@ public abstract class BuildHttpClientBase
         final NameValueCollection queryParameters = new NameValueCollection();
         queryParameters.addIfNotEmpty("type", type); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, BuildReportMetadata.class);
     }
@@ -3092,12 +3087,12 @@ public abstract class BuildHttpClientBase
         final NameValueCollection queryParameters = new NameValueCollection();
         queryParameters.addIfNotEmpty("type", type); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, BuildReportMetadata.class);
     }
@@ -3128,12 +3123,12 @@ public abstract class BuildHttpClientBase
         final NameValueCollection queryParameters = new NameValueCollection();
         queryParameters.addIfNotEmpty("type", type); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       TEXT_HTML_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.TEXT_HTML_TYPE);
 
         return super.sendRequest(httpRequest, InputStream.class);
     }
@@ -3164,12 +3159,12 @@ public abstract class BuildHttpClientBase
         final NameValueCollection queryParameters = new NameValueCollection();
         queryParameters.addIfNotEmpty("type", type); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       TEXT_HTML_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.TEXT_HTML_TYPE);
 
         return super.sendRequest(httpRequest, InputStream.class);
     }
@@ -3184,10 +3179,10 @@ public abstract class BuildHttpClientBase
         final UUID locationId = UUID.fromString("3813d06c-9e36-4ea1-aac3-61a485d60e3d"); //$NON-NLS-1$
         final ApiResourceVersion apiVersion = new ApiResourceVersion("3.0-preview.2"); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, BuildResourceUsage.class);
     }
@@ -3212,11 +3207,11 @@ public abstract class BuildHttpClientBase
         routeValues.put("project", project); //$NON-NLS-1$
         routeValues.put("definitionId", definitionId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<BuildDefinitionRevision>>() {});
     }
@@ -3241,11 +3236,11 @@ public abstract class BuildHttpClientBase
         routeValues.put("project", project); //$NON-NLS-1$
         routeValues.put("definitionId", definitionId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<BuildDefinitionRevision>>() {});
     }
@@ -3260,10 +3255,10 @@ public abstract class BuildHttpClientBase
         final UUID locationId = UUID.fromString("aa8c1c9c-ef8b-474a-b8c4-785c7b191d0d"); //$NON-NLS-1$
         final ApiResourceVersion apiVersion = new ApiResourceVersion("3.0-preview.1"); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, BuildSettings.class);
     }
@@ -3280,12 +3275,12 @@ public abstract class BuildHttpClientBase
         final UUID locationId = UUID.fromString("aa8c1c9c-ef8b-474a-b8c4-785c7b191d0d"); //$NON-NLS-1$
         final ApiResourceVersion apiVersion = new ApiResourceVersion("3.0-preview.1"); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.PATCH,
-                                                       locationId,
-                                                       apiVersion,
-                                                       settings,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.PATCH,
+                                                               locationId,
+                                                               apiVersion,
+                                                               settings,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, BuildSettings.class);
     }
@@ -3314,11 +3309,11 @@ public abstract class BuildHttpClientBase
         routeValues.put("buildId", buildId); //$NON-NLS-1$
         routeValues.put("tag", tag); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.PUT,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.PUT,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<String>>() {});
     }
@@ -3347,11 +3342,11 @@ public abstract class BuildHttpClientBase
         routeValues.put("buildId", buildId); //$NON-NLS-1$
         routeValues.put("tag", tag); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.PUT,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.PUT,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<String>>() {});
     }
@@ -3379,13 +3374,13 @@ public abstract class BuildHttpClientBase
         routeValues.put("project", project); //$NON-NLS-1$
         routeValues.put("buildId", buildId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.POST,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       tags,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.POST,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               tags,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<String>>() {});
     }
@@ -3413,13 +3408,13 @@ public abstract class BuildHttpClientBase
         routeValues.put("project", project); //$NON-NLS-1$
         routeValues.put("buildId", buildId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.POST,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       tags,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.POST,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               tags,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<String>>() {});
     }
@@ -3448,11 +3443,11 @@ public abstract class BuildHttpClientBase
         routeValues.put("buildId", buildId); //$NON-NLS-1$
         routeValues.put("tag", tag); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.DELETE,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.DELETE,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<String>>() {});
     }
@@ -3481,11 +3476,11 @@ public abstract class BuildHttpClientBase
         routeValues.put("buildId", buildId); //$NON-NLS-1$
         routeValues.put("tag", tag); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.DELETE,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.DELETE,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<String>>() {});
     }
@@ -3510,11 +3505,11 @@ public abstract class BuildHttpClientBase
         routeValues.put("project", project); //$NON-NLS-1$
         routeValues.put("buildId", buildId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<String>>() {});
     }
@@ -3539,11 +3534,11 @@ public abstract class BuildHttpClientBase
         routeValues.put("project", project); //$NON-NLS-1$
         routeValues.put("buildId", buildId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<String>>() {});
     }
@@ -3563,11 +3558,11 @@ public abstract class BuildHttpClientBase
         final Map<String, Object> routeValues = new HashMap<String, Object>();
         routeValues.put("project", project); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<String>>() {});
     }
@@ -3587,11 +3582,11 @@ public abstract class BuildHttpClientBase
         final Map<String, Object> routeValues = new HashMap<String, Object>();
         routeValues.put("project", project); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<String>>() {});
     }
@@ -3615,11 +3610,11 @@ public abstract class BuildHttpClientBase
         routeValues.put("project", project); //$NON-NLS-1$
         routeValues.put("templateId", templateId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.DELETE,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.DELETE,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         super.sendRequest(httpRequest);
     }
@@ -3643,11 +3638,11 @@ public abstract class BuildHttpClientBase
         routeValues.put("project", project); //$NON-NLS-1$
         routeValues.put("templateId", templateId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.DELETE,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.DELETE,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         super.sendRequest(httpRequest);
     }
@@ -3672,11 +3667,11 @@ public abstract class BuildHttpClientBase
         routeValues.put("project", project); //$NON-NLS-1$
         routeValues.put("templateId", templateId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, BuildDefinitionTemplate.class);
     }
@@ -3701,11 +3696,11 @@ public abstract class BuildHttpClientBase
         routeValues.put("project", project); //$NON-NLS-1$
         routeValues.put("templateId", templateId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, BuildDefinitionTemplate.class);
     }
@@ -3725,11 +3720,11 @@ public abstract class BuildHttpClientBase
         final Map<String, Object> routeValues = new HashMap<String, Object>();
         routeValues.put("project", project); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<BuildDefinitionTemplate>>() {});
     }
@@ -3749,11 +3744,11 @@ public abstract class BuildHttpClientBase
         final Map<String, Object> routeValues = new HashMap<String, Object>();
         routeValues.put("project", project); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<BuildDefinitionTemplate>>() {});
     }
@@ -3781,13 +3776,13 @@ public abstract class BuildHttpClientBase
         routeValues.put("project", project); //$NON-NLS-1$
         routeValues.put("templateId", templateId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.PUT,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       template,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.PUT,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               template,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, BuildDefinitionTemplate.class);
     }
@@ -3815,13 +3810,13 @@ public abstract class BuildHttpClientBase
         routeValues.put("project", project); //$NON-NLS-1$
         routeValues.put("templateId", templateId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.PUT,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       template,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.PUT,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               template,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, BuildDefinitionTemplate.class);
     }
@@ -3860,12 +3855,12 @@ public abstract class BuildHttpClientBase
         queryParameters.addIfNotNull("changeId", changeId); //$NON-NLS-1$
         queryParameters.addIfNotNull("planId", planId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, Timeline.class);
     }
@@ -3904,12 +3899,12 @@ public abstract class BuildHttpClientBase
         queryParameters.addIfNotNull("changeId", changeId); //$NON-NLS-1$
         queryParameters.addIfNotNull("planId", planId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, Timeline.class);
     }
@@ -3940,12 +3935,12 @@ public abstract class BuildHttpClientBase
         final NameValueCollection queryParameters = new NameValueCollection();
         queryParameters.addIfNotNull("$top", top); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<ResourceRef>>() {});
     }
@@ -3976,12 +3971,12 @@ public abstract class BuildHttpClientBase
         final NameValueCollection queryParameters = new NameValueCollection();
         queryParameters.addIfNotNull("$top", top); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<ResourceRef>>() {});
     }
@@ -4015,14 +4010,14 @@ public abstract class BuildHttpClientBase
         final NameValueCollection queryParameters = new NameValueCollection();
         queryParameters.addIfNotNull("$top", top); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.POST,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       commitIds,
-                                                       APPLICATION_JSON_TYPE,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.POST,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               commitIds,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<ResourceRef>>() {});
     }
@@ -4056,14 +4051,14 @@ public abstract class BuildHttpClientBase
         final NameValueCollection queryParameters = new NameValueCollection();
         queryParameters.addIfNotNull("$top", top); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.POST,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       commitIds,
-                                                       APPLICATION_JSON_TYPE,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.POST,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               commitIds,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<ResourceRef>>() {});
     }
@@ -4098,12 +4093,12 @@ public abstract class BuildHttpClientBase
         queryParameters.put("toBuildId", String.valueOf(toBuildId)); //$NON-NLS-1$
         queryParameters.addIfNotNull("$top", top); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<ResourceRef>>() {});
     }
@@ -4138,12 +4133,12 @@ public abstract class BuildHttpClientBase
         queryParameters.put("toBuildId", String.valueOf(toBuildId)); //$NON-NLS-1$
         queryParameters.addIfNotNull("$top", top); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<ResourceRef>>() {});
     }

--- a/Rest/alm-tfs-client/src/main/generated/com/microsoft/alm/teamfoundation/build/webapi/events/SyncBuildCompletedEvent.java
+++ b/Rest/alm-tfs-client/src/main/generated/com/microsoft/alm/teamfoundation/build/webapi/events/SyncBuildCompletedEvent.java
@@ -1,0 +1,24 @@
+// @formatter:off
+/*
+* ---------------------------------------------------------
+* Copyright(C) Microsoft Corporation. All rights reserved.
+* Licensed under the MIT license. See License.txt in the project root.
+* ---------------------------------------------------------
+*
+* ---------------------------------------------------------
+* Generated file, DO NOT EDIT
+* ---------------------------------------------------------
+*
+* See following wiki page for instructions on how to regenerate:
+*   https://vsowiki.com/index.php?title=Rest_Client_Generation
+*/
+
+package com.microsoft.alm.teamfoundation.build.webapi.events;
+
+
+/** 
+ */
+public class SyncBuildCompletedEvent
+    extends BuildUpdatedEvent {
+
+}

--- a/Rest/alm-tfs-client/src/main/generated/com/microsoft/alm/teamfoundation/build/webapi/events/SyncBuildStartedEvent.java
+++ b/Rest/alm-tfs-client/src/main/generated/com/microsoft/alm/teamfoundation/build/webapi/events/SyncBuildStartedEvent.java
@@ -1,0 +1,24 @@
+// @formatter:off
+/*
+* ---------------------------------------------------------
+* Copyright(C) Microsoft Corporation. All rights reserved.
+* Licensed under the MIT license. See License.txt in the project root.
+* ---------------------------------------------------------
+*
+* ---------------------------------------------------------
+* Generated file, DO NOT EDIT
+* ---------------------------------------------------------
+*
+* See following wiki page for instructions on how to regenerate:
+*   https://vsowiki.com/index.php?title=Rest_Client_Generation
+*/
+
+package com.microsoft.alm.teamfoundation.build.webapi.events;
+
+
+/** 
+ */
+public class SyncBuildStartedEvent
+    extends BuildUpdatedEvent {
+
+}

--- a/Rest/alm-tfs-client/src/main/generated/com/microsoft/alm/teamfoundation/chat/webapi/ChatHttpClientBase.java
+++ b/Rest/alm-tfs-client/src/main/generated/com/microsoft/alm/teamfoundation/chat/webapi/ChatHttpClientBase.java
@@ -22,8 +22,12 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import com.fasterxml.jackson.core.type.TypeReference;
+import com.microsoft.alm.client.HttpMethod;
 import com.microsoft.alm.client.model.NameValueCollection;
 import com.microsoft.alm.client.VssHttpClientBase;
+import com.microsoft.alm.client.VssMediaTypes;
+import com.microsoft.alm.client.VssRestClientHandler;
+import com.microsoft.alm.client.VssRestRequest;
 import com.microsoft.alm.teamfoundation.chat.webapi.Message;
 import com.microsoft.alm.teamfoundation.chat.webapi.MessageData;
 import com.microsoft.alm.teamfoundation.chat.webapi.Room;
@@ -45,22 +49,13 @@ public abstract class ChatHttpClientBase
     * Create a new instance of ChatHttpClientBase
     *
     * @param jaxrsClient
-    *            an initialized instance of a JAX-RS Client implementation
+    *            a DefaultRestClientHandler initialized with an instance of a JAX-RS Client implementation or
+    *            a TEERestClientHamdler initialized with TEE HTTP client implementation
     * @param baseUrl
-    *            a TFS project collection URL
+    *            a TFS services URL
     */
-    protected ChatHttpClientBase(final Object jaxrsClient, final URI baseUrl) {
-        super(jaxrsClient, baseUrl);
-    }
-
-    /**
-    * Create a new instance of ChatHttpClientBase
-    *
-    * @param tfsConnection
-    *            an initialized instance of a TfsTeamProjectCollection
-    */
-    protected ChatHttpClientBase(final Object tfsConnection) {
-        super(tfsConnection);
+    protected ChatHttpClientBase(final VssRestClientHandler clientHandler, final URI baseUrl) {
+        super(clientHandler, baseUrl);
     }
 
     @Override
@@ -87,11 +82,11 @@ public abstract class ChatHttpClientBase
         routeValues.put("roomId", roomId); //$NON-NLS-1$
         routeValues.put("messageId", messageId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.DELETE,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.DELETE,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         super.sendRequest(httpRequest);
     }
@@ -111,11 +106,11 @@ public abstract class ChatHttpClientBase
         final Map<String, Object> routeValues = new HashMap<String, Object>();
         routeValues.put("roomId", roomId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<Message>>() {});
     }
@@ -140,11 +135,11 @@ public abstract class ChatHttpClientBase
         routeValues.put("roomId", roomId); //$NON-NLS-1$
         routeValues.put("messageId", messageId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, Message.class);
     }
@@ -168,13 +163,13 @@ public abstract class ChatHttpClientBase
         final Map<String, Object> routeValues = new HashMap<String, Object>();
         routeValues.put("roomId", roomId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.POST,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       messageUpdate,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.POST,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               messageUpdate,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, Message.class);
     }
@@ -202,13 +197,13 @@ public abstract class ChatHttpClientBase
         routeValues.put("roomId", roomId); //$NON-NLS-1$
         routeValues.put("messageId", messageId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.PATCH,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       messageUpdate,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.PATCH,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               messageUpdate,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, Message.class);
     }
@@ -225,12 +220,12 @@ public abstract class ChatHttpClientBase
         final UUID locationId = UUID.fromString("3d0e7ee0-a6c9-497e-9a2c-23b687e860e2"); //$NON-NLS-1$
         final ApiResourceVersion apiVersion = new ApiResourceVersion("3.0-preview.1"); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.POST,
-                                                       locationId,
-                                                       apiVersion,
-                                                       roomUpdate,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.POST,
+                                                               locationId,
+                                                               apiVersion,
+                                                               roomUpdate,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, Room.class);
     }
@@ -249,11 +244,11 @@ public abstract class ChatHttpClientBase
         final Map<String, Object> routeValues = new HashMap<String, Object>();
         routeValues.put("roomId", roomId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.DELETE,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.DELETE,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         super.sendRequest(httpRequest);
     }
@@ -268,10 +263,10 @@ public abstract class ChatHttpClientBase
         final UUID locationId = UUID.fromString("3d0e7ee0-a6c9-497e-9a2c-23b687e860e2"); //$NON-NLS-1$
         final ApiResourceVersion apiVersion = new ApiResourceVersion("3.0-preview.1"); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<Room>>() {});
     }
@@ -291,11 +286,11 @@ public abstract class ChatHttpClientBase
         final Map<String, Object> routeValues = new HashMap<String, Object>();
         routeValues.put("roomId", roomId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, Room.class);
     }
@@ -319,13 +314,13 @@ public abstract class ChatHttpClientBase
         final Map<String, Object> routeValues = new HashMap<String, Object>();
         routeValues.put("roomId", roomId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.PATCH,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       roomUpdate,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.PATCH,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               roomUpdate,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, Room.class);
     }
@@ -345,11 +340,11 @@ public abstract class ChatHttpClientBase
         final Map<String, Object> routeValues = new HashMap<String, Object>();
         routeValues.put("roomId", roomId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<User>>() {});
     }
@@ -374,11 +369,11 @@ public abstract class ChatHttpClientBase
         routeValues.put("roomId", roomId); //$NON-NLS-1$
         routeValues.put("userId", userId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, User.class);
     }
@@ -405,13 +400,13 @@ public abstract class ChatHttpClientBase
         routeValues.put("roomId", roomId); //$NON-NLS-1$
         routeValues.put("userId", userId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.PUT,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       userUpdate,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.PUT,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               userUpdate,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         super.sendRequest(httpRequest);
     }
@@ -435,11 +430,11 @@ public abstract class ChatHttpClientBase
         routeValues.put("roomId", roomId); //$NON-NLS-1$
         routeValues.put("userId", userId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.DELETE,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.DELETE,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         super.sendRequest(httpRequest);
     }

--- a/Rest/alm-tfs-client/src/main/generated/com/microsoft/alm/teamfoundation/core/webapi/CoreHttpClientBase.java
+++ b/Rest/alm-tfs-client/src/main/generated/com/microsoft/alm/teamfoundation/core/webapi/CoreHttpClientBase.java
@@ -22,8 +22,12 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import com.fasterxml.jackson.core.type.TypeReference;
+import com.microsoft.alm.client.HttpMethod;
 import com.microsoft.alm.client.model.NameValueCollection;
 import com.microsoft.alm.client.VssHttpClientBase;
+import com.microsoft.alm.client.VssMediaTypes;
+import com.microsoft.alm.client.VssRestClientHandler;
+import com.microsoft.alm.client.VssRestRequest;
 import com.microsoft.alm.teamfoundation.core.webapi.ConnectedServiceKind;
 import com.microsoft.alm.teamfoundation.core.webapi.IdentityData;
 import com.microsoft.alm.teamfoundation.core.webapi.Process;
@@ -53,22 +57,13 @@ public abstract class CoreHttpClientBase
     * Create a new instance of CoreHttpClientBase
     *
     * @param jaxrsClient
-    *            an initialized instance of a JAX-RS Client implementation
+    *            a DefaultRestClientHandler initialized with an instance of a JAX-RS Client implementation or
+    *            a TEERestClientHamdler initialized with TEE HTTP client implementation
     * @param baseUrl
-    *            a TFS project collection URL
+    *            a TFS services URL
     */
-    protected CoreHttpClientBase(final Object jaxrsClient, final URI baseUrl) {
-        super(jaxrsClient, baseUrl);
-    }
-
-    /**
-    * Create a new instance of CoreHttpClientBase
-    *
-    * @param tfsConnection
-    *            an initialized instance of a TfsTeamProjectCollection
-    */
-    protected CoreHttpClientBase(final Object tfsConnection) {
-        super(tfsConnection);
+    protected CoreHttpClientBase(final VssRestClientHandler clientHandler, final URI baseUrl) {
+        super(clientHandler, baseUrl);
     }
 
     @Override
@@ -95,13 +90,13 @@ public abstract class CoreHttpClientBase
         final Map<String, Object> routeValues = new HashMap<String, Object>();
         routeValues.put("projectId", projectId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.POST,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       connectedServiceCreationData,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.POST,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               connectedServiceCreationData,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, WebApiConnectedService.class);
     }
@@ -126,11 +121,11 @@ public abstract class CoreHttpClientBase
         routeValues.put("projectId", projectId); //$NON-NLS-1$
         routeValues.put("name", name); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, WebApiConnectedServiceDetails.class);
     }
@@ -157,12 +152,12 @@ public abstract class CoreHttpClientBase
         final NameValueCollection queryParameters = new NameValueCollection();
         queryParameters.addIfNotNull("kind", kind); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<WebApiConnectedService>>() {});
     }
@@ -185,13 +180,13 @@ public abstract class CoreHttpClientBase
         final Map<String, Object> routeValues = new HashMap<String, Object>();
         routeValues.put("mruName", mruName); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.POST,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       mruData,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.POST,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               mruData,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         super.sendRequest(httpRequest);
     }
@@ -214,11 +209,11 @@ public abstract class CoreHttpClientBase
         final Map<String, Object> routeValues = new HashMap<String, Object>();
         routeValues.put("mruName", mruName); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.DELETE,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.DELETE,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         super.sendRequest(httpRequest);
     }
@@ -238,11 +233,11 @@ public abstract class CoreHttpClientBase
         final Map<String, Object> routeValues = new HashMap<String, Object>();
         routeValues.put("mruName", mruName); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<IdentityRef>>() {});
     }
@@ -265,13 +260,13 @@ public abstract class CoreHttpClientBase
         final Map<String, Object> routeValues = new HashMap<String, Object>();
         routeValues.put("mruName", mruName); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.PATCH,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       mruData,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.PATCH,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               mruData,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         super.sendRequest(httpRequest);
     }
@@ -306,12 +301,12 @@ public abstract class CoreHttpClientBase
         queryParameters.addIfNotNull("$top", top); //$NON-NLS-1$
         queryParameters.addIfNotNull("$skip", skip); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<IdentityRef>>() {});
     }
@@ -331,11 +326,11 @@ public abstract class CoreHttpClientBase
         final Map<String, Object> routeValues = new HashMap<String, Object>();
         routeValues.put("processId", processId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, Process.class);
     }
@@ -350,10 +345,10 @@ public abstract class CoreHttpClientBase
         final UUID locationId = UUID.fromString("93878975-88c5-4e6a-8abb-7ddd77a8a7d8"); //$NON-NLS-1$
         final ApiResourceVersion apiVersion = new ApiResourceVersion("3.0-preview.1"); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<Process>>() {});
     }
@@ -373,11 +368,11 @@ public abstract class CoreHttpClientBase
         final Map<String, Object> routeValues = new HashMap<String, Object>();
         routeValues.put("collectionId", collectionId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, TeamProjectCollection.class);
     }
@@ -402,11 +397,11 @@ public abstract class CoreHttpClientBase
         queryParameters.addIfNotNull("$top", top); //$NON-NLS-1$
         queryParameters.addIfNotNull("$skip", skip); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<TeamProjectCollectionReference>>() {});
     }
@@ -426,11 +421,11 @@ public abstract class CoreHttpClientBase
         final NameValueCollection queryParameters = new NameValueCollection();
         queryParameters.addIfNotNull("minRevision", minRevision); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<TeamProjectReference>>() {});
     }
@@ -461,12 +456,12 @@ public abstract class CoreHttpClientBase
         queryParameters.addIfNotNull("includeCapabilities", includeCapabilities); //$NON-NLS-1$
         queryParameters.addIfNotNull("includeHistory", includeHistory); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, TeamProject.class);
     }
@@ -495,11 +490,11 @@ public abstract class CoreHttpClientBase
         queryParameters.addIfNotNull("$top", top); //$NON-NLS-1$
         queryParameters.addIfNotNull("$skip", skip); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<TeamProjectReference>>() {});
     }
@@ -516,12 +511,12 @@ public abstract class CoreHttpClientBase
         final UUID locationId = UUID.fromString("603fe2ac-9723-48b9-88ad-09305aa6c6e1"); //$NON-NLS-1$
         final ApiResourceVersion apiVersion = new ApiResourceVersion("3.0-preview.3"); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.POST,
-                                                       locationId,
-                                                       apiVersion,
-                                                       projectToCreate,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.POST,
+                                                               locationId,
+                                                               apiVersion,
+                                                               projectToCreate,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, OperationReference.class);
     }
@@ -541,11 +536,11 @@ public abstract class CoreHttpClientBase
         final Map<String, Object> routeValues = new HashMap<String, Object>();
         routeValues.put("projectId", projectId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.DELETE,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.DELETE,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, OperationReference.class);
     }
@@ -569,13 +564,13 @@ public abstract class CoreHttpClientBase
         final Map<String, Object> routeValues = new HashMap<String, Object>();
         routeValues.put("projectId", projectId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.PATCH,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       projectUpdate,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.PATCH,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               projectUpdate,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, OperationReference.class);
     }
@@ -595,11 +590,11 @@ public abstract class CoreHttpClientBase
         final NameValueCollection queryParameters = new NameValueCollection();
         queryParameters.addIfNotEmpty("proxyUrl", proxyUrl); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<Proxy>>() {});
     }
@@ -623,13 +618,13 @@ public abstract class CoreHttpClientBase
         final Map<String, Object> routeValues = new HashMap<String, Object>();
         routeValues.put("projectId", projectId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.POST,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       team,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.POST,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               team,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, WebApiTeam.class);
     }
@@ -653,11 +648,11 @@ public abstract class CoreHttpClientBase
         routeValues.put("projectId", projectId); //$NON-NLS-1$
         routeValues.put("teamId", teamId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.DELETE,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.DELETE,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         super.sendRequest(httpRequest);
     }
@@ -682,11 +677,11 @@ public abstract class CoreHttpClientBase
         routeValues.put("projectId", projectId); //$NON-NLS-1$
         routeValues.put("teamId", teamId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, WebApiTeam.class);
     }
@@ -717,12 +712,12 @@ public abstract class CoreHttpClientBase
         queryParameters.addIfNotNull("$top", top); //$NON-NLS-1$
         queryParameters.addIfNotNull("$skip", skip); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<WebApiTeam>>() {});
     }
@@ -750,13 +745,13 @@ public abstract class CoreHttpClientBase
         routeValues.put("projectId", projectId); //$NON-NLS-1$
         routeValues.put("teamId", teamId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.PATCH,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       teamData,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.PATCH,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               teamData,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, WebApiTeam.class);
     }

--- a/Rest/alm-tfs-client/src/main/generated/com/microsoft/alm/teamfoundation/policy/webapi/PolicyHttpClientBase.java
+++ b/Rest/alm-tfs-client/src/main/generated/com/microsoft/alm/teamfoundation/policy/webapi/PolicyHttpClientBase.java
@@ -22,8 +22,12 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import com.fasterxml.jackson.core.type.TypeReference;
+import com.microsoft.alm.client.HttpMethod;
 import com.microsoft.alm.client.model.NameValueCollection;
 import com.microsoft.alm.client.VssHttpClientBase;
+import com.microsoft.alm.client.VssMediaTypes;
+import com.microsoft.alm.client.VssRestClientHandler;
+import com.microsoft.alm.client.VssRestRequest;
 import com.microsoft.alm.teamfoundation.policy.webapi.PolicyConfiguration;
 import com.microsoft.alm.teamfoundation.policy.webapi.PolicyEvaluationRecord;
 import com.microsoft.alm.teamfoundation.policy.webapi.PolicyType;
@@ -42,22 +46,13 @@ public abstract class PolicyHttpClientBase
     * Create a new instance of PolicyHttpClientBase
     *
     * @param jaxrsClient
-    *            an initialized instance of a JAX-RS Client implementation
+    *            a DefaultRestClientHandler initialized with an instance of a JAX-RS Client implementation or
+    *            a TEERestClientHamdler initialized with TEE HTTP client implementation
     * @param baseUrl
-    *            a TFS project collection URL
+    *            a TFS services URL
     */
-    protected PolicyHttpClientBase(final Object jaxrsClient, final URI baseUrl) {
-        super(jaxrsClient, baseUrl);
-    }
-
-    /**
-    * Create a new instance of PolicyHttpClientBase
-    *
-    * @param tfsConnection
-    *            an initialized instance of a TfsTeamProjectCollection
-    */
-    protected PolicyHttpClientBase(final Object tfsConnection) {
-        super(tfsConnection);
+    protected PolicyHttpClientBase(final VssRestClientHandler clientHandler, final URI baseUrl) {
+        super(clientHandler, baseUrl);
     }
 
     @Override
@@ -88,13 +83,13 @@ public abstract class PolicyHttpClientBase
         routeValues.put("project", project); //$NON-NLS-1$
         routeValues.put("configurationId", configurationId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.POST,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       configuration,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.POST,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               configuration,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, PolicyConfiguration.class);
     }
@@ -122,13 +117,13 @@ public abstract class PolicyHttpClientBase
         routeValues.put("project", project); //$NON-NLS-1$
         routeValues.put("configurationId", configurationId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.POST,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       configuration,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.POST,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               configuration,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, PolicyConfiguration.class);
     }
@@ -152,11 +147,11 @@ public abstract class PolicyHttpClientBase
         routeValues.put("project", project); //$NON-NLS-1$
         routeValues.put("configurationId", configurationId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.DELETE,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.DELETE,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         super.sendRequest(httpRequest);
     }
@@ -180,11 +175,11 @@ public abstract class PolicyHttpClientBase
         routeValues.put("project", project); //$NON-NLS-1$
         routeValues.put("configurationId", configurationId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.DELETE,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.DELETE,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         super.sendRequest(httpRequest);
     }
@@ -209,11 +204,11 @@ public abstract class PolicyHttpClientBase
         routeValues.put("project", project); //$NON-NLS-1$
         routeValues.put("configurationId", configurationId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, PolicyConfiguration.class);
     }
@@ -238,11 +233,11 @@ public abstract class PolicyHttpClientBase
         routeValues.put("project", project); //$NON-NLS-1$
         routeValues.put("configurationId", configurationId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, PolicyConfiguration.class);
     }
@@ -262,11 +257,11 @@ public abstract class PolicyHttpClientBase
         final Map<String, Object> routeValues = new HashMap<String, Object>();
         routeValues.put("project", project); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<PolicyConfiguration>>() {});
     }
@@ -286,11 +281,11 @@ public abstract class PolicyHttpClientBase
         final Map<String, Object> routeValues = new HashMap<String, Object>();
         routeValues.put("project", project); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<PolicyConfiguration>>() {});
     }
@@ -318,13 +313,13 @@ public abstract class PolicyHttpClientBase
         routeValues.put("project", project); //$NON-NLS-1$
         routeValues.put("configurationId", configurationId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.PUT,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       configuration,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.PUT,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               configuration,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, PolicyConfiguration.class);
     }
@@ -352,13 +347,13 @@ public abstract class PolicyHttpClientBase
         routeValues.put("project", project); //$NON-NLS-1$
         routeValues.put("configurationId", configurationId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.PUT,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       configuration,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.PUT,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               configuration,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, PolicyConfiguration.class);
     }
@@ -383,11 +378,11 @@ public abstract class PolicyHttpClientBase
         routeValues.put("project", project); //$NON-NLS-1$
         routeValues.put("evaluationId", evaluationId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, PolicyEvaluationRecord.class);
     }
@@ -412,11 +407,11 @@ public abstract class PolicyHttpClientBase
         routeValues.put("project", project); //$NON-NLS-1$
         routeValues.put("evaluationId", evaluationId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, PolicyEvaluationRecord.class);
     }
@@ -441,11 +436,11 @@ public abstract class PolicyHttpClientBase
         routeValues.put("project", project); //$NON-NLS-1$
         routeValues.put("evaluationId", evaluationId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.PATCH,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.PATCH,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, PolicyEvaluationRecord.class);
     }
@@ -470,11 +465,11 @@ public abstract class PolicyHttpClientBase
         routeValues.put("project", project); //$NON-NLS-1$
         routeValues.put("evaluationId", evaluationId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.PATCH,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.PATCH,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, PolicyEvaluationRecord.class);
     }
@@ -513,12 +508,12 @@ public abstract class PolicyHttpClientBase
         queryParameters.addIfNotNull("$top", top); //$NON-NLS-1$
         queryParameters.addIfNotNull("$skip", skip); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<PolicyEvaluationRecord>>() {});
     }
@@ -557,12 +552,12 @@ public abstract class PolicyHttpClientBase
         queryParameters.addIfNotNull("$top", top); //$NON-NLS-1$
         queryParameters.addIfNotNull("$skip", skip); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<PolicyEvaluationRecord>>() {});
     }
@@ -591,11 +586,11 @@ public abstract class PolicyHttpClientBase
         routeValues.put("configurationId", configurationId); //$NON-NLS-1$
         routeValues.put("revisionId", revisionId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, PolicyConfiguration.class);
     }
@@ -624,11 +619,11 @@ public abstract class PolicyHttpClientBase
         routeValues.put("configurationId", configurationId); //$NON-NLS-1$
         routeValues.put("revisionId", revisionId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, PolicyConfiguration.class);
     }
@@ -663,12 +658,12 @@ public abstract class PolicyHttpClientBase
         queryParameters.addIfNotNull("$top", top); //$NON-NLS-1$
         queryParameters.addIfNotNull("$skip", skip); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<PolicyConfiguration>>() {});
     }
@@ -703,12 +698,12 @@ public abstract class PolicyHttpClientBase
         queryParameters.addIfNotNull("$top", top); //$NON-NLS-1$
         queryParameters.addIfNotNull("$skip", skip); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<PolicyConfiguration>>() {});
     }
@@ -733,11 +728,11 @@ public abstract class PolicyHttpClientBase
         routeValues.put("project", project); //$NON-NLS-1$
         routeValues.put("typeId", typeId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, PolicyType.class);
     }
@@ -762,11 +757,11 @@ public abstract class PolicyHttpClientBase
         routeValues.put("project", project); //$NON-NLS-1$
         routeValues.put("typeId", typeId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, PolicyType.class);
     }
@@ -786,11 +781,11 @@ public abstract class PolicyHttpClientBase
         final Map<String, Object> routeValues = new HashMap<String, Object>();
         routeValues.put("project", project); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<PolicyType>>() {});
     }
@@ -810,11 +805,11 @@ public abstract class PolicyHttpClientBase
         final Map<String, Object> routeValues = new HashMap<String, Object>();
         routeValues.put("project", project); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<PolicyType>>() {});
     }

--- a/Rest/alm-tfs-client/src/main/generated/com/microsoft/alm/teamfoundation/sourcecontrol/webapi/GitCommitRef.java
+++ b/Rest/alm-tfs-client/src/main/generated/com/microsoft/alm/teamfoundation/sourcecontrol/webapi/GitCommitRef.java
@@ -18,6 +18,7 @@ package com.microsoft.alm.teamfoundation.sourcecontrol.webapi;
 import java.util.ArrayList;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.microsoft.alm.visualstudio.services.webapi.ReferenceLinks;
+import com.microsoft.alm.visualstudio.services.webapi.ResourceRef;
 
 /** 
  */
@@ -35,6 +36,7 @@ public class GitCommitRef {
     private String remoteUrl;
     private ArrayList<GitStatus> statuses;
     private String url;
+    private ArrayList<ResourceRef> workItems;
 
     @JsonProperty("_links")
     public ReferenceLinks getLinks() {
@@ -132,5 +134,13 @@ public class GitCommitRef {
 
     public void setUrl(final String url) {
         this.url = url;
+    }
+
+    public ArrayList<ResourceRef> getWorkItems() {
+        return workItems;
+    }
+
+    public void setWorkItems(final ArrayList<ResourceRef> workItems) {
+        this.workItems = workItems;
     }
 }

--- a/Rest/alm-tfs-client/src/main/generated/com/microsoft/alm/teamfoundation/sourcecontrol/webapi/GitHttpClientBase.java
+++ b/Rest/alm-tfs-client/src/main/generated/com/microsoft/alm/teamfoundation/sourcecontrol/webapi/GitHttpClientBase.java
@@ -23,8 +23,12 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import com.fasterxml.jackson.core.type.TypeReference;
+import com.microsoft.alm.client.HttpMethod;
 import com.microsoft.alm.client.model.NameValueCollection;
 import com.microsoft.alm.client.VssHttpClientBase;
+import com.microsoft.alm.client.VssMediaTypes;
+import com.microsoft.alm.client.VssRestClientHandler;
+import com.microsoft.alm.client.VssRestRequest;
 import com.microsoft.alm.teamfoundation.sourcecontrol.webapi.AssociatedWorkItem;
 import com.microsoft.alm.teamfoundation.sourcecontrol.webapi.GitAsyncRefOperationParameters;
 import com.microsoft.alm.teamfoundation.sourcecontrol.webapi.GitBaseVersionDescriptor;
@@ -39,7 +43,6 @@ import com.microsoft.alm.teamfoundation.sourcecontrol.webapi.GitDeletedRepositor
 import com.microsoft.alm.teamfoundation.sourcecontrol.webapi.GitItem;
 import com.microsoft.alm.teamfoundation.sourcecontrol.webapi.GitItemRequestData;
 import com.microsoft.alm.teamfoundation.sourcecontrol.webapi.GitPullRequest;
-import com.microsoft.alm.teamfoundation.sourcecontrol.webapi.GitPullRequestChange;
 import com.microsoft.alm.teamfoundation.sourcecontrol.webapi.GitPullRequestCommentThread;
 import com.microsoft.alm.teamfoundation.sourcecontrol.webapi.GitPullRequestIteration;
 import com.microsoft.alm.teamfoundation.sourcecontrol.webapi.GitPullRequestIterationChanges;
@@ -79,22 +82,13 @@ public abstract class GitHttpClientBase
     * Create a new instance of GitHttpClientBase
     *
     * @param jaxrsClient
-    *            an initialized instance of a JAX-RS Client implementation
+    *            a DefaultRestClientHandler initialized with an instance of a JAX-RS Client implementation or
+    *            a TEERestClientHamdler initialized with TEE HTTP client implementation
     * @param baseUrl
-    *            a TFS project collection URL
+    *            a TFS services URL
     */
-    protected GitHttpClientBase(final Object jaxrsClient, final URI baseUrl) {
-        super(jaxrsClient, baseUrl);
-    }
-
-    /**
-    * Create a new instance of GitHttpClientBase
-    *
-    * @param tfsConnection
-    *            an initialized instance of a TfsTeamProjectCollection
-    */
-    protected GitHttpClientBase(final Object tfsConnection) {
-        super(tfsConnection);
+    protected GitHttpClientBase(final VssRestClientHandler clientHandler, final URI baseUrl) {
+        super(clientHandler, baseUrl);
     }
 
     @Override
@@ -136,12 +130,12 @@ public abstract class GitHttpClientBase
         queryParameters.addIfNotNull("download", download); //$NON-NLS-1$
         queryParameters.addIfNotEmpty("fileName", fileName); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, GitBlobRef.class);
     }
@@ -180,12 +174,12 @@ public abstract class GitHttpClientBase
         queryParameters.addIfNotNull("download", download); //$NON-NLS-1$
         queryParameters.addIfNotEmpty("fileName", fileName); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, GitBlobRef.class);
     }
@@ -224,12 +218,12 @@ public abstract class GitHttpClientBase
         queryParameters.addIfNotNull("download", download); //$NON-NLS-1$
         queryParameters.addIfNotEmpty("fileName", fileName); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, GitBlobRef.class);
     }
@@ -268,12 +262,12 @@ public abstract class GitHttpClientBase
         queryParameters.addIfNotNull("download", download); //$NON-NLS-1$
         queryParameters.addIfNotEmpty("fileName", fileName); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, GitBlobRef.class);
     }
@@ -308,12 +302,12 @@ public abstract class GitHttpClientBase
         queryParameters.addIfNotNull("download", download); //$NON-NLS-1$
         queryParameters.addIfNotEmpty("fileName", fileName); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, GitBlobRef.class);
     }
@@ -348,12 +342,12 @@ public abstract class GitHttpClientBase
         queryParameters.addIfNotNull("download", download); //$NON-NLS-1$
         queryParameters.addIfNotEmpty("fileName", fileName); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, GitBlobRef.class);
     }
@@ -392,12 +386,12 @@ public abstract class GitHttpClientBase
         queryParameters.addIfNotNull("download", download); //$NON-NLS-1$
         queryParameters.addIfNotEmpty("fileName", fileName); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_OCTET_STREAM_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_OCTET_STREAM_TYPE);
 
         return super.sendRequest(httpRequest, InputStream.class);
     }
@@ -436,12 +430,12 @@ public abstract class GitHttpClientBase
         queryParameters.addIfNotNull("download", download); //$NON-NLS-1$
         queryParameters.addIfNotEmpty("fileName", fileName); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_OCTET_STREAM_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_OCTET_STREAM_TYPE);
 
         return super.sendRequest(httpRequest, InputStream.class);
     }
@@ -480,12 +474,12 @@ public abstract class GitHttpClientBase
         queryParameters.addIfNotNull("download", download); //$NON-NLS-1$
         queryParameters.addIfNotEmpty("fileName", fileName); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_OCTET_STREAM_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_OCTET_STREAM_TYPE);
 
         return super.sendRequest(httpRequest, InputStream.class);
     }
@@ -524,12 +518,12 @@ public abstract class GitHttpClientBase
         queryParameters.addIfNotNull("download", download); //$NON-NLS-1$
         queryParameters.addIfNotEmpty("fileName", fileName); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_OCTET_STREAM_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_OCTET_STREAM_TYPE);
 
         return super.sendRequest(httpRequest, InputStream.class);
     }
@@ -564,12 +558,12 @@ public abstract class GitHttpClientBase
         queryParameters.addIfNotNull("download", download); //$NON-NLS-1$
         queryParameters.addIfNotEmpty("fileName", fileName); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_OCTET_STREAM_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_OCTET_STREAM_TYPE);
 
         return super.sendRequest(httpRequest, InputStream.class);
     }
@@ -604,12 +598,12 @@ public abstract class GitHttpClientBase
         queryParameters.addIfNotNull("download", download); //$NON-NLS-1$
         queryParameters.addIfNotEmpty("fileName", fileName); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_OCTET_STREAM_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_OCTET_STREAM_TYPE);
 
         return super.sendRequest(httpRequest, InputStream.class);
     }
@@ -639,14 +633,14 @@ public abstract class GitHttpClientBase
         final NameValueCollection queryParameters = new NameValueCollection();
         queryParameters.addIfNotEmpty("filename", filename); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.POST,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       blobIds,
-                                                       APPLICATION_JSON_TYPE,
-                                                       queryParameters,
-                                                       APPLICATION_ZIP_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.POST,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               blobIds,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_ZIP_TYPE);
 
         return super.sendRequest(httpRequest, InputStream.class);
     }
@@ -676,14 +670,14 @@ public abstract class GitHttpClientBase
         final NameValueCollection queryParameters = new NameValueCollection();
         queryParameters.addIfNotEmpty("filename", filename); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.POST,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       blobIds,
-                                                       APPLICATION_JSON_TYPE,
-                                                       queryParameters,
-                                                       APPLICATION_ZIP_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.POST,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               blobIds,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_ZIP_TYPE);
 
         return super.sendRequest(httpRequest, InputStream.class);
     }
@@ -717,14 +711,14 @@ public abstract class GitHttpClientBase
         final NameValueCollection queryParameters = new NameValueCollection();
         queryParameters.addIfNotEmpty("filename", filename); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.POST,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       blobIds,
-                                                       APPLICATION_JSON_TYPE,
-                                                       queryParameters,
-                                                       APPLICATION_ZIP_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.POST,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               blobIds,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_ZIP_TYPE);
 
         return super.sendRequest(httpRequest, InputStream.class);
     }
@@ -758,14 +752,14 @@ public abstract class GitHttpClientBase
         final NameValueCollection queryParameters = new NameValueCollection();
         queryParameters.addIfNotEmpty("filename", filename); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.POST,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       blobIds,
-                                                       APPLICATION_JSON_TYPE,
-                                                       queryParameters,
-                                                       APPLICATION_ZIP_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.POST,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               blobIds,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_ZIP_TYPE);
 
         return super.sendRequest(httpRequest, InputStream.class);
     }
@@ -799,14 +793,14 @@ public abstract class GitHttpClientBase
         final NameValueCollection queryParameters = new NameValueCollection();
         queryParameters.addIfNotEmpty("filename", filename); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.POST,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       blobIds,
-                                                       APPLICATION_JSON_TYPE,
-                                                       queryParameters,
-                                                       APPLICATION_ZIP_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.POST,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               blobIds,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_ZIP_TYPE);
 
         return super.sendRequest(httpRequest, InputStream.class);
     }
@@ -840,14 +834,14 @@ public abstract class GitHttpClientBase
         final NameValueCollection queryParameters = new NameValueCollection();
         queryParameters.addIfNotEmpty("filename", filename); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.POST,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       blobIds,
-                                                       APPLICATION_JSON_TYPE,
-                                                       queryParameters,
-                                                       APPLICATION_ZIP_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.POST,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               blobIds,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_ZIP_TYPE);
 
         return super.sendRequest(httpRequest, InputStream.class);
     }
@@ -886,12 +880,12 @@ public abstract class GitHttpClientBase
         queryParameters.addIfNotNull("download", download); //$NON-NLS-1$
         queryParameters.addIfNotEmpty("fileName", fileName); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_ZIP_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_ZIP_TYPE);
 
         return super.sendRequest(httpRequest, InputStream.class);
     }
@@ -930,12 +924,12 @@ public abstract class GitHttpClientBase
         queryParameters.addIfNotNull("download", download); //$NON-NLS-1$
         queryParameters.addIfNotEmpty("fileName", fileName); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_ZIP_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_ZIP_TYPE);
 
         return super.sendRequest(httpRequest, InputStream.class);
     }
@@ -974,12 +968,12 @@ public abstract class GitHttpClientBase
         queryParameters.addIfNotNull("download", download); //$NON-NLS-1$
         queryParameters.addIfNotEmpty("fileName", fileName); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_ZIP_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_ZIP_TYPE);
 
         return super.sendRequest(httpRequest, InputStream.class);
     }
@@ -1018,12 +1012,12 @@ public abstract class GitHttpClientBase
         queryParameters.addIfNotNull("download", download); //$NON-NLS-1$
         queryParameters.addIfNotEmpty("fileName", fileName); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_ZIP_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_ZIP_TYPE);
 
         return super.sendRequest(httpRequest, InputStream.class);
     }
@@ -1058,12 +1052,12 @@ public abstract class GitHttpClientBase
         queryParameters.addIfNotNull("download", download); //$NON-NLS-1$
         queryParameters.addIfNotEmpty("fileName", fileName); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_ZIP_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_ZIP_TYPE);
 
         return super.sendRequest(httpRequest, InputStream.class);
     }
@@ -1098,12 +1092,12 @@ public abstract class GitHttpClientBase
         queryParameters.addIfNotNull("download", download); //$NON-NLS-1$
         queryParameters.addIfNotEmpty("fileName", fileName); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_ZIP_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_ZIP_TYPE);
 
         return super.sendRequest(httpRequest, InputStream.class);
     }
@@ -1138,12 +1132,12 @@ public abstract class GitHttpClientBase
         queryParameters.addIfNotEmpty("name", name); //$NON-NLS-1$
         addModelAsQueryParams(queryParameters, baseVersionDescriptor);
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, GitBranchStats.class);
     }
@@ -1178,12 +1172,12 @@ public abstract class GitHttpClientBase
         queryParameters.addIfNotEmpty("name", name); //$NON-NLS-1$
         addModelAsQueryParams(queryParameters, baseVersionDescriptor);
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, GitBranchStats.class);
     }
@@ -1218,12 +1212,12 @@ public abstract class GitHttpClientBase
         queryParameters.addIfNotEmpty("name", name); //$NON-NLS-1$
         addModelAsQueryParams(queryParameters, baseVersionDescriptor);
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, GitBranchStats.class);
     }
@@ -1258,12 +1252,12 @@ public abstract class GitHttpClientBase
         queryParameters.addIfNotEmpty("name", name); //$NON-NLS-1$
         addModelAsQueryParams(queryParameters, baseVersionDescriptor);
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, GitBranchStats.class);
     }
@@ -1294,12 +1288,12 @@ public abstract class GitHttpClientBase
         queryParameters.addIfNotEmpty("name", name); //$NON-NLS-1$
         addModelAsQueryParams(queryParameters, baseVersionDescriptor);
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, GitBranchStats.class);
     }
@@ -1330,12 +1324,12 @@ public abstract class GitHttpClientBase
         queryParameters.addIfNotEmpty("name", name); //$NON-NLS-1$
         addModelAsQueryParams(queryParameters, baseVersionDescriptor);
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, GitBranchStats.class);
     }
@@ -1366,12 +1360,12 @@ public abstract class GitHttpClientBase
         final NameValueCollection queryParameters = new NameValueCollection();
         addModelAsQueryParams(queryParameters, baseVersionDescriptor);
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<GitBranchStats>>() {});
     }
@@ -1402,12 +1396,12 @@ public abstract class GitHttpClientBase
         final NameValueCollection queryParameters = new NameValueCollection();
         addModelAsQueryParams(queryParameters, baseVersionDescriptor);
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<GitBranchStats>>() {});
     }
@@ -1438,12 +1432,12 @@ public abstract class GitHttpClientBase
         final NameValueCollection queryParameters = new NameValueCollection();
         addModelAsQueryParams(queryParameters, baseVersionDescriptor);
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<GitBranchStats>>() {});
     }
@@ -1474,12 +1468,12 @@ public abstract class GitHttpClientBase
         final NameValueCollection queryParameters = new NameValueCollection();
         addModelAsQueryParams(queryParameters, baseVersionDescriptor);
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<GitBranchStats>>() {});
     }
@@ -1506,12 +1500,12 @@ public abstract class GitHttpClientBase
         final NameValueCollection queryParameters = new NameValueCollection();
         addModelAsQueryParams(queryParameters, baseVersionDescriptor);
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<GitBranchStats>>() {});
     }
@@ -1538,12 +1532,12 @@ public abstract class GitHttpClientBase
         final NameValueCollection queryParameters = new NameValueCollection();
         addModelAsQueryParams(queryParameters, baseVersionDescriptor);
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<GitBranchStats>>() {});
     }
@@ -1567,13 +1561,13 @@ public abstract class GitHttpClientBase
         final Map<String, Object> routeValues = new HashMap<String, Object>();
         routeValues.put("repositoryId", repositoryId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.POST,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       searchCriteria,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.POST,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               searchCriteria,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<GitBranchStats>>() {});
     }
@@ -1597,13 +1591,13 @@ public abstract class GitHttpClientBase
         final Map<String, Object> routeValues = new HashMap<String, Object>();
         routeValues.put("repositoryId", repositoryId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.POST,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       searchCriteria,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.POST,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               searchCriteria,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<GitBranchStats>>() {});
     }
@@ -1631,13 +1625,13 @@ public abstract class GitHttpClientBase
         routeValues.put("project", project); //$NON-NLS-1$
         routeValues.put("repositoryId", repositoryId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.POST,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       searchCriteria,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.POST,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               searchCriteria,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<GitBranchStats>>() {});
     }
@@ -1665,13 +1659,13 @@ public abstract class GitHttpClientBase
         routeValues.put("project", project); //$NON-NLS-1$
         routeValues.put("repositoryId", repositoryId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.POST,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       searchCriteria,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.POST,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               searchCriteria,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<GitBranchStats>>() {});
     }
@@ -1699,13 +1693,13 @@ public abstract class GitHttpClientBase
         routeValues.put("project", project); //$NON-NLS-1$
         routeValues.put("repositoryId", repositoryId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.POST,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       searchCriteria,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.POST,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               searchCriteria,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<GitBranchStats>>() {});
     }
@@ -1733,13 +1727,13 @@ public abstract class GitHttpClientBase
         routeValues.put("project", project); //$NON-NLS-1$
         routeValues.put("repositoryId", repositoryId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.POST,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       searchCriteria,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.POST,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               searchCriteria,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<GitBranchStats>>() {});
     }
@@ -1778,12 +1772,12 @@ public abstract class GitHttpClientBase
         queryParameters.addIfNotNull("top", top); //$NON-NLS-1$
         queryParameters.addIfNotNull("skip", skip); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, GitCommitChanges.class);
     }
@@ -1822,12 +1816,12 @@ public abstract class GitHttpClientBase
         queryParameters.addIfNotNull("top", top); //$NON-NLS-1$
         queryParameters.addIfNotNull("skip", skip); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, GitCommitChanges.class);
     }
@@ -1866,12 +1860,12 @@ public abstract class GitHttpClientBase
         queryParameters.addIfNotNull("top", top); //$NON-NLS-1$
         queryParameters.addIfNotNull("skip", skip); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, GitCommitChanges.class);
     }
@@ -1910,12 +1904,12 @@ public abstract class GitHttpClientBase
         queryParameters.addIfNotNull("top", top); //$NON-NLS-1$
         queryParameters.addIfNotNull("skip", skip); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, GitCommitChanges.class);
     }
@@ -1950,12 +1944,12 @@ public abstract class GitHttpClientBase
         queryParameters.addIfNotNull("top", top); //$NON-NLS-1$
         queryParameters.addIfNotNull("skip", skip); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, GitCommitChanges.class);
     }
@@ -1990,12 +1984,12 @@ public abstract class GitHttpClientBase
         queryParameters.addIfNotNull("top", top); //$NON-NLS-1$
         queryParameters.addIfNotNull("skip", skip); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, GitCommitChanges.class);
     }
@@ -2023,13 +2017,13 @@ public abstract class GitHttpClientBase
         routeValues.put("project", project); //$NON-NLS-1$
         routeValues.put("repositoryId", repositoryId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.POST,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       cherryPickToCreate,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.POST,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               cherryPickToCreate,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, GitCherryPick.class);
     }
@@ -2057,13 +2051,13 @@ public abstract class GitHttpClientBase
         routeValues.put("project", project); //$NON-NLS-1$
         routeValues.put("repositoryId", repositoryId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.POST,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       cherryPickToCreate,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.POST,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               cherryPickToCreate,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, GitCherryPick.class);
     }
@@ -2091,13 +2085,13 @@ public abstract class GitHttpClientBase
         routeValues.put("project", project); //$NON-NLS-1$
         routeValues.put("repositoryId", repositoryId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.POST,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       cherryPickToCreate,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.POST,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               cherryPickToCreate,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, GitCherryPick.class);
     }
@@ -2125,13 +2119,13 @@ public abstract class GitHttpClientBase
         routeValues.put("project", project); //$NON-NLS-1$
         routeValues.put("repositoryId", repositoryId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.POST,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       cherryPickToCreate,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.POST,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               cherryPickToCreate,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, GitCherryPick.class);
     }
@@ -2160,11 +2154,11 @@ public abstract class GitHttpClientBase
         routeValues.put("cherryPickId", cherryPickId); //$NON-NLS-1$
         routeValues.put("repositoryId", repositoryId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, GitCherryPick.class);
     }
@@ -2193,11 +2187,11 @@ public abstract class GitHttpClientBase
         routeValues.put("cherryPickId", cherryPickId); //$NON-NLS-1$
         routeValues.put("repositoryId", repositoryId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, GitCherryPick.class);
     }
@@ -2226,11 +2220,11 @@ public abstract class GitHttpClientBase
         routeValues.put("cherryPickId", cherryPickId); //$NON-NLS-1$
         routeValues.put("repositoryId", repositoryId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, GitCherryPick.class);
     }
@@ -2259,11 +2253,11 @@ public abstract class GitHttpClientBase
         routeValues.put("cherryPickId", cherryPickId); //$NON-NLS-1$
         routeValues.put("repositoryId", repositoryId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, GitCherryPick.class);
     }
@@ -2294,12 +2288,12 @@ public abstract class GitHttpClientBase
         final NameValueCollection queryParameters = new NameValueCollection();
         queryParameters.addIfNotEmpty("refName", refName); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, GitCherryPick.class);
     }
@@ -2330,12 +2324,12 @@ public abstract class GitHttpClientBase
         final NameValueCollection queryParameters = new NameValueCollection();
         queryParameters.addIfNotEmpty("refName", refName); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, GitCherryPick.class);
     }
@@ -2366,12 +2360,12 @@ public abstract class GitHttpClientBase
         final NameValueCollection queryParameters = new NameValueCollection();
         queryParameters.addIfNotEmpty("refName", refName); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, GitCherryPick.class);
     }
@@ -2402,12 +2396,12 @@ public abstract class GitHttpClientBase
         final NameValueCollection queryParameters = new NameValueCollection();
         queryParameters.addIfNotEmpty("refName", refName); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, GitCherryPick.class);
     }
@@ -2454,12 +2448,12 @@ public abstract class GitHttpClientBase
         addModelAsQueryParams(queryParameters, baseVersionDescriptor);
         addModelAsQueryParams(queryParameters, targetVersionDescriptor);
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, GitCommitDiffs.class);
     }
@@ -2506,12 +2500,12 @@ public abstract class GitHttpClientBase
         addModelAsQueryParams(queryParameters, baseVersionDescriptor);
         addModelAsQueryParams(queryParameters, targetVersionDescriptor);
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, GitCommitDiffs.class);
     }
@@ -2558,12 +2552,12 @@ public abstract class GitHttpClientBase
         addModelAsQueryParams(queryParameters, baseVersionDescriptor);
         addModelAsQueryParams(queryParameters, targetVersionDescriptor);
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, GitCommitDiffs.class);
     }
@@ -2610,12 +2604,12 @@ public abstract class GitHttpClientBase
         addModelAsQueryParams(queryParameters, baseVersionDescriptor);
         addModelAsQueryParams(queryParameters, targetVersionDescriptor);
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, GitCommitDiffs.class);
     }
@@ -2658,12 +2652,12 @@ public abstract class GitHttpClientBase
         addModelAsQueryParams(queryParameters, baseVersionDescriptor);
         addModelAsQueryParams(queryParameters, targetVersionDescriptor);
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, GitCommitDiffs.class);
     }
@@ -2706,12 +2700,12 @@ public abstract class GitHttpClientBase
         addModelAsQueryParams(queryParameters, baseVersionDescriptor);
         addModelAsQueryParams(queryParameters, targetVersionDescriptor);
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, GitCommitDiffs.class);
     }
@@ -2746,12 +2740,12 @@ public abstract class GitHttpClientBase
         final NameValueCollection queryParameters = new NameValueCollection();
         queryParameters.addIfNotNull("changeCount", changeCount); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, GitCommit.class);
     }
@@ -2786,12 +2780,12 @@ public abstract class GitHttpClientBase
         final NameValueCollection queryParameters = new NameValueCollection();
         queryParameters.addIfNotNull("changeCount", changeCount); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, GitCommit.class);
     }
@@ -2826,12 +2820,12 @@ public abstract class GitHttpClientBase
         final NameValueCollection queryParameters = new NameValueCollection();
         queryParameters.addIfNotNull("changeCount", changeCount); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, GitCommit.class);
     }
@@ -2866,12 +2860,12 @@ public abstract class GitHttpClientBase
         final NameValueCollection queryParameters = new NameValueCollection();
         queryParameters.addIfNotNull("changeCount", changeCount); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, GitCommit.class);
     }
@@ -2902,12 +2896,12 @@ public abstract class GitHttpClientBase
         final NameValueCollection queryParameters = new NameValueCollection();
         queryParameters.addIfNotNull("changeCount", changeCount); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, GitCommit.class);
     }
@@ -2938,12 +2932,12 @@ public abstract class GitHttpClientBase
         final NameValueCollection queryParameters = new NameValueCollection();
         queryParameters.addIfNotNull("changeCount", changeCount); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, GitCommit.class);
     }
@@ -2982,12 +2976,12 @@ public abstract class GitHttpClientBase
         queryParameters.addIfNotNull("$skip", skip); //$NON-NLS-1$
         queryParameters.addIfNotNull("$top", top); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<GitCommitRef>>() {});
     }
@@ -3026,12 +3020,12 @@ public abstract class GitHttpClientBase
         queryParameters.addIfNotNull("$skip", skip); //$NON-NLS-1$
         queryParameters.addIfNotNull("$top", top); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<GitCommitRef>>() {});
     }
@@ -3070,12 +3064,12 @@ public abstract class GitHttpClientBase
         queryParameters.addIfNotNull("$skip", skip); //$NON-NLS-1$
         queryParameters.addIfNotNull("$top", top); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<GitCommitRef>>() {});
     }
@@ -3114,12 +3108,12 @@ public abstract class GitHttpClientBase
         queryParameters.addIfNotNull("$skip", skip); //$NON-NLS-1$
         queryParameters.addIfNotNull("$top", top); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<GitCommitRef>>() {});
     }
@@ -3154,12 +3148,12 @@ public abstract class GitHttpClientBase
         queryParameters.addIfNotNull("$skip", skip); //$NON-NLS-1$
         queryParameters.addIfNotNull("$top", top); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<GitCommitRef>>() {});
     }
@@ -3194,12 +3188,12 @@ public abstract class GitHttpClientBase
         queryParameters.addIfNotNull("$skip", skip); //$NON-NLS-1$
         queryParameters.addIfNotNull("$top", top); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<GitCommitRef>>() {});
     }
@@ -3242,12 +3236,12 @@ public abstract class GitHttpClientBase
         queryParameters.addIfNotNull("skip", skip); //$NON-NLS-1$
         queryParameters.addIfNotNull("includeLinks", includeLinks); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<GitCommitRef>>() {});
     }
@@ -3290,12 +3284,12 @@ public abstract class GitHttpClientBase
         queryParameters.addIfNotNull("skip", skip); //$NON-NLS-1$
         queryParameters.addIfNotNull("includeLinks", includeLinks); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<GitCommitRef>>() {});
     }
@@ -3338,12 +3332,12 @@ public abstract class GitHttpClientBase
         queryParameters.addIfNotNull("skip", skip); //$NON-NLS-1$
         queryParameters.addIfNotNull("includeLinks", includeLinks); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<GitCommitRef>>() {});
     }
@@ -3386,12 +3380,12 @@ public abstract class GitHttpClientBase
         queryParameters.addIfNotNull("skip", skip); //$NON-NLS-1$
         queryParameters.addIfNotNull("includeLinks", includeLinks); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<GitCommitRef>>() {});
     }
@@ -3430,12 +3424,12 @@ public abstract class GitHttpClientBase
         queryParameters.addIfNotNull("skip", skip); //$NON-NLS-1$
         queryParameters.addIfNotNull("includeLinks", includeLinks); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<GitCommitRef>>() {});
     }
@@ -3474,12 +3468,12 @@ public abstract class GitHttpClientBase
         queryParameters.addIfNotNull("skip", skip); //$NON-NLS-1$
         queryParameters.addIfNotNull("includeLinks", includeLinks); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<GitCommitRef>>() {});
     }
@@ -3517,14 +3511,14 @@ public abstract class GitHttpClientBase
         queryParameters.addIfNotNull("$top", top); //$NON-NLS-1$
         queryParameters.addIfNotNull("includeStatuses", includeStatuses); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.POST,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       searchCriteria,
-                                                       APPLICATION_JSON_TYPE,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.POST,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               searchCriteria,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<GitCommitRef>>() {});
     }
@@ -3562,14 +3556,14 @@ public abstract class GitHttpClientBase
         queryParameters.addIfNotNull("$top", top); //$NON-NLS-1$
         queryParameters.addIfNotNull("includeStatuses", includeStatuses); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.POST,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       searchCriteria,
-                                                       APPLICATION_JSON_TYPE,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.POST,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               searchCriteria,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<GitCommitRef>>() {});
     }
@@ -3611,14 +3605,14 @@ public abstract class GitHttpClientBase
         queryParameters.addIfNotNull("$top", top); //$NON-NLS-1$
         queryParameters.addIfNotNull("includeStatuses", includeStatuses); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.POST,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       searchCriteria,
-                                                       APPLICATION_JSON_TYPE,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.POST,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               searchCriteria,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<GitCommitRef>>() {});
     }
@@ -3660,14 +3654,14 @@ public abstract class GitHttpClientBase
         queryParameters.addIfNotNull("$top", top); //$NON-NLS-1$
         queryParameters.addIfNotNull("includeStatuses", includeStatuses); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.POST,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       searchCriteria,
-                                                       APPLICATION_JSON_TYPE,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.POST,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               searchCriteria,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<GitCommitRef>>() {});
     }
@@ -3709,14 +3703,14 @@ public abstract class GitHttpClientBase
         queryParameters.addIfNotNull("$top", top); //$NON-NLS-1$
         queryParameters.addIfNotNull("includeStatuses", includeStatuses); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.POST,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       searchCriteria,
-                                                       APPLICATION_JSON_TYPE,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.POST,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               searchCriteria,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<GitCommitRef>>() {});
     }
@@ -3758,14 +3752,14 @@ public abstract class GitHttpClientBase
         queryParameters.addIfNotNull("$top", top); //$NON-NLS-1$
         queryParameters.addIfNotNull("includeStatuses", includeStatuses); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.POST,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       searchCriteria,
-                                                       APPLICATION_JSON_TYPE,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.POST,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               searchCriteria,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<GitCommitRef>>() {});
     }
@@ -3785,11 +3779,11 @@ public abstract class GitHttpClientBase
         final Map<String, Object> routeValues = new HashMap<String, Object>();
         routeValues.put("project", project); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<GitDeletedRepository>>() {});
     }
@@ -3809,11 +3803,11 @@ public abstract class GitHttpClientBase
         final Map<String, Object> routeValues = new HashMap<String, Object>();
         routeValues.put("project", project); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<GitDeletedRepository>>() {});
     }
@@ -3868,12 +3862,12 @@ public abstract class GitHttpClientBase
         queryParameters.addIfNotNull("download", download); //$NON-NLS-1$
         addModelAsQueryParams(queryParameters, versionDescriptor);
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, GitItem.class);
     }
@@ -3928,12 +3922,12 @@ public abstract class GitHttpClientBase
         queryParameters.addIfNotNull("download", download); //$NON-NLS-1$
         addModelAsQueryParams(queryParameters, versionDescriptor);
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, GitItem.class);
     }
@@ -3988,12 +3982,12 @@ public abstract class GitHttpClientBase
         queryParameters.addIfNotNull("download", download); //$NON-NLS-1$
         addModelAsQueryParams(queryParameters, versionDescriptor);
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, GitItem.class);
     }
@@ -4048,12 +4042,12 @@ public abstract class GitHttpClientBase
         queryParameters.addIfNotNull("download", download); //$NON-NLS-1$
         addModelAsQueryParams(queryParameters, versionDescriptor);
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, GitItem.class);
     }
@@ -4104,12 +4098,12 @@ public abstract class GitHttpClientBase
         queryParameters.addIfNotNull("download", download); //$NON-NLS-1$
         addModelAsQueryParams(queryParameters, versionDescriptor);
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, GitItem.class);
     }
@@ -4160,12 +4154,12 @@ public abstract class GitHttpClientBase
         queryParameters.addIfNotNull("download", download); //$NON-NLS-1$
         addModelAsQueryParams(queryParameters, versionDescriptor);
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, GitItem.class);
     }
@@ -4220,12 +4214,12 @@ public abstract class GitHttpClientBase
         queryParameters.addIfNotNull("download", download); //$NON-NLS-1$
         addModelAsQueryParams(queryParameters, versionDescriptor);
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_OCTET_STREAM_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_OCTET_STREAM_TYPE);
 
         return super.sendRequest(httpRequest, InputStream.class);
     }
@@ -4280,12 +4274,12 @@ public abstract class GitHttpClientBase
         queryParameters.addIfNotNull("download", download); //$NON-NLS-1$
         addModelAsQueryParams(queryParameters, versionDescriptor);
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_OCTET_STREAM_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_OCTET_STREAM_TYPE);
 
         return super.sendRequest(httpRequest, InputStream.class);
     }
@@ -4340,12 +4334,12 @@ public abstract class GitHttpClientBase
         queryParameters.addIfNotNull("download", download); //$NON-NLS-1$
         addModelAsQueryParams(queryParameters, versionDescriptor);
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_OCTET_STREAM_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_OCTET_STREAM_TYPE);
 
         return super.sendRequest(httpRequest, InputStream.class);
     }
@@ -4400,12 +4394,12 @@ public abstract class GitHttpClientBase
         queryParameters.addIfNotNull("download", download); //$NON-NLS-1$
         addModelAsQueryParams(queryParameters, versionDescriptor);
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_OCTET_STREAM_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_OCTET_STREAM_TYPE);
 
         return super.sendRequest(httpRequest, InputStream.class);
     }
@@ -4456,12 +4450,12 @@ public abstract class GitHttpClientBase
         queryParameters.addIfNotNull("download", download); //$NON-NLS-1$
         addModelAsQueryParams(queryParameters, versionDescriptor);
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_OCTET_STREAM_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_OCTET_STREAM_TYPE);
 
         return super.sendRequest(httpRequest, InputStream.class);
     }
@@ -4512,12 +4506,12 @@ public abstract class GitHttpClientBase
         queryParameters.addIfNotNull("download", download); //$NON-NLS-1$
         addModelAsQueryParams(queryParameters, versionDescriptor);
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_OCTET_STREAM_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_OCTET_STREAM_TYPE);
 
         return super.sendRequest(httpRequest, InputStream.class);
     }
@@ -4572,12 +4566,12 @@ public abstract class GitHttpClientBase
         queryParameters.addIfNotNull("includeLinks", includeLinks); //$NON-NLS-1$
         addModelAsQueryParams(queryParameters, versionDescriptor);
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<GitItem>>() {});
     }
@@ -4632,12 +4626,12 @@ public abstract class GitHttpClientBase
         queryParameters.addIfNotNull("includeLinks", includeLinks); //$NON-NLS-1$
         addModelAsQueryParams(queryParameters, versionDescriptor);
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<GitItem>>() {});
     }
@@ -4692,12 +4686,12 @@ public abstract class GitHttpClientBase
         queryParameters.addIfNotNull("includeLinks", includeLinks); //$NON-NLS-1$
         addModelAsQueryParams(queryParameters, versionDescriptor);
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<GitItem>>() {});
     }
@@ -4752,12 +4746,12 @@ public abstract class GitHttpClientBase
         queryParameters.addIfNotNull("includeLinks", includeLinks); //$NON-NLS-1$
         addModelAsQueryParams(queryParameters, versionDescriptor);
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<GitItem>>() {});
     }
@@ -4808,12 +4802,12 @@ public abstract class GitHttpClientBase
         queryParameters.addIfNotNull("includeLinks", includeLinks); //$NON-NLS-1$
         addModelAsQueryParams(queryParameters, versionDescriptor);
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<GitItem>>() {});
     }
@@ -4864,12 +4858,12 @@ public abstract class GitHttpClientBase
         queryParameters.addIfNotNull("includeLinks", includeLinks); //$NON-NLS-1$
         addModelAsQueryParams(queryParameters, versionDescriptor);
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<GitItem>>() {});
     }
@@ -4924,12 +4918,12 @@ public abstract class GitHttpClientBase
         queryParameters.addIfNotNull("download", download); //$NON-NLS-1$
         addModelAsQueryParams(queryParameters, versionDescriptor);
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       TEXT_PLAIN_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.TEXT_PLAIN_TYPE);
 
         return super.sendRequest(httpRequest, InputStream.class);
     }
@@ -4984,12 +4978,12 @@ public abstract class GitHttpClientBase
         queryParameters.addIfNotNull("download", download); //$NON-NLS-1$
         addModelAsQueryParams(queryParameters, versionDescriptor);
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       TEXT_PLAIN_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.TEXT_PLAIN_TYPE);
 
         return super.sendRequest(httpRequest, InputStream.class);
     }
@@ -5044,12 +5038,12 @@ public abstract class GitHttpClientBase
         queryParameters.addIfNotNull("download", download); //$NON-NLS-1$
         addModelAsQueryParams(queryParameters, versionDescriptor);
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       TEXT_PLAIN_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.TEXT_PLAIN_TYPE);
 
         return super.sendRequest(httpRequest, InputStream.class);
     }
@@ -5104,12 +5098,12 @@ public abstract class GitHttpClientBase
         queryParameters.addIfNotNull("download", download); //$NON-NLS-1$
         addModelAsQueryParams(queryParameters, versionDescriptor);
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       TEXT_PLAIN_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.TEXT_PLAIN_TYPE);
 
         return super.sendRequest(httpRequest, InputStream.class);
     }
@@ -5160,12 +5154,12 @@ public abstract class GitHttpClientBase
         queryParameters.addIfNotNull("download", download); //$NON-NLS-1$
         addModelAsQueryParams(queryParameters, versionDescriptor);
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       TEXT_PLAIN_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.TEXT_PLAIN_TYPE);
 
         return super.sendRequest(httpRequest, InputStream.class);
     }
@@ -5216,12 +5210,12 @@ public abstract class GitHttpClientBase
         queryParameters.addIfNotNull("download", download); //$NON-NLS-1$
         addModelAsQueryParams(queryParameters, versionDescriptor);
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       TEXT_PLAIN_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.TEXT_PLAIN_TYPE);
 
         return super.sendRequest(httpRequest, InputStream.class);
     }
@@ -5276,12 +5270,12 @@ public abstract class GitHttpClientBase
         queryParameters.addIfNotNull("download", download); //$NON-NLS-1$
         addModelAsQueryParams(queryParameters, versionDescriptor);
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_ZIP_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_ZIP_TYPE);
 
         return super.sendRequest(httpRequest, InputStream.class);
     }
@@ -5336,12 +5330,12 @@ public abstract class GitHttpClientBase
         queryParameters.addIfNotNull("download", download); //$NON-NLS-1$
         addModelAsQueryParams(queryParameters, versionDescriptor);
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_ZIP_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_ZIP_TYPE);
 
         return super.sendRequest(httpRequest, InputStream.class);
     }
@@ -5396,12 +5390,12 @@ public abstract class GitHttpClientBase
         queryParameters.addIfNotNull("download", download); //$NON-NLS-1$
         addModelAsQueryParams(queryParameters, versionDescriptor);
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_ZIP_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_ZIP_TYPE);
 
         return super.sendRequest(httpRequest, InputStream.class);
     }
@@ -5456,12 +5450,12 @@ public abstract class GitHttpClientBase
         queryParameters.addIfNotNull("download", download); //$NON-NLS-1$
         addModelAsQueryParams(queryParameters, versionDescriptor);
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_ZIP_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_ZIP_TYPE);
 
         return super.sendRequest(httpRequest, InputStream.class);
     }
@@ -5512,12 +5506,12 @@ public abstract class GitHttpClientBase
         queryParameters.addIfNotNull("download", download); //$NON-NLS-1$
         addModelAsQueryParams(queryParameters, versionDescriptor);
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_ZIP_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_ZIP_TYPE);
 
         return super.sendRequest(httpRequest, InputStream.class);
     }
@@ -5568,12 +5562,12 @@ public abstract class GitHttpClientBase
         queryParameters.addIfNotNull("download", download); //$NON-NLS-1$
         addModelAsQueryParams(queryParameters, versionDescriptor);
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_ZIP_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_ZIP_TYPE);
 
         return super.sendRequest(httpRequest, InputStream.class);
     }
@@ -5597,13 +5591,13 @@ public abstract class GitHttpClientBase
         final Map<String, Object> routeValues = new HashMap<String, Object>();
         routeValues.put("repositoryId", repositoryId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.POST,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       requestData,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.POST,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               requestData,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<ArrayList<GitItem>>>() {});
     }
@@ -5627,13 +5621,13 @@ public abstract class GitHttpClientBase
         final Map<String, Object> routeValues = new HashMap<String, Object>();
         routeValues.put("repositoryId", repositoryId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.POST,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       requestData,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.POST,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               requestData,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<ArrayList<GitItem>>>() {});
     }
@@ -5661,13 +5655,13 @@ public abstract class GitHttpClientBase
         routeValues.put("project", project); //$NON-NLS-1$
         routeValues.put("repositoryId", repositoryId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.POST,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       requestData,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.POST,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               requestData,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<ArrayList<GitItem>>>() {});
     }
@@ -5695,13 +5689,13 @@ public abstract class GitHttpClientBase
         routeValues.put("project", project); //$NON-NLS-1$
         routeValues.put("repositoryId", repositoryId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.POST,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       requestData,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.POST,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               requestData,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<ArrayList<GitItem>>>() {});
     }
@@ -5729,13 +5723,13 @@ public abstract class GitHttpClientBase
         routeValues.put("project", project); //$NON-NLS-1$
         routeValues.put("repositoryId", repositoryId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.POST,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       requestData,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.POST,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               requestData,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<ArrayList<GitItem>>>() {});
     }
@@ -5763,13 +5757,13 @@ public abstract class GitHttpClientBase
         routeValues.put("project", project); //$NON-NLS-1$
         routeValues.put("repositoryId", repositoryId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.POST,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       requestData,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.POST,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               requestData,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<ArrayList<GitItem>>>() {});
     }
@@ -5798,11 +5792,11 @@ public abstract class GitHttpClientBase
         routeValues.put("pullRequestId", pullRequestId); //$NON-NLS-1$
         routeValues.put("iterationId", iterationId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<GitCommitRef>>() {});
     }
@@ -5831,11 +5825,11 @@ public abstract class GitHttpClientBase
         routeValues.put("pullRequestId", pullRequestId); //$NON-NLS-1$
         routeValues.put("iterationId", iterationId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<GitCommitRef>>() {});
     }
@@ -5868,11 +5862,11 @@ public abstract class GitHttpClientBase
         routeValues.put("pullRequestId", pullRequestId); //$NON-NLS-1$
         routeValues.put("iterationId", iterationId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<GitCommitRef>>() {});
     }
@@ -5905,11 +5899,11 @@ public abstract class GitHttpClientBase
         routeValues.put("pullRequestId", pullRequestId); //$NON-NLS-1$
         routeValues.put("iterationId", iterationId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<GitCommitRef>>() {});
     }
@@ -5942,11 +5936,11 @@ public abstract class GitHttpClientBase
         routeValues.put("pullRequestId", pullRequestId); //$NON-NLS-1$
         routeValues.put("iterationId", iterationId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<GitCommitRef>>() {});
     }
@@ -5979,11 +5973,11 @@ public abstract class GitHttpClientBase
         routeValues.put("pullRequestId", pullRequestId); //$NON-NLS-1$
         routeValues.put("iterationId", iterationId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<GitCommitRef>>() {});
     }
@@ -6008,11 +6002,11 @@ public abstract class GitHttpClientBase
         routeValues.put("repositoryId", repositoryId); //$NON-NLS-1$
         routeValues.put("pullRequestId", pullRequestId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<GitCommitRef>>() {});
     }
@@ -6037,11 +6031,11 @@ public abstract class GitHttpClientBase
         routeValues.put("repositoryId", repositoryId); //$NON-NLS-1$
         routeValues.put("pullRequestId", pullRequestId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<GitCommitRef>>() {});
     }
@@ -6070,11 +6064,11 @@ public abstract class GitHttpClientBase
         routeValues.put("repositoryId", repositoryId); //$NON-NLS-1$
         routeValues.put("pullRequestId", pullRequestId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<GitCommitRef>>() {});
     }
@@ -6103,11 +6097,11 @@ public abstract class GitHttpClientBase
         routeValues.put("repositoryId", repositoryId); //$NON-NLS-1$
         routeValues.put("pullRequestId", pullRequestId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<GitCommitRef>>() {});
     }
@@ -6136,11 +6130,11 @@ public abstract class GitHttpClientBase
         routeValues.put("repositoryId", repositoryId); //$NON-NLS-1$
         routeValues.put("pullRequestId", pullRequestId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<GitCommitRef>>() {});
     }
@@ -6169,11 +6163,11 @@ public abstract class GitHttpClientBase
         routeValues.put("repositoryId", repositoryId); //$NON-NLS-1$
         routeValues.put("pullRequestId", pullRequestId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<GitCommitRef>>() {});
     }
@@ -6181,6 +6175,310 @@ public abstract class GitHttpClientBase
     /** 
      * [Preview API 3.0-preview.1]
      * 
+     * @param project 
+     *            Project ID or project name
+     * @param repositoryId 
+     *            
+     * @param pullRequestId 
+     *            
+     * @param iterationId 
+     *            
+     * @param top 
+     *            
+     * @param skip 
+     *            
+     * @param compareTo 
+     *            
+     * @return GitPullRequestIterationChanges
+     */
+    public GitPullRequestIterationChanges getPullRequestIterationChanges(
+        final String project, 
+        final String repositoryId, 
+        final int pullRequestId, 
+        final int iterationId, 
+        final Integer top, 
+        final Integer skip, 
+        final Integer compareTo) { 
+
+        final UUID locationId = UUID.fromString("4216bdcf-b6b1-4d59-8b82-c34cc183fc8b"); //$NON-NLS-1$
+        final ApiResourceVersion apiVersion = new ApiResourceVersion("3.0-preview.1"); //$NON-NLS-1$
+
+        final Map<String, Object> routeValues = new HashMap<String, Object>();
+        routeValues.put("project", project); //$NON-NLS-1$
+        routeValues.put("repositoryId", repositoryId); //$NON-NLS-1$
+        routeValues.put("pullRequestId", pullRequestId); //$NON-NLS-1$
+        routeValues.put("iterationId", iterationId); //$NON-NLS-1$
+
+        final NameValueCollection queryParameters = new NameValueCollection();
+        queryParameters.addIfNotNull("$top", top); //$NON-NLS-1$
+        queryParameters.addIfNotNull("$skip", skip); //$NON-NLS-1$
+        queryParameters.addIfNotNull("$compareTo", compareTo); //$NON-NLS-1$
+
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
+
+        return super.sendRequest(httpRequest, GitPullRequestIterationChanges.class);
+    }
+
+    /** 
+     * [Preview API 3.0-preview.1]
+     * 
+     * @param project 
+     *            Project ID or project name
+     * @param repositoryId 
+     *            
+     * @param pullRequestId 
+     *            
+     * @param iterationId 
+     *            
+     * @param top 
+     *            
+     * @param skip 
+     *            
+     * @param compareTo 
+     *            
+     * @return GitPullRequestIterationChanges
+     */
+    public GitPullRequestIterationChanges getPullRequestIterationChanges(
+        final String project, 
+        final UUID repositoryId, 
+        final int pullRequestId, 
+        final int iterationId, 
+        final Integer top, 
+        final Integer skip, 
+        final Integer compareTo) { 
+
+        final UUID locationId = UUID.fromString("4216bdcf-b6b1-4d59-8b82-c34cc183fc8b"); //$NON-NLS-1$
+        final ApiResourceVersion apiVersion = new ApiResourceVersion("3.0-preview.1"); //$NON-NLS-1$
+
+        final Map<String, Object> routeValues = new HashMap<String, Object>();
+        routeValues.put("project", project); //$NON-NLS-1$
+        routeValues.put("repositoryId", repositoryId); //$NON-NLS-1$
+        routeValues.put("pullRequestId", pullRequestId); //$NON-NLS-1$
+        routeValues.put("iterationId", iterationId); //$NON-NLS-1$
+
+        final NameValueCollection queryParameters = new NameValueCollection();
+        queryParameters.addIfNotNull("$top", top); //$NON-NLS-1$
+        queryParameters.addIfNotNull("$skip", skip); //$NON-NLS-1$
+        queryParameters.addIfNotNull("$compareTo", compareTo); //$NON-NLS-1$
+
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
+
+        return super.sendRequest(httpRequest, GitPullRequestIterationChanges.class);
+    }
+
+    /** 
+     * [Preview API 3.0-preview.1]
+     * 
+     * @param project 
+     *            Project ID
+     * @param repositoryId 
+     *            
+     * @param pullRequestId 
+     *            
+     * @param iterationId 
+     *            
+     * @param top 
+     *            
+     * @param skip 
+     *            
+     * @param compareTo 
+     *            
+     * @return GitPullRequestIterationChanges
+     */
+    public GitPullRequestIterationChanges getPullRequestIterationChanges(
+        final UUID project, 
+        final String repositoryId, 
+        final int pullRequestId, 
+        final int iterationId, 
+        final Integer top, 
+        final Integer skip, 
+        final Integer compareTo) { 
+
+        final UUID locationId = UUID.fromString("4216bdcf-b6b1-4d59-8b82-c34cc183fc8b"); //$NON-NLS-1$
+        final ApiResourceVersion apiVersion = new ApiResourceVersion("3.0-preview.1"); //$NON-NLS-1$
+
+        final Map<String, Object> routeValues = new HashMap<String, Object>();
+        routeValues.put("project", project); //$NON-NLS-1$
+        routeValues.put("repositoryId", repositoryId); //$NON-NLS-1$
+        routeValues.put("pullRequestId", pullRequestId); //$NON-NLS-1$
+        routeValues.put("iterationId", iterationId); //$NON-NLS-1$
+
+        final NameValueCollection queryParameters = new NameValueCollection();
+        queryParameters.addIfNotNull("$top", top); //$NON-NLS-1$
+        queryParameters.addIfNotNull("$skip", skip); //$NON-NLS-1$
+        queryParameters.addIfNotNull("$compareTo", compareTo); //$NON-NLS-1$
+
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
+
+        return super.sendRequest(httpRequest, GitPullRequestIterationChanges.class);
+    }
+
+    /** 
+     * [Preview API 3.0-preview.1]
+     * 
+     * @param project 
+     *            Project ID
+     * @param repositoryId 
+     *            
+     * @param pullRequestId 
+     *            
+     * @param iterationId 
+     *            
+     * @param top 
+     *            
+     * @param skip 
+     *            
+     * @param compareTo 
+     *            
+     * @return GitPullRequestIterationChanges
+     */
+    public GitPullRequestIterationChanges getPullRequestIterationChanges(
+        final UUID project, 
+        final UUID repositoryId, 
+        final int pullRequestId, 
+        final int iterationId, 
+        final Integer top, 
+        final Integer skip, 
+        final Integer compareTo) { 
+
+        final UUID locationId = UUID.fromString("4216bdcf-b6b1-4d59-8b82-c34cc183fc8b"); //$NON-NLS-1$
+        final ApiResourceVersion apiVersion = new ApiResourceVersion("3.0-preview.1"); //$NON-NLS-1$
+
+        final Map<String, Object> routeValues = new HashMap<String, Object>();
+        routeValues.put("project", project); //$NON-NLS-1$
+        routeValues.put("repositoryId", repositoryId); //$NON-NLS-1$
+        routeValues.put("pullRequestId", pullRequestId); //$NON-NLS-1$
+        routeValues.put("iterationId", iterationId); //$NON-NLS-1$
+
+        final NameValueCollection queryParameters = new NameValueCollection();
+        queryParameters.addIfNotNull("$top", top); //$NON-NLS-1$
+        queryParameters.addIfNotNull("$skip", skip); //$NON-NLS-1$
+        queryParameters.addIfNotNull("$compareTo", compareTo); //$NON-NLS-1$
+
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
+
+        return super.sendRequest(httpRequest, GitPullRequestIterationChanges.class);
+    }
+
+    /** 
+     * [Preview API 3.0-preview.1]
+     * 
+     * @param repositoryId 
+     *            
+     * @param pullRequestId 
+     *            
+     * @param iterationId 
+     *            
+     * @param top 
+     *            
+     * @param skip 
+     *            
+     * @param compareTo 
+     *            
+     * @return GitPullRequestIterationChanges
+     */
+    public GitPullRequestIterationChanges getPullRequestIterationChanges(
+        final String repositoryId, 
+        final int pullRequestId, 
+        final int iterationId, 
+        final Integer top, 
+        final Integer skip, 
+        final Integer compareTo) { 
+
+        final UUID locationId = UUID.fromString("4216bdcf-b6b1-4d59-8b82-c34cc183fc8b"); //$NON-NLS-1$
+        final ApiResourceVersion apiVersion = new ApiResourceVersion("3.0-preview.1"); //$NON-NLS-1$
+
+        final Map<String, Object> routeValues = new HashMap<String, Object>();
+        routeValues.put("repositoryId", repositoryId); //$NON-NLS-1$
+        routeValues.put("pullRequestId", pullRequestId); //$NON-NLS-1$
+        routeValues.put("iterationId", iterationId); //$NON-NLS-1$
+
+        final NameValueCollection queryParameters = new NameValueCollection();
+        queryParameters.addIfNotNull("$top", top); //$NON-NLS-1$
+        queryParameters.addIfNotNull("$skip", skip); //$NON-NLS-1$
+        queryParameters.addIfNotNull("$compareTo", compareTo); //$NON-NLS-1$
+
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
+
+        return super.sendRequest(httpRequest, GitPullRequestIterationChanges.class);
+    }
+
+    /** 
+     * [Preview API 3.0-preview.1]
+     * 
+     * @param repositoryId 
+     *            
+     * @param pullRequestId 
+     *            
+     * @param iterationId 
+     *            
+     * @param top 
+     *            
+     * @param skip 
+     *            
+     * @param compareTo 
+     *            
+     * @return GitPullRequestIterationChanges
+     */
+    public GitPullRequestIterationChanges getPullRequestIterationChanges(
+        final UUID repositoryId, 
+        final int pullRequestId, 
+        final int iterationId, 
+        final Integer top, 
+        final Integer skip, 
+        final Integer compareTo) { 
+
+        final UUID locationId = UUID.fromString("4216bdcf-b6b1-4d59-8b82-c34cc183fc8b"); //$NON-NLS-1$
+        final ApiResourceVersion apiVersion = new ApiResourceVersion("3.0-preview.1"); //$NON-NLS-1$
+
+        final Map<String, Object> routeValues = new HashMap<String, Object>();
+        routeValues.put("repositoryId", repositoryId); //$NON-NLS-1$
+        routeValues.put("pullRequestId", pullRequestId); //$NON-NLS-1$
+        routeValues.put("iterationId", iterationId); //$NON-NLS-1$
+
+        final NameValueCollection queryParameters = new NameValueCollection();
+        queryParameters.addIfNotNull("$top", top); //$NON-NLS-1$
+        queryParameters.addIfNotNull("$skip", skip); //$NON-NLS-1$
+        queryParameters.addIfNotNull("$compareTo", compareTo); //$NON-NLS-1$
+
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
+
+        return super.sendRequest(httpRequest, GitPullRequestIterationChanges.class);
+    }
+
+    /** 
+     * [Preview API 3.0-preview.1]
+     * 
      * @param repositoryId 
      *            
      * @param pullRequestId 
@@ -6202,11 +6500,11 @@ public abstract class GitHttpClientBase
         routeValues.put("pullRequestId", pullRequestId); //$NON-NLS-1$
         routeValues.put("iterationId", iterationId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, GitPullRequestIteration.class);
     }
@@ -6235,11 +6533,11 @@ public abstract class GitHttpClientBase
         routeValues.put("pullRequestId", pullRequestId); //$NON-NLS-1$
         routeValues.put("iterationId", iterationId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, GitPullRequestIteration.class);
     }
@@ -6272,11 +6570,11 @@ public abstract class GitHttpClientBase
         routeValues.put("pullRequestId", pullRequestId); //$NON-NLS-1$
         routeValues.put("iterationId", iterationId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, GitPullRequestIteration.class);
     }
@@ -6309,11 +6607,11 @@ public abstract class GitHttpClientBase
         routeValues.put("pullRequestId", pullRequestId); //$NON-NLS-1$
         routeValues.put("iterationId", iterationId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, GitPullRequestIteration.class);
     }
@@ -6346,11 +6644,11 @@ public abstract class GitHttpClientBase
         routeValues.put("pullRequestId", pullRequestId); //$NON-NLS-1$
         routeValues.put("iterationId", iterationId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, GitPullRequestIteration.class);
     }
@@ -6383,11 +6681,11 @@ public abstract class GitHttpClientBase
         routeValues.put("pullRequestId", pullRequestId); //$NON-NLS-1$
         routeValues.put("iterationId", iterationId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, GitPullRequestIteration.class);
     }
@@ -6422,12 +6720,12 @@ public abstract class GitHttpClientBase
         final NameValueCollection queryParameters = new NameValueCollection();
         queryParameters.addIfNotNull("includeCommits", includeCommits); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<GitPullRequestIteration>>() {});
     }
@@ -6462,12 +6760,12 @@ public abstract class GitHttpClientBase
         final NameValueCollection queryParameters = new NameValueCollection();
         queryParameters.addIfNotNull("includeCommits", includeCommits); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<GitPullRequestIteration>>() {});
     }
@@ -6502,12 +6800,12 @@ public abstract class GitHttpClientBase
         final NameValueCollection queryParameters = new NameValueCollection();
         queryParameters.addIfNotNull("includeCommits", includeCommits); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<GitPullRequestIteration>>() {});
     }
@@ -6542,12 +6840,12 @@ public abstract class GitHttpClientBase
         final NameValueCollection queryParameters = new NameValueCollection();
         queryParameters.addIfNotNull("includeCommits", includeCommits); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<GitPullRequestIteration>>() {});
     }
@@ -6578,12 +6876,12 @@ public abstract class GitHttpClientBase
         final NameValueCollection queryParameters = new NameValueCollection();
         queryParameters.addIfNotNull("includeCommits", includeCommits); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<GitPullRequestIteration>>() {});
     }
@@ -6614,12 +6912,12 @@ public abstract class GitHttpClientBase
         final NameValueCollection queryParameters = new NameValueCollection();
         queryParameters.addIfNotNull("includeCommits", includeCommits); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<GitPullRequestIteration>>() {});
     }
@@ -6643,13 +6941,13 @@ public abstract class GitHttpClientBase
         final Map<String, Object> routeValues = new HashMap<String, Object>();
         routeValues.put("repositoryId", repositoryId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.POST,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queries,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.POST,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queries,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, GitPullRequestQuery.class);
     }
@@ -6673,13 +6971,13 @@ public abstract class GitHttpClientBase
         final Map<String, Object> routeValues = new HashMap<String, Object>();
         routeValues.put("repositoryId", repositoryId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.POST,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queries,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.POST,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queries,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, GitPullRequestQuery.class);
     }
@@ -6707,13 +7005,13 @@ public abstract class GitHttpClientBase
         routeValues.put("project", project); //$NON-NLS-1$
         routeValues.put("repositoryId", repositoryId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.POST,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queries,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.POST,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queries,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, GitPullRequestQuery.class);
     }
@@ -6741,13 +7039,13 @@ public abstract class GitHttpClientBase
         routeValues.put("project", project); //$NON-NLS-1$
         routeValues.put("repositoryId", repositoryId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.POST,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queries,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.POST,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queries,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, GitPullRequestQuery.class);
     }
@@ -6775,13 +7073,13 @@ public abstract class GitHttpClientBase
         routeValues.put("project", project); //$NON-NLS-1$
         routeValues.put("repositoryId", repositoryId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.POST,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queries,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.POST,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queries,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, GitPullRequestQuery.class);
     }
@@ -6809,13 +7107,13 @@ public abstract class GitHttpClientBase
         routeValues.put("project", project); //$NON-NLS-1$
         routeValues.put("repositoryId", repositoryId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.POST,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queries,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.POST,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queries,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, GitPullRequestQuery.class);
     }
@@ -6847,13 +7145,13 @@ public abstract class GitHttpClientBase
         routeValues.put("pullRequestId", pullRequestId); //$NON-NLS-1$
         routeValues.put("reviewerId", reviewerId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.PUT,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       reviewer,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.PUT,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               reviewer,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, IdentityRefWithVote.class);
     }
@@ -6885,13 +7183,13 @@ public abstract class GitHttpClientBase
         routeValues.put("pullRequestId", pullRequestId); //$NON-NLS-1$
         routeValues.put("reviewerId", reviewerId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.PUT,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       reviewer,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.PUT,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               reviewer,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, IdentityRefWithVote.class);
     }
@@ -6927,13 +7225,13 @@ public abstract class GitHttpClientBase
         routeValues.put("pullRequestId", pullRequestId); //$NON-NLS-1$
         routeValues.put("reviewerId", reviewerId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.PUT,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       reviewer,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.PUT,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               reviewer,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, IdentityRefWithVote.class);
     }
@@ -6969,13 +7267,13 @@ public abstract class GitHttpClientBase
         routeValues.put("pullRequestId", pullRequestId); //$NON-NLS-1$
         routeValues.put("reviewerId", reviewerId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.PUT,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       reviewer,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.PUT,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               reviewer,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, IdentityRefWithVote.class);
     }
@@ -7011,13 +7309,13 @@ public abstract class GitHttpClientBase
         routeValues.put("pullRequestId", pullRequestId); //$NON-NLS-1$
         routeValues.put("reviewerId", reviewerId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.PUT,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       reviewer,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.PUT,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               reviewer,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, IdentityRefWithVote.class);
     }
@@ -7053,13 +7351,13 @@ public abstract class GitHttpClientBase
         routeValues.put("pullRequestId", pullRequestId); //$NON-NLS-1$
         routeValues.put("reviewerId", reviewerId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.PUT,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       reviewer,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.PUT,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               reviewer,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, IdentityRefWithVote.class);
     }
@@ -7087,13 +7385,13 @@ public abstract class GitHttpClientBase
         routeValues.put("repositoryId", repositoryId); //$NON-NLS-1$
         routeValues.put("pullRequestId", pullRequestId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.POST,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       reviewers,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.POST,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               reviewers,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<IdentityRefWithVote>>() {});
     }
@@ -7121,13 +7419,13 @@ public abstract class GitHttpClientBase
         routeValues.put("repositoryId", repositoryId); //$NON-NLS-1$
         routeValues.put("pullRequestId", pullRequestId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.POST,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       reviewers,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.POST,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               reviewers,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<IdentityRefWithVote>>() {});
     }
@@ -7159,13 +7457,13 @@ public abstract class GitHttpClientBase
         routeValues.put("repositoryId", repositoryId); //$NON-NLS-1$
         routeValues.put("pullRequestId", pullRequestId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.POST,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       reviewers,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.POST,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               reviewers,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<IdentityRefWithVote>>() {});
     }
@@ -7197,13 +7495,13 @@ public abstract class GitHttpClientBase
         routeValues.put("repositoryId", repositoryId); //$NON-NLS-1$
         routeValues.put("pullRequestId", pullRequestId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.POST,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       reviewers,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.POST,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               reviewers,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<IdentityRefWithVote>>() {});
     }
@@ -7235,13 +7533,13 @@ public abstract class GitHttpClientBase
         routeValues.put("repositoryId", repositoryId); //$NON-NLS-1$
         routeValues.put("pullRequestId", pullRequestId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.POST,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       reviewers,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.POST,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               reviewers,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<IdentityRefWithVote>>() {});
     }
@@ -7273,13 +7571,13 @@ public abstract class GitHttpClientBase
         routeValues.put("repositoryId", repositoryId); //$NON-NLS-1$
         routeValues.put("pullRequestId", pullRequestId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.POST,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       reviewers,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.POST,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               reviewers,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<IdentityRefWithVote>>() {});
     }
@@ -7307,11 +7605,11 @@ public abstract class GitHttpClientBase
         routeValues.put("pullRequestId", pullRequestId); //$NON-NLS-1$
         routeValues.put("reviewerId", reviewerId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.DELETE,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.DELETE,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         super.sendRequest(httpRequest);
     }
@@ -7339,11 +7637,11 @@ public abstract class GitHttpClientBase
         routeValues.put("pullRequestId", pullRequestId); //$NON-NLS-1$
         routeValues.put("reviewerId", reviewerId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.DELETE,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.DELETE,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         super.sendRequest(httpRequest);
     }
@@ -7375,11 +7673,11 @@ public abstract class GitHttpClientBase
         routeValues.put("pullRequestId", pullRequestId); //$NON-NLS-1$
         routeValues.put("reviewerId", reviewerId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.DELETE,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.DELETE,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         super.sendRequest(httpRequest);
     }
@@ -7411,11 +7709,11 @@ public abstract class GitHttpClientBase
         routeValues.put("pullRequestId", pullRequestId); //$NON-NLS-1$
         routeValues.put("reviewerId", reviewerId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.DELETE,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.DELETE,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         super.sendRequest(httpRequest);
     }
@@ -7447,11 +7745,11 @@ public abstract class GitHttpClientBase
         routeValues.put("pullRequestId", pullRequestId); //$NON-NLS-1$
         routeValues.put("reviewerId", reviewerId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.DELETE,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.DELETE,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         super.sendRequest(httpRequest);
     }
@@ -7483,11 +7781,11 @@ public abstract class GitHttpClientBase
         routeValues.put("pullRequestId", pullRequestId); //$NON-NLS-1$
         routeValues.put("reviewerId", reviewerId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.DELETE,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.DELETE,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         super.sendRequest(httpRequest);
     }
@@ -7516,11 +7814,11 @@ public abstract class GitHttpClientBase
         routeValues.put("pullRequestId", pullRequestId); //$NON-NLS-1$
         routeValues.put("reviewerId", reviewerId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, IdentityRefWithVote.class);
     }
@@ -7549,11 +7847,11 @@ public abstract class GitHttpClientBase
         routeValues.put("pullRequestId", pullRequestId); //$NON-NLS-1$
         routeValues.put("reviewerId", reviewerId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, IdentityRefWithVote.class);
     }
@@ -7586,11 +7884,11 @@ public abstract class GitHttpClientBase
         routeValues.put("pullRequestId", pullRequestId); //$NON-NLS-1$
         routeValues.put("reviewerId", reviewerId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, IdentityRefWithVote.class);
     }
@@ -7623,11 +7921,11 @@ public abstract class GitHttpClientBase
         routeValues.put("pullRequestId", pullRequestId); //$NON-NLS-1$
         routeValues.put("reviewerId", reviewerId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, IdentityRefWithVote.class);
     }
@@ -7660,11 +7958,11 @@ public abstract class GitHttpClientBase
         routeValues.put("pullRequestId", pullRequestId); //$NON-NLS-1$
         routeValues.put("reviewerId", reviewerId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, IdentityRefWithVote.class);
     }
@@ -7697,11 +7995,11 @@ public abstract class GitHttpClientBase
         routeValues.put("pullRequestId", pullRequestId); //$NON-NLS-1$
         routeValues.put("reviewerId", reviewerId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, IdentityRefWithVote.class);
     }
@@ -7726,11 +8024,11 @@ public abstract class GitHttpClientBase
         routeValues.put("repositoryId", repositoryId); //$NON-NLS-1$
         routeValues.put("pullRequestId", pullRequestId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<IdentityRefWithVote>>() {});
     }
@@ -7755,11 +8053,11 @@ public abstract class GitHttpClientBase
         routeValues.put("repositoryId", repositoryId); //$NON-NLS-1$
         routeValues.put("pullRequestId", pullRequestId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<IdentityRefWithVote>>() {});
     }
@@ -7788,11 +8086,11 @@ public abstract class GitHttpClientBase
         routeValues.put("repositoryId", repositoryId); //$NON-NLS-1$
         routeValues.put("pullRequestId", pullRequestId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<IdentityRefWithVote>>() {});
     }
@@ -7821,11 +8119,11 @@ public abstract class GitHttpClientBase
         routeValues.put("repositoryId", repositoryId); //$NON-NLS-1$
         routeValues.put("pullRequestId", pullRequestId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<IdentityRefWithVote>>() {});
     }
@@ -7854,11 +8152,11 @@ public abstract class GitHttpClientBase
         routeValues.put("repositoryId", repositoryId); //$NON-NLS-1$
         routeValues.put("pullRequestId", pullRequestId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<IdentityRefWithVote>>() {});
     }
@@ -7887,11 +8185,11 @@ public abstract class GitHttpClientBase
         routeValues.put("repositoryId", repositoryId); //$NON-NLS-1$
         routeValues.put("pullRequestId", pullRequestId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<IdentityRefWithVote>>() {});
     }
@@ -7911,11 +8209,11 @@ public abstract class GitHttpClientBase
         final Map<String, Object> routeValues = new HashMap<String, Object>();
         routeValues.put("pullRequestId", pullRequestId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, GitPullRequest.class);
     }
@@ -7954,12 +8252,12 @@ public abstract class GitHttpClientBase
         queryParameters.addIfNotNull("$skip", skip); //$NON-NLS-1$
         queryParameters.addIfNotNull("$top", top); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<GitPullRequest>>() {});
     }
@@ -7998,12 +8296,12 @@ public abstract class GitHttpClientBase
         queryParameters.addIfNotNull("$skip", skip); //$NON-NLS-1$
         queryParameters.addIfNotNull("$top", top); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<GitPullRequest>>() {});
     }
@@ -8027,13 +8325,13 @@ public abstract class GitHttpClientBase
         final Map<String, Object> routeValues = new HashMap<String, Object>();
         routeValues.put("repositoryId", repositoryId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.POST,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       gitPullRequestToCreate,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.POST,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               gitPullRequestToCreate,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, GitPullRequest.class);
     }
@@ -8057,13 +8355,13 @@ public abstract class GitHttpClientBase
         final Map<String, Object> routeValues = new HashMap<String, Object>();
         routeValues.put("repositoryId", repositoryId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.POST,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       gitPullRequestToCreate,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.POST,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               gitPullRequestToCreate,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, GitPullRequest.class);
     }
@@ -8091,13 +8389,13 @@ public abstract class GitHttpClientBase
         routeValues.put("project", project); //$NON-NLS-1$
         routeValues.put("repositoryId", repositoryId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.POST,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       gitPullRequestToCreate,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.POST,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               gitPullRequestToCreate,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, GitPullRequest.class);
     }
@@ -8125,13 +8423,13 @@ public abstract class GitHttpClientBase
         routeValues.put("project", project); //$NON-NLS-1$
         routeValues.put("repositoryId", repositoryId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.POST,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       gitPullRequestToCreate,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.POST,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               gitPullRequestToCreate,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, GitPullRequest.class);
     }
@@ -8159,13 +8457,13 @@ public abstract class GitHttpClientBase
         routeValues.put("project", project); //$NON-NLS-1$
         routeValues.put("repositoryId", repositoryId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.POST,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       gitPullRequestToCreate,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.POST,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               gitPullRequestToCreate,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, GitPullRequest.class);
     }
@@ -8193,13 +8491,13 @@ public abstract class GitHttpClientBase
         routeValues.put("project", project); //$NON-NLS-1$
         routeValues.put("repositoryId", repositoryId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.POST,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       gitPullRequestToCreate,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.POST,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               gitPullRequestToCreate,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, GitPullRequest.class);
     }
@@ -8250,12 +8548,12 @@ public abstract class GitHttpClientBase
         queryParameters.addIfNotNull("includeCommits", includeCommits); //$NON-NLS-1$
         queryParameters.addIfNotNull("includeWorkItemRefs", includeWorkItemRefs); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, GitPullRequest.class);
     }
@@ -8306,12 +8604,12 @@ public abstract class GitHttpClientBase
         queryParameters.addIfNotNull("includeCommits", includeCommits); //$NON-NLS-1$
         queryParameters.addIfNotNull("includeWorkItemRefs", includeWorkItemRefs); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, GitPullRequest.class);
     }
@@ -8362,12 +8660,12 @@ public abstract class GitHttpClientBase
         queryParameters.addIfNotNull("includeCommits", includeCommits); //$NON-NLS-1$
         queryParameters.addIfNotNull("includeWorkItemRefs", includeWorkItemRefs); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, GitPullRequest.class);
     }
@@ -8418,12 +8716,12 @@ public abstract class GitHttpClientBase
         queryParameters.addIfNotNull("includeCommits", includeCommits); //$NON-NLS-1$
         queryParameters.addIfNotNull("includeWorkItemRefs", includeWorkItemRefs); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, GitPullRequest.class);
     }
@@ -8470,12 +8768,12 @@ public abstract class GitHttpClientBase
         queryParameters.addIfNotNull("includeCommits", includeCommits); //$NON-NLS-1$
         queryParameters.addIfNotNull("includeWorkItemRefs", includeWorkItemRefs); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, GitPullRequest.class);
     }
@@ -8522,12 +8820,12 @@ public abstract class GitHttpClientBase
         queryParameters.addIfNotNull("includeCommits", includeCommits); //$NON-NLS-1$
         queryParameters.addIfNotNull("includeWorkItemRefs", includeWorkItemRefs); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, GitPullRequest.class);
     }
@@ -8570,12 +8868,12 @@ public abstract class GitHttpClientBase
         queryParameters.addIfNotNull("$skip", skip); //$NON-NLS-1$
         queryParameters.addIfNotNull("$top", top); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<GitPullRequest>>() {});
     }
@@ -8618,12 +8916,12 @@ public abstract class GitHttpClientBase
         queryParameters.addIfNotNull("$skip", skip); //$NON-NLS-1$
         queryParameters.addIfNotNull("$top", top); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<GitPullRequest>>() {});
     }
@@ -8666,12 +8964,12 @@ public abstract class GitHttpClientBase
         queryParameters.addIfNotNull("$skip", skip); //$NON-NLS-1$
         queryParameters.addIfNotNull("$top", top); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<GitPullRequest>>() {});
     }
@@ -8714,12 +9012,12 @@ public abstract class GitHttpClientBase
         queryParameters.addIfNotNull("$skip", skip); //$NON-NLS-1$
         queryParameters.addIfNotNull("$top", top); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<GitPullRequest>>() {});
     }
@@ -8758,12 +9056,12 @@ public abstract class GitHttpClientBase
         queryParameters.addIfNotNull("$skip", skip); //$NON-NLS-1$
         queryParameters.addIfNotNull("$top", top); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<GitPullRequest>>() {});
     }
@@ -8802,12 +9100,12 @@ public abstract class GitHttpClientBase
         queryParameters.addIfNotNull("$skip", skip); //$NON-NLS-1$
         queryParameters.addIfNotNull("$top", top); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<GitPullRequest>>() {});
     }
@@ -8835,13 +9133,13 @@ public abstract class GitHttpClientBase
         routeValues.put("repositoryId", repositoryId); //$NON-NLS-1$
         routeValues.put("pullRequestId", pullRequestId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.PATCH,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       gitPullRequestToUpdate,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.PATCH,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               gitPullRequestToUpdate,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, GitPullRequest.class);
     }
@@ -8869,13 +9167,13 @@ public abstract class GitHttpClientBase
         routeValues.put("repositoryId", repositoryId); //$NON-NLS-1$
         routeValues.put("pullRequestId", pullRequestId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.PATCH,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       gitPullRequestToUpdate,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.PATCH,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               gitPullRequestToUpdate,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, GitPullRequest.class);
     }
@@ -8907,13 +9205,13 @@ public abstract class GitHttpClientBase
         routeValues.put("repositoryId", repositoryId); //$NON-NLS-1$
         routeValues.put("pullRequestId", pullRequestId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.PATCH,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       gitPullRequestToUpdate,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.PATCH,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               gitPullRequestToUpdate,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, GitPullRequest.class);
     }
@@ -8945,13 +9243,13 @@ public abstract class GitHttpClientBase
         routeValues.put("repositoryId", repositoryId); //$NON-NLS-1$
         routeValues.put("pullRequestId", pullRequestId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.PATCH,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       gitPullRequestToUpdate,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.PATCH,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               gitPullRequestToUpdate,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, GitPullRequest.class);
     }
@@ -8983,13 +9281,13 @@ public abstract class GitHttpClientBase
         routeValues.put("repositoryId", repositoryId); //$NON-NLS-1$
         routeValues.put("pullRequestId", pullRequestId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.PATCH,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       gitPullRequestToUpdate,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.PATCH,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               gitPullRequestToUpdate,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, GitPullRequest.class);
     }
@@ -9021,13 +9319,13 @@ public abstract class GitHttpClientBase
         routeValues.put("repositoryId", repositoryId); //$NON-NLS-1$
         routeValues.put("pullRequestId", pullRequestId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.PATCH,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       gitPullRequestToUpdate,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.PATCH,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               gitPullRequestToUpdate,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, GitPullRequest.class);
     }
@@ -9059,13 +9357,13 @@ public abstract class GitHttpClientBase
         routeValues.put("pullRequestId", pullRequestId); //$NON-NLS-1$
         routeValues.put("iterationId", iterationId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.POST,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       status,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.POST,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               status,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, GitPullRequestStatus.class);
     }
@@ -9097,13 +9395,13 @@ public abstract class GitHttpClientBase
         routeValues.put("pullRequestId", pullRequestId); //$NON-NLS-1$
         routeValues.put("iterationId", iterationId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.POST,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       status,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.POST,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               status,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, GitPullRequestStatus.class);
     }
@@ -9139,13 +9437,13 @@ public abstract class GitHttpClientBase
         routeValues.put("pullRequestId", pullRequestId); //$NON-NLS-1$
         routeValues.put("iterationId", iterationId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.POST,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       status,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.POST,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               status,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, GitPullRequestStatus.class);
     }
@@ -9181,13 +9479,13 @@ public abstract class GitHttpClientBase
         routeValues.put("pullRequestId", pullRequestId); //$NON-NLS-1$
         routeValues.put("iterationId", iterationId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.POST,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       status,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.POST,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               status,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, GitPullRequestStatus.class);
     }
@@ -9223,13 +9521,13 @@ public abstract class GitHttpClientBase
         routeValues.put("pullRequestId", pullRequestId); //$NON-NLS-1$
         routeValues.put("iterationId", iterationId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.POST,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       status,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.POST,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               status,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, GitPullRequestStatus.class);
     }
@@ -9265,13 +9563,13 @@ public abstract class GitHttpClientBase
         routeValues.put("pullRequestId", pullRequestId); //$NON-NLS-1$
         routeValues.put("iterationId", iterationId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.POST,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       status,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.POST,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               status,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, GitPullRequestStatus.class);
     }
@@ -9304,11 +9602,11 @@ public abstract class GitHttpClientBase
         routeValues.put("iterationId", iterationId); //$NON-NLS-1$
         routeValues.put("statusId", statusId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, GitPullRequestStatus.class);
     }
@@ -9341,11 +9639,11 @@ public abstract class GitHttpClientBase
         routeValues.put("iterationId", iterationId); //$NON-NLS-1$
         routeValues.put("statusId", statusId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, GitPullRequestStatus.class);
     }
@@ -9382,11 +9680,11 @@ public abstract class GitHttpClientBase
         routeValues.put("iterationId", iterationId); //$NON-NLS-1$
         routeValues.put("statusId", statusId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, GitPullRequestStatus.class);
     }
@@ -9423,11 +9721,11 @@ public abstract class GitHttpClientBase
         routeValues.put("iterationId", iterationId); //$NON-NLS-1$
         routeValues.put("statusId", statusId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, GitPullRequestStatus.class);
     }
@@ -9464,11 +9762,11 @@ public abstract class GitHttpClientBase
         routeValues.put("iterationId", iterationId); //$NON-NLS-1$
         routeValues.put("statusId", statusId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, GitPullRequestStatus.class);
     }
@@ -9505,11 +9803,11 @@ public abstract class GitHttpClientBase
         routeValues.put("iterationId", iterationId); //$NON-NLS-1$
         routeValues.put("statusId", statusId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, GitPullRequestStatus.class);
     }
@@ -9538,11 +9836,11 @@ public abstract class GitHttpClientBase
         routeValues.put("pullRequestId", pullRequestId); //$NON-NLS-1$
         routeValues.put("iterationId", iterationId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<GitPullRequestStatus>>() {});
     }
@@ -9571,11 +9869,11 @@ public abstract class GitHttpClientBase
         routeValues.put("pullRequestId", pullRequestId); //$NON-NLS-1$
         routeValues.put("iterationId", iterationId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<GitPullRequestStatus>>() {});
     }
@@ -9608,11 +9906,11 @@ public abstract class GitHttpClientBase
         routeValues.put("pullRequestId", pullRequestId); //$NON-NLS-1$
         routeValues.put("iterationId", iterationId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<GitPullRequestStatus>>() {});
     }
@@ -9645,11 +9943,11 @@ public abstract class GitHttpClientBase
         routeValues.put("pullRequestId", pullRequestId); //$NON-NLS-1$
         routeValues.put("iterationId", iterationId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<GitPullRequestStatus>>() {});
     }
@@ -9682,11 +9980,11 @@ public abstract class GitHttpClientBase
         routeValues.put("pullRequestId", pullRequestId); //$NON-NLS-1$
         routeValues.put("iterationId", iterationId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<GitPullRequestStatus>>() {});
     }
@@ -9719,11 +10017,11 @@ public abstract class GitHttpClientBase
         routeValues.put("pullRequestId", pullRequestId); //$NON-NLS-1$
         routeValues.put("iterationId", iterationId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<GitPullRequestStatus>>() {});
     }
@@ -9759,13 +10057,13 @@ public abstract class GitHttpClientBase
         routeValues.put("iterationId", iterationId); //$NON-NLS-1$
         routeValues.put("statusId", statusId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.PATCH,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       status,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.PATCH,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               status,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, GitPullRequestStatus.class);
     }
@@ -9801,13 +10099,13 @@ public abstract class GitHttpClientBase
         routeValues.put("iterationId", iterationId); //$NON-NLS-1$
         routeValues.put("statusId", statusId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.PATCH,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       status,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.PATCH,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               status,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, GitPullRequestStatus.class);
     }
@@ -9847,13 +10145,13 @@ public abstract class GitHttpClientBase
         routeValues.put("iterationId", iterationId); //$NON-NLS-1$
         routeValues.put("statusId", statusId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.PATCH,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       status,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.PATCH,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               status,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, GitPullRequestStatus.class);
     }
@@ -9893,13 +10191,13 @@ public abstract class GitHttpClientBase
         routeValues.put("iterationId", iterationId); //$NON-NLS-1$
         routeValues.put("statusId", statusId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.PATCH,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       status,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.PATCH,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               status,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, GitPullRequestStatus.class);
     }
@@ -9939,13 +10237,13 @@ public abstract class GitHttpClientBase
         routeValues.put("iterationId", iterationId); //$NON-NLS-1$
         routeValues.put("statusId", statusId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.PATCH,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       status,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.PATCH,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               status,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, GitPullRequestStatus.class);
     }
@@ -9985,13 +10283,13 @@ public abstract class GitHttpClientBase
         routeValues.put("iterationId", iterationId); //$NON-NLS-1$
         routeValues.put("statusId", statusId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.PATCH,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       status,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.PATCH,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               status,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, GitPullRequestStatus.class);
     }
@@ -10019,13 +10317,13 @@ public abstract class GitHttpClientBase
         routeValues.put("repositoryId", repositoryId); //$NON-NLS-1$
         routeValues.put("pullRequestId", pullRequestId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.POST,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       status,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.POST,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               status,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, GitPullRequestStatus.class);
     }
@@ -10053,13 +10351,13 @@ public abstract class GitHttpClientBase
         routeValues.put("repositoryId", repositoryId); //$NON-NLS-1$
         routeValues.put("pullRequestId", pullRequestId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.POST,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       status,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.POST,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               status,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, GitPullRequestStatus.class);
     }
@@ -10091,13 +10389,13 @@ public abstract class GitHttpClientBase
         routeValues.put("repositoryId", repositoryId); //$NON-NLS-1$
         routeValues.put("pullRequestId", pullRequestId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.POST,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       status,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.POST,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               status,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, GitPullRequestStatus.class);
     }
@@ -10129,13 +10427,13 @@ public abstract class GitHttpClientBase
         routeValues.put("repositoryId", repositoryId); //$NON-NLS-1$
         routeValues.put("pullRequestId", pullRequestId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.POST,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       status,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.POST,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               status,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, GitPullRequestStatus.class);
     }
@@ -10167,13 +10465,13 @@ public abstract class GitHttpClientBase
         routeValues.put("repositoryId", repositoryId); //$NON-NLS-1$
         routeValues.put("pullRequestId", pullRequestId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.POST,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       status,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.POST,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               status,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, GitPullRequestStatus.class);
     }
@@ -10205,13 +10503,13 @@ public abstract class GitHttpClientBase
         routeValues.put("repositoryId", repositoryId); //$NON-NLS-1$
         routeValues.put("pullRequestId", pullRequestId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.POST,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       status,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.POST,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               status,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, GitPullRequestStatus.class);
     }
@@ -10240,11 +10538,11 @@ public abstract class GitHttpClientBase
         routeValues.put("pullRequestId", pullRequestId); //$NON-NLS-1$
         routeValues.put("statusId", statusId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, GitPullRequestStatus.class);
     }
@@ -10273,11 +10571,11 @@ public abstract class GitHttpClientBase
         routeValues.put("pullRequestId", pullRequestId); //$NON-NLS-1$
         routeValues.put("statusId", statusId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, GitPullRequestStatus.class);
     }
@@ -10310,11 +10608,11 @@ public abstract class GitHttpClientBase
         routeValues.put("pullRequestId", pullRequestId); //$NON-NLS-1$
         routeValues.put("statusId", statusId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, GitPullRequestStatus.class);
     }
@@ -10347,11 +10645,11 @@ public abstract class GitHttpClientBase
         routeValues.put("pullRequestId", pullRequestId); //$NON-NLS-1$
         routeValues.put("statusId", statusId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, GitPullRequestStatus.class);
     }
@@ -10384,11 +10682,11 @@ public abstract class GitHttpClientBase
         routeValues.put("pullRequestId", pullRequestId); //$NON-NLS-1$
         routeValues.put("statusId", statusId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, GitPullRequestStatus.class);
     }
@@ -10421,11 +10719,11 @@ public abstract class GitHttpClientBase
         routeValues.put("pullRequestId", pullRequestId); //$NON-NLS-1$
         routeValues.put("statusId", statusId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, GitPullRequestStatus.class);
     }
@@ -10450,11 +10748,11 @@ public abstract class GitHttpClientBase
         routeValues.put("repositoryId", repositoryId); //$NON-NLS-1$
         routeValues.put("pullRequestId", pullRequestId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<GitPullRequestStatus>>() {});
     }
@@ -10479,11 +10777,11 @@ public abstract class GitHttpClientBase
         routeValues.put("repositoryId", repositoryId); //$NON-NLS-1$
         routeValues.put("pullRequestId", pullRequestId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<GitPullRequestStatus>>() {});
     }
@@ -10512,11 +10810,11 @@ public abstract class GitHttpClientBase
         routeValues.put("repositoryId", repositoryId); //$NON-NLS-1$
         routeValues.put("pullRequestId", pullRequestId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<GitPullRequestStatus>>() {});
     }
@@ -10545,11 +10843,11 @@ public abstract class GitHttpClientBase
         routeValues.put("repositoryId", repositoryId); //$NON-NLS-1$
         routeValues.put("pullRequestId", pullRequestId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<GitPullRequestStatus>>() {});
     }
@@ -10578,11 +10876,11 @@ public abstract class GitHttpClientBase
         routeValues.put("repositoryId", repositoryId); //$NON-NLS-1$
         routeValues.put("pullRequestId", pullRequestId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<GitPullRequestStatus>>() {});
     }
@@ -10611,11 +10909,11 @@ public abstract class GitHttpClientBase
         routeValues.put("repositoryId", repositoryId); //$NON-NLS-1$
         routeValues.put("pullRequestId", pullRequestId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<GitPullRequestStatus>>() {});
     }
@@ -10647,13 +10945,13 @@ public abstract class GitHttpClientBase
         routeValues.put("pullRequestId", pullRequestId); //$NON-NLS-1$
         routeValues.put("statusId", statusId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.PATCH,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       status,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.PATCH,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               status,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, GitPullRequestStatus.class);
     }
@@ -10685,13 +10983,13 @@ public abstract class GitHttpClientBase
         routeValues.put("pullRequestId", pullRequestId); //$NON-NLS-1$
         routeValues.put("statusId", statusId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.PATCH,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       status,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.PATCH,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               status,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, GitPullRequestStatus.class);
     }
@@ -10727,13 +11025,13 @@ public abstract class GitHttpClientBase
         routeValues.put("pullRequestId", pullRequestId); //$NON-NLS-1$
         routeValues.put("statusId", statusId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.PATCH,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       status,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.PATCH,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               status,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, GitPullRequestStatus.class);
     }
@@ -10769,13 +11067,13 @@ public abstract class GitHttpClientBase
         routeValues.put("pullRequestId", pullRequestId); //$NON-NLS-1$
         routeValues.put("statusId", statusId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.PATCH,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       status,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.PATCH,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               status,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, GitPullRequestStatus.class);
     }
@@ -10811,13 +11109,13 @@ public abstract class GitHttpClientBase
         routeValues.put("pullRequestId", pullRequestId); //$NON-NLS-1$
         routeValues.put("statusId", statusId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.PATCH,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       status,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.PATCH,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               status,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, GitPullRequestStatus.class);
     }
@@ -10853,13 +11151,13 @@ public abstract class GitHttpClientBase
         routeValues.put("pullRequestId", pullRequestId); //$NON-NLS-1$
         routeValues.put("statusId", statusId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.PATCH,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       status,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.PATCH,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               status,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, GitPullRequestStatus.class);
     }
@@ -10887,13 +11185,13 @@ public abstract class GitHttpClientBase
         routeValues.put("repositoryId", repositoryId); //$NON-NLS-1$
         routeValues.put("pullRequestId", pullRequestId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.POST,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       commentThread,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.POST,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               commentThread,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, GitPullRequestCommentThread.class);
     }
@@ -10921,13 +11219,13 @@ public abstract class GitHttpClientBase
         routeValues.put("repositoryId", repositoryId); //$NON-NLS-1$
         routeValues.put("pullRequestId", pullRequestId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.POST,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       commentThread,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.POST,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               commentThread,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, GitPullRequestCommentThread.class);
     }
@@ -10959,13 +11257,13 @@ public abstract class GitHttpClientBase
         routeValues.put("repositoryId", repositoryId); //$NON-NLS-1$
         routeValues.put("pullRequestId", pullRequestId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.POST,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       commentThread,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.POST,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               commentThread,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, GitPullRequestCommentThread.class);
     }
@@ -10997,13 +11295,13 @@ public abstract class GitHttpClientBase
         routeValues.put("repositoryId", repositoryId); //$NON-NLS-1$
         routeValues.put("pullRequestId", pullRequestId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.POST,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       commentThread,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.POST,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               commentThread,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, GitPullRequestCommentThread.class);
     }
@@ -11035,13 +11333,13 @@ public abstract class GitHttpClientBase
         routeValues.put("repositoryId", repositoryId); //$NON-NLS-1$
         routeValues.put("pullRequestId", pullRequestId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.POST,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       commentThread,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.POST,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               commentThread,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, GitPullRequestCommentThread.class);
     }
@@ -11073,13 +11371,13 @@ public abstract class GitHttpClientBase
         routeValues.put("repositoryId", repositoryId); //$NON-NLS-1$
         routeValues.put("pullRequestId", pullRequestId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.POST,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       commentThread,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.POST,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               commentThread,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, GitPullRequestCommentThread.class);
     }
@@ -11108,11 +11406,11 @@ public abstract class GitHttpClientBase
         routeValues.put("pullRequestId", pullRequestId); //$NON-NLS-1$
         routeValues.put("threadId", threadId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, GitPullRequestCommentThread.class);
     }
@@ -11141,11 +11439,11 @@ public abstract class GitHttpClientBase
         routeValues.put("pullRequestId", pullRequestId); //$NON-NLS-1$
         routeValues.put("threadId", threadId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, GitPullRequestCommentThread.class);
     }
@@ -11178,11 +11476,11 @@ public abstract class GitHttpClientBase
         routeValues.put("pullRequestId", pullRequestId); //$NON-NLS-1$
         routeValues.put("threadId", threadId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, GitPullRequestCommentThread.class);
     }
@@ -11215,11 +11513,11 @@ public abstract class GitHttpClientBase
         routeValues.put("pullRequestId", pullRequestId); //$NON-NLS-1$
         routeValues.put("threadId", threadId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, GitPullRequestCommentThread.class);
     }
@@ -11252,11 +11550,11 @@ public abstract class GitHttpClientBase
         routeValues.put("pullRequestId", pullRequestId); //$NON-NLS-1$
         routeValues.put("threadId", threadId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, GitPullRequestCommentThread.class);
     }
@@ -11289,11 +11587,11 @@ public abstract class GitHttpClientBase
         routeValues.put("pullRequestId", pullRequestId); //$NON-NLS-1$
         routeValues.put("threadId", threadId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, GitPullRequestCommentThread.class);
     }
@@ -11318,11 +11616,11 @@ public abstract class GitHttpClientBase
         routeValues.put("repositoryId", repositoryId); //$NON-NLS-1$
         routeValues.put("pullRequestId", pullRequestId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<GitPullRequestCommentThread>>() {});
     }
@@ -11347,11 +11645,11 @@ public abstract class GitHttpClientBase
         routeValues.put("repositoryId", repositoryId); //$NON-NLS-1$
         routeValues.put("pullRequestId", pullRequestId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<GitPullRequestCommentThread>>() {});
     }
@@ -11380,11 +11678,11 @@ public abstract class GitHttpClientBase
         routeValues.put("repositoryId", repositoryId); //$NON-NLS-1$
         routeValues.put("pullRequestId", pullRequestId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<GitPullRequestCommentThread>>() {});
     }
@@ -11413,11 +11711,11 @@ public abstract class GitHttpClientBase
         routeValues.put("repositoryId", repositoryId); //$NON-NLS-1$
         routeValues.put("pullRequestId", pullRequestId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<GitPullRequestCommentThread>>() {});
     }
@@ -11446,11 +11744,11 @@ public abstract class GitHttpClientBase
         routeValues.put("repositoryId", repositoryId); //$NON-NLS-1$
         routeValues.put("pullRequestId", pullRequestId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<GitPullRequestCommentThread>>() {});
     }
@@ -11479,11 +11777,11 @@ public abstract class GitHttpClientBase
         routeValues.put("repositoryId", repositoryId); //$NON-NLS-1$
         routeValues.put("pullRequestId", pullRequestId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<GitPullRequestCommentThread>>() {});
     }
@@ -11515,13 +11813,13 @@ public abstract class GitHttpClientBase
         routeValues.put("pullRequestId", pullRequestId); //$NON-NLS-1$
         routeValues.put("threadId", threadId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.PATCH,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       commentThread,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.PATCH,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               commentThread,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, GitPullRequestCommentThread.class);
     }
@@ -11553,13 +11851,13 @@ public abstract class GitHttpClientBase
         routeValues.put("pullRequestId", pullRequestId); //$NON-NLS-1$
         routeValues.put("threadId", threadId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.PATCH,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       commentThread,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.PATCH,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               commentThread,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, GitPullRequestCommentThread.class);
     }
@@ -11595,13 +11893,13 @@ public abstract class GitHttpClientBase
         routeValues.put("pullRequestId", pullRequestId); //$NON-NLS-1$
         routeValues.put("threadId", threadId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.PATCH,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       commentThread,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.PATCH,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               commentThread,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, GitPullRequestCommentThread.class);
     }
@@ -11637,13 +11935,13 @@ public abstract class GitHttpClientBase
         routeValues.put("pullRequestId", pullRequestId); //$NON-NLS-1$
         routeValues.put("threadId", threadId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.PATCH,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       commentThread,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.PATCH,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               commentThread,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, GitPullRequestCommentThread.class);
     }
@@ -11679,13 +11977,13 @@ public abstract class GitHttpClientBase
         routeValues.put("pullRequestId", pullRequestId); //$NON-NLS-1$
         routeValues.put("threadId", threadId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.PATCH,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       commentThread,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.PATCH,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               commentThread,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, GitPullRequestCommentThread.class);
     }
@@ -11721,13 +12019,13 @@ public abstract class GitHttpClientBase
         routeValues.put("pullRequestId", pullRequestId); //$NON-NLS-1$
         routeValues.put("threadId", threadId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.PATCH,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       commentThread,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.PATCH,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               commentThread,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, GitPullRequestCommentThread.class);
     }
@@ -11752,11 +12050,11 @@ public abstract class GitHttpClientBase
         routeValues.put("repositoryId", repositoryId); //$NON-NLS-1$
         routeValues.put("pullRequestId", pullRequestId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<AssociatedWorkItem>>() {});
     }
@@ -11781,11 +12079,11 @@ public abstract class GitHttpClientBase
         routeValues.put("repositoryId", repositoryId); //$NON-NLS-1$
         routeValues.put("pullRequestId", pullRequestId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<AssociatedWorkItem>>() {});
     }
@@ -11814,11 +12112,11 @@ public abstract class GitHttpClientBase
         routeValues.put("repositoryId", repositoryId); //$NON-NLS-1$
         routeValues.put("pullRequestId", pullRequestId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<AssociatedWorkItem>>() {});
     }
@@ -11847,11 +12145,11 @@ public abstract class GitHttpClientBase
         routeValues.put("repositoryId", repositoryId); //$NON-NLS-1$
         routeValues.put("pullRequestId", pullRequestId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<AssociatedWorkItem>>() {});
     }
@@ -11880,11 +12178,11 @@ public abstract class GitHttpClientBase
         routeValues.put("repositoryId", repositoryId); //$NON-NLS-1$
         routeValues.put("pullRequestId", pullRequestId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<AssociatedWorkItem>>() {});
     }
@@ -11913,11 +12211,11 @@ public abstract class GitHttpClientBase
         routeValues.put("repositoryId", repositoryId); //$NON-NLS-1$
         routeValues.put("pullRequestId", pullRequestId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<AssociatedWorkItem>>() {});
     }
@@ -11941,13 +12239,13 @@ public abstract class GitHttpClientBase
         final Map<String, Object> routeValues = new HashMap<String, Object>();
         routeValues.put("repositoryId", repositoryId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.POST,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       push,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.POST,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               push,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, GitPush.class);
     }
@@ -11971,13 +12269,13 @@ public abstract class GitHttpClientBase
         final Map<String, Object> routeValues = new HashMap<String, Object>();
         routeValues.put("repositoryId", repositoryId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.POST,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       push,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.POST,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               push,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, GitPush.class);
     }
@@ -12005,13 +12303,13 @@ public abstract class GitHttpClientBase
         routeValues.put("project", project); //$NON-NLS-1$
         routeValues.put("repositoryId", repositoryId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.POST,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       push,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.POST,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               push,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, GitPush.class);
     }
@@ -12039,13 +12337,13 @@ public abstract class GitHttpClientBase
         routeValues.put("project", project); //$NON-NLS-1$
         routeValues.put("repositoryId", repositoryId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.POST,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       push,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.POST,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               push,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, GitPush.class);
     }
@@ -12073,13 +12371,13 @@ public abstract class GitHttpClientBase
         routeValues.put("project", project); //$NON-NLS-1$
         routeValues.put("repositoryId", repositoryId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.POST,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       push,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.POST,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               push,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, GitPush.class);
     }
@@ -12107,13 +12405,13 @@ public abstract class GitHttpClientBase
         routeValues.put("project", project); //$NON-NLS-1$
         routeValues.put("repositoryId", repositoryId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.POST,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       push,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.POST,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               push,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, GitPush.class);
     }
@@ -12152,12 +12450,12 @@ public abstract class GitHttpClientBase
         queryParameters.addIfNotNull("includeCommits", includeCommits); //$NON-NLS-1$
         queryParameters.addIfNotNull("includeRefUpdates", includeRefUpdates); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, GitPush.class);
     }
@@ -12196,12 +12494,12 @@ public abstract class GitHttpClientBase
         queryParameters.addIfNotNull("includeCommits", includeCommits); //$NON-NLS-1$
         queryParameters.addIfNotNull("includeRefUpdates", includeRefUpdates); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, GitPush.class);
     }
@@ -12240,12 +12538,12 @@ public abstract class GitHttpClientBase
         queryParameters.addIfNotNull("includeCommits", includeCommits); //$NON-NLS-1$
         queryParameters.addIfNotNull("includeRefUpdates", includeRefUpdates); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, GitPush.class);
     }
@@ -12284,12 +12582,12 @@ public abstract class GitHttpClientBase
         queryParameters.addIfNotNull("includeCommits", includeCommits); //$NON-NLS-1$
         queryParameters.addIfNotNull("includeRefUpdates", includeRefUpdates); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, GitPush.class);
     }
@@ -12324,12 +12622,12 @@ public abstract class GitHttpClientBase
         queryParameters.addIfNotNull("includeCommits", includeCommits); //$NON-NLS-1$
         queryParameters.addIfNotNull("includeRefUpdates", includeRefUpdates); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, GitPush.class);
     }
@@ -12364,12 +12662,12 @@ public abstract class GitHttpClientBase
         queryParameters.addIfNotNull("includeCommits", includeCommits); //$NON-NLS-1$
         queryParameters.addIfNotNull("includeRefUpdates", includeRefUpdates); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, GitPush.class);
     }
@@ -12408,12 +12706,12 @@ public abstract class GitHttpClientBase
         queryParameters.addIfNotNull("$top", top); //$NON-NLS-1$
         addModelAsQueryParams(queryParameters, searchCriteria);
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<GitPush>>() {});
     }
@@ -12452,12 +12750,12 @@ public abstract class GitHttpClientBase
         queryParameters.addIfNotNull("$top", top); //$NON-NLS-1$
         addModelAsQueryParams(queryParameters, searchCriteria);
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<GitPush>>() {});
     }
@@ -12496,12 +12794,12 @@ public abstract class GitHttpClientBase
         queryParameters.addIfNotNull("$top", top); //$NON-NLS-1$
         addModelAsQueryParams(queryParameters, searchCriteria);
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<GitPush>>() {});
     }
@@ -12540,12 +12838,12 @@ public abstract class GitHttpClientBase
         queryParameters.addIfNotNull("$top", top); //$NON-NLS-1$
         addModelAsQueryParams(queryParameters, searchCriteria);
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<GitPush>>() {});
     }
@@ -12580,12 +12878,12 @@ public abstract class GitHttpClientBase
         queryParameters.addIfNotNull("$top", top); //$NON-NLS-1$
         addModelAsQueryParams(queryParameters, searchCriteria);
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<GitPush>>() {});
     }
@@ -12620,12 +12918,12 @@ public abstract class GitHttpClientBase
         queryParameters.addIfNotNull("$top", top); //$NON-NLS-1$
         addModelAsQueryParams(queryParameters, searchCriteria);
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<GitPush>>() {});
     }
@@ -12652,13 +12950,13 @@ public abstract class GitHttpClientBase
         routeValues.put("project", project); //$NON-NLS-1$
         routeValues.put("repositoryId", repositoryId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.POST,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       refLockRequest,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.POST,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               refLockRequest,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         super.sendRequest(httpRequest);
     }
@@ -12685,13 +12983,13 @@ public abstract class GitHttpClientBase
         routeValues.put("project", project); //$NON-NLS-1$
         routeValues.put("repositoryId", repositoryId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.POST,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       refLockRequest,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.POST,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               refLockRequest,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         super.sendRequest(httpRequest);
     }
@@ -12718,13 +13016,13 @@ public abstract class GitHttpClientBase
         routeValues.put("project", project); //$NON-NLS-1$
         routeValues.put("repositoryId", repositoryId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.POST,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       refLockRequest,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.POST,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               refLockRequest,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         super.sendRequest(httpRequest);
     }
@@ -12751,13 +13049,13 @@ public abstract class GitHttpClientBase
         routeValues.put("project", project); //$NON-NLS-1$
         routeValues.put("repositoryId", repositoryId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.POST,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       refLockRequest,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.POST,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               refLockRequest,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         super.sendRequest(httpRequest);
     }
@@ -12792,12 +13090,12 @@ public abstract class GitHttpClientBase
         queryParameters.addIfNotEmpty("filter", filter); //$NON-NLS-1$
         queryParameters.addIfNotNull("includeLinks", includeLinks); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<GitRef>>() {});
     }
@@ -12832,12 +13130,12 @@ public abstract class GitHttpClientBase
         queryParameters.addIfNotEmpty("filter", filter); //$NON-NLS-1$
         queryParameters.addIfNotNull("includeLinks", includeLinks); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<GitRef>>() {});
     }
@@ -12872,12 +13170,12 @@ public abstract class GitHttpClientBase
         queryParameters.addIfNotEmpty("filter", filter); //$NON-NLS-1$
         queryParameters.addIfNotNull("includeLinks", includeLinks); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<GitRef>>() {});
     }
@@ -12912,12 +13210,12 @@ public abstract class GitHttpClientBase
         queryParameters.addIfNotEmpty("filter", filter); //$NON-NLS-1$
         queryParameters.addIfNotNull("includeLinks", includeLinks); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<GitRef>>() {});
     }
@@ -12948,12 +13246,12 @@ public abstract class GitHttpClientBase
         queryParameters.addIfNotEmpty("filter", filter); //$NON-NLS-1$
         queryParameters.addIfNotNull("includeLinks", includeLinks); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<GitRef>>() {});
     }
@@ -12984,12 +13282,12 @@ public abstract class GitHttpClientBase
         queryParameters.addIfNotEmpty("filter", filter); //$NON-NLS-1$
         queryParameters.addIfNotNull("includeLinks", includeLinks); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<GitRef>>() {});
     }
@@ -13019,14 +13317,14 @@ public abstract class GitHttpClientBase
         final NameValueCollection queryParameters = new NameValueCollection();
         queryParameters.addIfNotEmpty("projectId", projectId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.POST,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       refUpdates,
-                                                       APPLICATION_JSON_TYPE,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.POST,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               refUpdates,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<GitRefUpdateResult>>() {});
     }
@@ -13056,14 +13354,14 @@ public abstract class GitHttpClientBase
         final NameValueCollection queryParameters = new NameValueCollection();
         queryParameters.addIfNotEmpty("projectId", projectId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.POST,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       refUpdates,
-                                                       APPLICATION_JSON_TYPE,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.POST,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               refUpdates,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<GitRefUpdateResult>>() {});
     }
@@ -13097,14 +13395,14 @@ public abstract class GitHttpClientBase
         final NameValueCollection queryParameters = new NameValueCollection();
         queryParameters.addIfNotEmpty("projectId", projectId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.POST,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       refUpdates,
-                                                       APPLICATION_JSON_TYPE,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.POST,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               refUpdates,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<GitRefUpdateResult>>() {});
     }
@@ -13138,14 +13436,14 @@ public abstract class GitHttpClientBase
         final NameValueCollection queryParameters = new NameValueCollection();
         queryParameters.addIfNotEmpty("projectId", projectId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.POST,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       refUpdates,
-                                                       APPLICATION_JSON_TYPE,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.POST,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               refUpdates,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<GitRefUpdateResult>>() {});
     }
@@ -13179,14 +13477,14 @@ public abstract class GitHttpClientBase
         final NameValueCollection queryParameters = new NameValueCollection();
         queryParameters.addIfNotEmpty("projectId", projectId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.POST,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       refUpdates,
-                                                       APPLICATION_JSON_TYPE,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.POST,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               refUpdates,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<GitRefUpdateResult>>() {});
     }
@@ -13220,14 +13518,14 @@ public abstract class GitHttpClientBase
         final NameValueCollection queryParameters = new NameValueCollection();
         queryParameters.addIfNotEmpty("projectId", projectId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.POST,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       refUpdates,
-                                                       APPLICATION_JSON_TYPE,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.POST,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               refUpdates,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<GitRefUpdateResult>>() {});
     }
@@ -13251,13 +13549,13 @@ public abstract class GitHttpClientBase
         final Map<String, Object> routeValues = new HashMap<String, Object>();
         routeValues.put("project", project); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.POST,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       favorite,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.POST,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               favorite,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, GitRefFavorite.class);
     }
@@ -13281,13 +13579,13 @@ public abstract class GitHttpClientBase
         final Map<String, Object> routeValues = new HashMap<String, Object>();
         routeValues.put("project", project); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.POST,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       favorite,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.POST,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               favorite,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, GitRefFavorite.class);
     }
@@ -13311,11 +13609,11 @@ public abstract class GitHttpClientBase
         routeValues.put("project", project); //$NON-NLS-1$
         routeValues.put("favoriteId", favoriteId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.DELETE,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.DELETE,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         super.sendRequest(httpRequest);
     }
@@ -13339,11 +13637,11 @@ public abstract class GitHttpClientBase
         routeValues.put("project", project); //$NON-NLS-1$
         routeValues.put("favoriteId", favoriteId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.DELETE,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.DELETE,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         super.sendRequest(httpRequest);
     }
@@ -13368,11 +13666,11 @@ public abstract class GitHttpClientBase
         routeValues.put("project", project); //$NON-NLS-1$
         routeValues.put("favoriteId", favoriteId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, GitRefFavorite.class);
     }
@@ -13397,11 +13695,11 @@ public abstract class GitHttpClientBase
         routeValues.put("project", project); //$NON-NLS-1$
         routeValues.put("favoriteId", favoriteId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, GitRefFavorite.class);
     }
@@ -13432,12 +13730,12 @@ public abstract class GitHttpClientBase
         queryParameters.addIfNotEmpty("repositoryId", repositoryId); //$NON-NLS-1$
         queryParameters.addIfNotEmpty("identityId", identityId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<GitRefFavorite>>() {});
     }
@@ -13468,12 +13766,12 @@ public abstract class GitHttpClientBase
         queryParameters.addIfNotEmpty("repositoryId", repositoryId); //$NON-NLS-1$
         queryParameters.addIfNotEmpty("identityId", identityId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<GitRefFavorite>>() {});
     }
@@ -13490,12 +13788,12 @@ public abstract class GitHttpClientBase
         final UUID locationId = UUID.fromString("225f7195-f9c7-4d14-ab28-a83f7ff77e1f"); //$NON-NLS-1$
         final ApiResourceVersion apiVersion = new ApiResourceVersion("3.0-preview.1"); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.POST,
-                                                       locationId,
-                                                       apiVersion,
-                                                       gitRepositoryToCreate,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.POST,
+                                                               locationId,
+                                                               apiVersion,
+                                                               gitRepositoryToCreate,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, GitRepository.class);
     }
@@ -13519,13 +13817,13 @@ public abstract class GitHttpClientBase
         final Map<String, Object> routeValues = new HashMap<String, Object>();
         routeValues.put("project", project); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.POST,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       gitRepositoryToCreate,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.POST,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               gitRepositoryToCreate,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, GitRepository.class);
     }
@@ -13549,13 +13847,13 @@ public abstract class GitHttpClientBase
         final Map<String, Object> routeValues = new HashMap<String, Object>();
         routeValues.put("project", project); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.POST,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       gitRepositoryToCreate,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.POST,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               gitRepositoryToCreate,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, GitRepository.class);
     }
@@ -13574,11 +13872,11 @@ public abstract class GitHttpClientBase
         final Map<String, Object> routeValues = new HashMap<String, Object>();
         routeValues.put("repositoryId", repositoryId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.DELETE,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.DELETE,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         super.sendRequest(httpRequest);
     }
@@ -13602,11 +13900,11 @@ public abstract class GitHttpClientBase
         routeValues.put("project", project); //$NON-NLS-1$
         routeValues.put("repositoryId", repositoryId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.DELETE,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.DELETE,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         super.sendRequest(httpRequest);
     }
@@ -13630,11 +13928,11 @@ public abstract class GitHttpClientBase
         routeValues.put("project", project); //$NON-NLS-1$
         routeValues.put("repositoryId", repositoryId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.DELETE,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.DELETE,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         super.sendRequest(httpRequest);
     }
@@ -13661,12 +13959,12 @@ public abstract class GitHttpClientBase
         final NameValueCollection queryParameters = new NameValueCollection();
         queryParameters.addIfNotNull("includeLinks", includeLinks); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<GitRepository>>() {});
     }
@@ -13693,12 +13991,12 @@ public abstract class GitHttpClientBase
         final NameValueCollection queryParameters = new NameValueCollection();
         queryParameters.addIfNotNull("includeLinks", includeLinks); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<GitRepository>>() {});
     }
@@ -13718,11 +14016,11 @@ public abstract class GitHttpClientBase
         final NameValueCollection queryParameters = new NameValueCollection();
         queryParameters.addIfNotNull("includeLinks", includeLinks); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<GitRepository>>() {});
     }
@@ -13742,11 +14040,11 @@ public abstract class GitHttpClientBase
         final Map<String, Object> routeValues = new HashMap<String, Object>();
         routeValues.put("repositoryId", repositoryId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, GitRepository.class);
     }
@@ -13766,11 +14064,11 @@ public abstract class GitHttpClientBase
         final Map<String, Object> routeValues = new HashMap<String, Object>();
         routeValues.put("repositoryId", repositoryId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, GitRepository.class);
     }
@@ -13795,11 +14093,11 @@ public abstract class GitHttpClientBase
         routeValues.put("project", project); //$NON-NLS-1$
         routeValues.put("repositoryId", repositoryId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, GitRepository.class);
     }
@@ -13824,11 +14122,11 @@ public abstract class GitHttpClientBase
         routeValues.put("project", project); //$NON-NLS-1$
         routeValues.put("repositoryId", repositoryId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, GitRepository.class);
     }
@@ -13853,11 +14151,11 @@ public abstract class GitHttpClientBase
         routeValues.put("project", project); //$NON-NLS-1$
         routeValues.put("repositoryId", repositoryId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, GitRepository.class);
     }
@@ -13882,11 +14180,11 @@ public abstract class GitHttpClientBase
         routeValues.put("project", project); //$NON-NLS-1$
         routeValues.put("repositoryId", repositoryId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, GitRepository.class);
     }
@@ -13910,13 +14208,13 @@ public abstract class GitHttpClientBase
         final Map<String, Object> routeValues = new HashMap<String, Object>();
         routeValues.put("repositoryId", repositoryId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.PATCH,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       newRepositoryInfo,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.PATCH,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               newRepositoryInfo,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, GitRepository.class);
     }
@@ -13944,13 +14242,13 @@ public abstract class GitHttpClientBase
         routeValues.put("project", project); //$NON-NLS-1$
         routeValues.put("repositoryId", repositoryId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.PATCH,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       newRepositoryInfo,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.PATCH,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               newRepositoryInfo,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, GitRepository.class);
     }
@@ -13978,13 +14276,13 @@ public abstract class GitHttpClientBase
         routeValues.put("project", project); //$NON-NLS-1$
         routeValues.put("repositoryId", repositoryId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.PATCH,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       newRepositoryInfo,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.PATCH,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               newRepositoryInfo,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, GitRepository.class);
     }
@@ -14012,13 +14310,13 @@ public abstract class GitHttpClientBase
         routeValues.put("project", project); //$NON-NLS-1$
         routeValues.put("repositoryId", repositoryId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.POST,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       revertToCreate,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.POST,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               revertToCreate,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, GitRevert.class);
     }
@@ -14046,13 +14344,13 @@ public abstract class GitHttpClientBase
         routeValues.put("project", project); //$NON-NLS-1$
         routeValues.put("repositoryId", repositoryId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.POST,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       revertToCreate,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.POST,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               revertToCreate,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, GitRevert.class);
     }
@@ -14080,13 +14378,13 @@ public abstract class GitHttpClientBase
         routeValues.put("project", project); //$NON-NLS-1$
         routeValues.put("repositoryId", repositoryId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.POST,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       revertToCreate,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.POST,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               revertToCreate,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, GitRevert.class);
     }
@@ -14114,13 +14412,13 @@ public abstract class GitHttpClientBase
         routeValues.put("project", project); //$NON-NLS-1$
         routeValues.put("repositoryId", repositoryId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.POST,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       revertToCreate,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.POST,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               revertToCreate,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, GitRevert.class);
     }
@@ -14149,11 +14447,11 @@ public abstract class GitHttpClientBase
         routeValues.put("revertId", revertId); //$NON-NLS-1$
         routeValues.put("repositoryId", repositoryId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, GitRevert.class);
     }
@@ -14182,11 +14480,11 @@ public abstract class GitHttpClientBase
         routeValues.put("revertId", revertId); //$NON-NLS-1$
         routeValues.put("repositoryId", repositoryId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, GitRevert.class);
     }
@@ -14215,11 +14513,11 @@ public abstract class GitHttpClientBase
         routeValues.put("revertId", revertId); //$NON-NLS-1$
         routeValues.put("repositoryId", repositoryId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, GitRevert.class);
     }
@@ -14248,11 +14546,11 @@ public abstract class GitHttpClientBase
         routeValues.put("revertId", revertId); //$NON-NLS-1$
         routeValues.put("repositoryId", repositoryId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, GitRevert.class);
     }
@@ -14283,12 +14581,12 @@ public abstract class GitHttpClientBase
         final NameValueCollection queryParameters = new NameValueCollection();
         queryParameters.addIfNotEmpty("refName", refName); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, GitRevert.class);
     }
@@ -14319,12 +14617,12 @@ public abstract class GitHttpClientBase
         final NameValueCollection queryParameters = new NameValueCollection();
         queryParameters.addIfNotEmpty("refName", refName); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, GitRevert.class);
     }
@@ -14355,12 +14653,12 @@ public abstract class GitHttpClientBase
         final NameValueCollection queryParameters = new NameValueCollection();
         queryParameters.addIfNotEmpty("refName", refName); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, GitRevert.class);
     }
@@ -14391,12 +14689,12 @@ public abstract class GitHttpClientBase
         final NameValueCollection queryParameters = new NameValueCollection();
         queryParameters.addIfNotEmpty("refName", refName); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, GitRevert.class);
     }
@@ -14424,13 +14722,13 @@ public abstract class GitHttpClientBase
         routeValues.put("commitId", commitId); //$NON-NLS-1$
         routeValues.put("repositoryId", repositoryId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.POST,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       gitCommitStatusToCreate,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.POST,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               gitCommitStatusToCreate,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, GitStatus.class);
     }
@@ -14458,13 +14756,13 @@ public abstract class GitHttpClientBase
         routeValues.put("commitId", commitId); //$NON-NLS-1$
         routeValues.put("repositoryId", repositoryId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.POST,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       gitCommitStatusToCreate,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.POST,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               gitCommitStatusToCreate,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, GitStatus.class);
     }
@@ -14496,13 +14794,13 @@ public abstract class GitHttpClientBase
         routeValues.put("commitId", commitId); //$NON-NLS-1$
         routeValues.put("repositoryId", repositoryId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.POST,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       gitCommitStatusToCreate,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.POST,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               gitCommitStatusToCreate,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, GitStatus.class);
     }
@@ -14534,13 +14832,13 @@ public abstract class GitHttpClientBase
         routeValues.put("commitId", commitId); //$NON-NLS-1$
         routeValues.put("repositoryId", repositoryId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.POST,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       gitCommitStatusToCreate,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.POST,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               gitCommitStatusToCreate,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, GitStatus.class);
     }
@@ -14572,13 +14870,13 @@ public abstract class GitHttpClientBase
         routeValues.put("commitId", commitId); //$NON-NLS-1$
         routeValues.put("repositoryId", repositoryId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.POST,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       gitCommitStatusToCreate,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.POST,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               gitCommitStatusToCreate,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, GitStatus.class);
     }
@@ -14610,13 +14908,13 @@ public abstract class GitHttpClientBase
         routeValues.put("commitId", commitId); //$NON-NLS-1$
         routeValues.put("repositoryId", repositoryId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.POST,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       gitCommitStatusToCreate,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.POST,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               gitCommitStatusToCreate,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, GitStatus.class);
     }
@@ -14659,12 +14957,12 @@ public abstract class GitHttpClientBase
         queryParameters.addIfNotNull("skip", skip); //$NON-NLS-1$
         queryParameters.addIfNotNull("latestOnly", latestOnly); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<GitStatus>>() {});
     }
@@ -14707,12 +15005,12 @@ public abstract class GitHttpClientBase
         queryParameters.addIfNotNull("skip", skip); //$NON-NLS-1$
         queryParameters.addIfNotNull("latestOnly", latestOnly); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<GitStatus>>() {});
     }
@@ -14755,12 +15053,12 @@ public abstract class GitHttpClientBase
         queryParameters.addIfNotNull("skip", skip); //$NON-NLS-1$
         queryParameters.addIfNotNull("latestOnly", latestOnly); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<GitStatus>>() {});
     }
@@ -14803,12 +15101,12 @@ public abstract class GitHttpClientBase
         queryParameters.addIfNotNull("skip", skip); //$NON-NLS-1$
         queryParameters.addIfNotNull("latestOnly", latestOnly); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<GitStatus>>() {});
     }
@@ -14847,12 +15145,12 @@ public abstract class GitHttpClientBase
         queryParameters.addIfNotNull("skip", skip); //$NON-NLS-1$
         queryParameters.addIfNotNull("latestOnly", latestOnly); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<GitStatus>>() {});
     }
@@ -14891,12 +15189,12 @@ public abstract class GitHttpClientBase
         queryParameters.addIfNotNull("skip", skip); //$NON-NLS-1$
         queryParameters.addIfNotNull("latestOnly", latestOnly); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<GitStatus>>() {});
     }
@@ -14939,12 +15237,12 @@ public abstract class GitHttpClientBase
         queryParameters.addIfNotNull("recursive", recursive); //$NON-NLS-1$
         queryParameters.addIfNotEmpty("fileName", fileName); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, GitTreeRef.class);
     }
@@ -14987,12 +15285,12 @@ public abstract class GitHttpClientBase
         queryParameters.addIfNotNull("recursive", recursive); //$NON-NLS-1$
         queryParameters.addIfNotEmpty("fileName", fileName); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, GitTreeRef.class);
     }
@@ -15035,12 +15333,12 @@ public abstract class GitHttpClientBase
         queryParameters.addIfNotNull("recursive", recursive); //$NON-NLS-1$
         queryParameters.addIfNotEmpty("fileName", fileName); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, GitTreeRef.class);
     }
@@ -15083,12 +15381,12 @@ public abstract class GitHttpClientBase
         queryParameters.addIfNotNull("recursive", recursive); //$NON-NLS-1$
         queryParameters.addIfNotEmpty("fileName", fileName); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, GitTreeRef.class);
     }
@@ -15127,12 +15425,12 @@ public abstract class GitHttpClientBase
         queryParameters.addIfNotNull("recursive", recursive); //$NON-NLS-1$
         queryParameters.addIfNotEmpty("fileName", fileName); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, GitTreeRef.class);
     }
@@ -15171,12 +15469,12 @@ public abstract class GitHttpClientBase
         queryParameters.addIfNotNull("recursive", recursive); //$NON-NLS-1$
         queryParameters.addIfNotEmpty("fileName", fileName); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, GitTreeRef.class);
     }
@@ -15219,12 +15517,12 @@ public abstract class GitHttpClientBase
         queryParameters.addIfNotNull("recursive", recursive); //$NON-NLS-1$
         queryParameters.addIfNotEmpty("fileName", fileName); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_ZIP_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_ZIP_TYPE);
 
         return super.sendRequest(httpRequest, InputStream.class);
     }
@@ -15267,12 +15565,12 @@ public abstract class GitHttpClientBase
         queryParameters.addIfNotNull("recursive", recursive); //$NON-NLS-1$
         queryParameters.addIfNotEmpty("fileName", fileName); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_ZIP_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_ZIP_TYPE);
 
         return super.sendRequest(httpRequest, InputStream.class);
     }
@@ -15315,12 +15613,12 @@ public abstract class GitHttpClientBase
         queryParameters.addIfNotNull("recursive", recursive); //$NON-NLS-1$
         queryParameters.addIfNotEmpty("fileName", fileName); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_ZIP_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_ZIP_TYPE);
 
         return super.sendRequest(httpRequest, InputStream.class);
     }
@@ -15363,12 +15661,12 @@ public abstract class GitHttpClientBase
         queryParameters.addIfNotNull("recursive", recursive); //$NON-NLS-1$
         queryParameters.addIfNotEmpty("fileName", fileName); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_ZIP_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_ZIP_TYPE);
 
         return super.sendRequest(httpRequest, InputStream.class);
     }
@@ -15407,12 +15705,12 @@ public abstract class GitHttpClientBase
         queryParameters.addIfNotNull("recursive", recursive); //$NON-NLS-1$
         queryParameters.addIfNotEmpty("fileName", fileName); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_ZIP_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_ZIP_TYPE);
 
         return super.sendRequest(httpRequest, InputStream.class);
     }
@@ -15451,12 +15749,12 @@ public abstract class GitHttpClientBase
         queryParameters.addIfNotNull("recursive", recursive); //$NON-NLS-1$
         queryParameters.addIfNotEmpty("fileName", fileName); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_ZIP_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_ZIP_TYPE);
 
         return super.sendRequest(httpRequest, InputStream.class);
     }

--- a/Rest/alm-tfs-client/src/main/generated/com/microsoft/alm/teamfoundation/sourcecontrol/webapi/GitPullRequestIterationChanges.java
+++ b/Rest/alm-tfs-client/src/main/generated/com/microsoft/alm/teamfoundation/sourcecontrol/webapi/GitPullRequestIterationChanges.java
@@ -22,8 +22,8 @@ import java.util.ArrayList;
 public class GitPullRequestIterationChanges {
 
     private ArrayList<GitPullRequestChange> changeEntries;
-    private ArrayList<String> nextSkip;
-    private ArrayList<String> nextTop;
+    private int nextSkip;
+    private int nextTop;
 
     public ArrayList<GitPullRequestChange> getChangeEntries() {
         return changeEntries;
@@ -33,19 +33,19 @@ public class GitPullRequestIterationChanges {
         this.changeEntries = changeEntries;
     }
 
-    public ArrayList<String> getNextSkip() {
+    public int getNextSkip() {
         return nextSkip;
     }
 
-    public void setNextSkip(final ArrayList<String> nextSkip) {
+    public void setNextSkip(final int nextSkip) {
         this.nextSkip = nextSkip;
     }
 
-    public ArrayList<String> getNextTop() {
+    public int getNextTop() {
         return nextTop;
     }
 
-    public void setNextTop(final ArrayList<String> nextTop) {
+    public void setNextTop(final int nextTop) {
         this.nextTop = nextTop;
     }
 }

--- a/Rest/alm-tfs-client/src/main/generated/com/microsoft/alm/teamfoundation/sourcecontrol/webapi/GitQueryCommitsCriteria.java
+++ b/Rest/alm-tfs-client/src/main/generated/com/microsoft/alm/teamfoundation/sourcecontrol/webapi/GitQueryCommitsCriteria.java
@@ -58,6 +58,10 @@ public class GitQueryCommitsCriteria {
     */
     private boolean includeLinks;
     /**
+    * Whether to include linked work items
+    */
+    private boolean includeWorkItems;
+    /**
     * Path of item to search under
     */
     private String itemPath;
@@ -202,6 +206,20 @@ public class GitQueryCommitsCriteria {
     */
     public void setIncludeLinks(final boolean includeLinks) {
         this.includeLinks = includeLinks;
+    }
+
+    /**
+    * Whether to include linked work items
+    */
+    public boolean getIncludeWorkItems() {
+        return includeWorkItems;
+    }
+
+    /**
+    * Whether to include linked work items
+    */
+    public void setIncludeWorkItems(final boolean includeWorkItems) {
+        this.includeWorkItems = includeWorkItems;
     }
 
     /**

--- a/Rest/alm-tfs-client/src/main/generated/com/microsoft/alm/teamfoundation/sourcecontrol/webapi/TfvcHttpClientBase.java
+++ b/Rest/alm-tfs-client/src/main/generated/com/microsoft/alm/teamfoundation/sourcecontrol/webapi/TfvcHttpClientBase.java
@@ -23,8 +23,12 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import com.fasterxml.jackson.core.type.TypeReference;
+import com.microsoft.alm.client.HttpMethod;
 import com.microsoft.alm.client.model.NameValueCollection;
 import com.microsoft.alm.client.VssHttpClientBase;
+import com.microsoft.alm.client.VssMediaTypes;
+import com.microsoft.alm.client.VssRestClientHandler;
+import com.microsoft.alm.client.VssRestRequest;
 import com.microsoft.alm.teamfoundation.sourcecontrol.webapi.AssociatedWorkItem;
 import com.microsoft.alm.teamfoundation.sourcecontrol.webapi.TfvcBranch;
 import com.microsoft.alm.teamfoundation.sourcecontrol.webapi.TfvcBranchRef;
@@ -58,22 +62,13 @@ public abstract class TfvcHttpClientBase
     * Create a new instance of TfvcHttpClientBase
     *
     * @param jaxrsClient
-    *            an initialized instance of a JAX-RS Client implementation
+    *            a DefaultRestClientHandler initialized with an instance of a JAX-RS Client implementation or
+    *            a TEERestClientHamdler initialized with TEE HTTP client implementation
     * @param baseUrl
-    *            a TFS project collection URL
+    *            a TFS services URL
     */
-    protected TfvcHttpClientBase(final Object jaxrsClient, final URI baseUrl) {
-        super(jaxrsClient, baseUrl);
-    }
-
-    /**
-    * Create a new instance of TfvcHttpClientBase
-    *
-    * @param tfsConnection
-    *            an initialized instance of a TfsTeamProjectCollection
-    */
-    protected TfvcHttpClientBase(final Object tfsConnection) {
-        super(tfsConnection);
+    protected TfvcHttpClientBase(final VssRestClientHandler clientHandler, final URI baseUrl) {
+        super(clientHandler, baseUrl);
     }
 
     @Override
@@ -111,12 +106,12 @@ public abstract class TfvcHttpClientBase
         queryParameters.addIfNotNull("includeParent", includeParent); //$NON-NLS-1$
         queryParameters.addIfNotNull("includeChildren", includeChildren); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, TfvcBranch.class);
     }
@@ -151,12 +146,12 @@ public abstract class TfvcHttpClientBase
         queryParameters.addIfNotNull("includeParent", includeParent); //$NON-NLS-1$
         queryParameters.addIfNotNull("includeChildren", includeChildren); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, TfvcBranch.class);
     }
@@ -185,11 +180,11 @@ public abstract class TfvcHttpClientBase
         queryParameters.addIfNotNull("includeParent", includeParent); //$NON-NLS-1$
         queryParameters.addIfNotNull("includeChildren", includeChildren); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, TfvcBranch.class);
     }
@@ -228,12 +223,12 @@ public abstract class TfvcHttpClientBase
         queryParameters.addIfNotNull("includeDeleted", includeDeleted); //$NON-NLS-1$
         queryParameters.addIfNotNull("includeLinks", includeLinks); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<TfvcBranch>>() {});
     }
@@ -272,12 +267,12 @@ public abstract class TfvcHttpClientBase
         queryParameters.addIfNotNull("includeDeleted", includeDeleted); //$NON-NLS-1$
         queryParameters.addIfNotNull("includeLinks", includeLinks); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<TfvcBranch>>() {});
     }
@@ -310,11 +305,11 @@ public abstract class TfvcHttpClientBase
         queryParameters.addIfNotNull("includeDeleted", includeDeleted); //$NON-NLS-1$
         queryParameters.addIfNotNull("includeLinks", includeLinks); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<TfvcBranch>>() {});
     }
@@ -349,12 +344,12 @@ public abstract class TfvcHttpClientBase
         queryParameters.addIfNotNull("includeDeleted", includeDeleted); //$NON-NLS-1$
         queryParameters.addIfNotNull("includeLinks", includeLinks); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<TfvcBranchRef>>() {});
     }
@@ -389,12 +384,12 @@ public abstract class TfvcHttpClientBase
         queryParameters.addIfNotNull("includeDeleted", includeDeleted); //$NON-NLS-1$
         queryParameters.addIfNotNull("includeLinks", includeLinks); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<TfvcBranchRef>>() {});
     }
@@ -423,11 +418,11 @@ public abstract class TfvcHttpClientBase
         queryParameters.addIfNotNull("includeDeleted", includeDeleted); //$NON-NLS-1$
         queryParameters.addIfNotNull("includeLinks", includeLinks); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<TfvcBranchRef>>() {});
     }
@@ -458,12 +453,12 @@ public abstract class TfvcHttpClientBase
         queryParameters.addIfNotNull("$skip", skip); //$NON-NLS-1$
         queryParameters.addIfNotNull("$top", top); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<TfvcChange>>() {});
     }
@@ -480,12 +475,12 @@ public abstract class TfvcHttpClientBase
         final UUID locationId = UUID.fromString("0bc8f0a4-6bfb-42a9-ba84-139da7b99c49"); //$NON-NLS-1$
         final ApiResourceVersion apiVersion = new ApiResourceVersion("3.0-preview.2"); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.POST,
-                                                       locationId,
-                                                       apiVersion,
-                                                       changeset,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.POST,
+                                                               locationId,
+                                                               apiVersion,
+                                                               changeset,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, TfvcChangesetRef.class);
     }
@@ -509,13 +504,13 @@ public abstract class TfvcHttpClientBase
         final Map<String, Object> routeValues = new HashMap<String, Object>();
         routeValues.put("project", project); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.POST,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       changeset,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.POST,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               changeset,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, TfvcChangesetRef.class);
     }
@@ -539,13 +534,13 @@ public abstract class TfvcHttpClientBase
         final Map<String, Object> routeValues = new HashMap<String, Object>();
         routeValues.put("project", project); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.POST,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       changeset,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.POST,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               changeset,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, TfvcChangesetRef.class);
     }
@@ -608,12 +603,12 @@ public abstract class TfvcHttpClientBase
         queryParameters.addIfNotEmpty("$orderby", orderby); //$NON-NLS-1$
         addModelAsQueryParams(queryParameters, searchCriteria);
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, TfvcChangeset.class);
     }
@@ -676,12 +671,12 @@ public abstract class TfvcHttpClientBase
         queryParameters.addIfNotEmpty("$orderby", orderby); //$NON-NLS-1$
         addModelAsQueryParams(queryParameters, searchCriteria);
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, TfvcChangeset.class);
     }
@@ -740,12 +735,12 @@ public abstract class TfvcHttpClientBase
         queryParameters.addIfNotEmpty("$orderby", orderby); //$NON-NLS-1$
         addModelAsQueryParams(queryParameters, searchCriteria);
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, TfvcChangeset.class);
     }
@@ -788,12 +783,12 @@ public abstract class TfvcHttpClientBase
         queryParameters.addIfNotEmpty("$orderby", orderby); //$NON-NLS-1$
         addModelAsQueryParams(queryParameters, searchCriteria);
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<TfvcChangesetRef>>() {});
     }
@@ -836,12 +831,12 @@ public abstract class TfvcHttpClientBase
         queryParameters.addIfNotEmpty("$orderby", orderby); //$NON-NLS-1$
         addModelAsQueryParams(queryParameters, searchCriteria);
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<TfvcChangesetRef>>() {});
     }
@@ -878,11 +873,11 @@ public abstract class TfvcHttpClientBase
         queryParameters.addIfNotEmpty("$orderby", orderby); //$NON-NLS-1$
         addModelAsQueryParams(queryParameters, searchCriteria);
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<TfvcChangesetRef>>() {});
     }
@@ -899,12 +894,12 @@ public abstract class TfvcHttpClientBase
         final UUID locationId = UUID.fromString("b7e7c173-803c-4fea-9ec8-31ee35c5502a"); //$NON-NLS-1$
         final ApiResourceVersion apiVersion = new ApiResourceVersion("3.0-preview.1"); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.POST,
-                                                       locationId,
-                                                       apiVersion,
-                                                       changesetsRequestData,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.POST,
+                                                               locationId,
+                                                               apiVersion,
+                                                               changesetsRequestData,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<TfvcChangesetRef>>() {});
     }
@@ -924,11 +919,11 @@ public abstract class TfvcHttpClientBase
         final Map<String, Object> routeValues = new HashMap<String, Object>();
         routeValues.put("id", id); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<AssociatedWorkItem>>() {});
     }
@@ -945,12 +940,12 @@ public abstract class TfvcHttpClientBase
         final UUID locationId = UUID.fromString("fe6f827b-5f64-480f-b8af-1eca3b80e833"); //$NON-NLS-1$
         final ApiResourceVersion apiVersion = new ApiResourceVersion("3.0-preview.1"); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.POST,
-                                                       locationId,
-                                                       apiVersion,
-                                                       itemRequestData,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.POST,
+                                                               locationId,
+                                                               apiVersion,
+                                                               itemRequestData,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<ArrayList<TfvcItem>>>() {});
     }
@@ -974,13 +969,13 @@ public abstract class TfvcHttpClientBase
         final Map<String, Object> routeValues = new HashMap<String, Object>();
         routeValues.put("project", project); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.POST,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       itemRequestData,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.POST,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               itemRequestData,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<ArrayList<TfvcItem>>>() {});
     }
@@ -1004,13 +999,13 @@ public abstract class TfvcHttpClientBase
         final Map<String, Object> routeValues = new HashMap<String, Object>();
         routeValues.put("project", project); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.POST,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       itemRequestData,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.POST,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               itemRequestData,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<ArrayList<TfvcItem>>>() {});
     }
@@ -1027,12 +1022,12 @@ public abstract class TfvcHttpClientBase
         final UUID locationId = UUID.fromString("fe6f827b-5f64-480f-b8af-1eca3b80e833"); //$NON-NLS-1$
         final ApiResourceVersion apiVersion = new ApiResourceVersion("3.0-preview.1"); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.POST,
-                                                       locationId,
-                                                       apiVersion,
-                                                       itemRequestData,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_ZIP_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.POST,
+                                                               locationId,
+                                                               apiVersion,
+                                                               itemRequestData,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_ZIP_TYPE);
 
         return super.sendRequest(httpRequest, InputStream.class);
     }
@@ -1056,13 +1051,13 @@ public abstract class TfvcHttpClientBase
         final Map<String, Object> routeValues = new HashMap<String, Object>();
         routeValues.put("project", project); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.POST,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       itemRequestData,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_ZIP_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.POST,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               itemRequestData,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_ZIP_TYPE);
 
         return super.sendRequest(httpRequest, InputStream.class);
     }
@@ -1086,13 +1081,13 @@ public abstract class TfvcHttpClientBase
         final Map<String, Object> routeValues = new HashMap<String, Object>();
         routeValues.put("project", project); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.POST,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       itemRequestData,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_ZIP_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.POST,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               itemRequestData,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_ZIP_TYPE);
 
         return super.sendRequest(httpRequest, InputStream.class);
     }
@@ -1139,12 +1134,12 @@ public abstract class TfvcHttpClientBase
         queryParameters.addIfNotNull("recursionLevel", recursionLevel); //$NON-NLS-1$
         addModelAsQueryParams(queryParameters, versionDescriptor);
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, TfvcItem.class);
     }
@@ -1191,12 +1186,12 @@ public abstract class TfvcHttpClientBase
         queryParameters.addIfNotNull("recursionLevel", recursionLevel); //$NON-NLS-1$
         addModelAsQueryParams(queryParameters, versionDescriptor);
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, TfvcItem.class);
     }
@@ -1237,11 +1232,11 @@ public abstract class TfvcHttpClientBase
         queryParameters.addIfNotNull("recursionLevel", recursionLevel); //$NON-NLS-1$
         addModelAsQueryParams(queryParameters, versionDescriptor);
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, TfvcItem.class);
     }
@@ -1288,12 +1283,12 @@ public abstract class TfvcHttpClientBase
         queryParameters.addIfNotNull("recursionLevel", recursionLevel); //$NON-NLS-1$
         addModelAsQueryParams(queryParameters, versionDescriptor);
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_OCTET_STREAM_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_OCTET_STREAM_TYPE);
 
         return super.sendRequest(httpRequest, InputStream.class);
     }
@@ -1340,12 +1335,12 @@ public abstract class TfvcHttpClientBase
         queryParameters.addIfNotNull("recursionLevel", recursionLevel); //$NON-NLS-1$
         addModelAsQueryParams(queryParameters, versionDescriptor);
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_OCTET_STREAM_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_OCTET_STREAM_TYPE);
 
         return super.sendRequest(httpRequest, InputStream.class);
     }
@@ -1386,11 +1381,11 @@ public abstract class TfvcHttpClientBase
         queryParameters.addIfNotNull("recursionLevel", recursionLevel); //$NON-NLS-1$
         addModelAsQueryParams(queryParameters, versionDescriptor);
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_OCTET_STREAM_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_OCTET_STREAM_TYPE);
 
         return super.sendRequest(httpRequest, InputStream.class);
     }
@@ -1429,12 +1424,12 @@ public abstract class TfvcHttpClientBase
         queryParameters.addIfNotNull("includeLinks", includeLinks); //$NON-NLS-1$
         addModelAsQueryParams(queryParameters, versionDescriptor);
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<TfvcItem>>() {});
     }
@@ -1473,12 +1468,12 @@ public abstract class TfvcHttpClientBase
         queryParameters.addIfNotNull("includeLinks", includeLinks); //$NON-NLS-1$
         addModelAsQueryParams(queryParameters, versionDescriptor);
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<TfvcItem>>() {});
     }
@@ -1511,11 +1506,11 @@ public abstract class TfvcHttpClientBase
         queryParameters.addIfNotNull("includeLinks", includeLinks); //$NON-NLS-1$
         addModelAsQueryParams(queryParameters, versionDescriptor);
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<TfvcItem>>() {});
     }
@@ -1562,12 +1557,12 @@ public abstract class TfvcHttpClientBase
         queryParameters.addIfNotNull("recursionLevel", recursionLevel); //$NON-NLS-1$
         addModelAsQueryParams(queryParameters, versionDescriptor);
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       TEXT_PLAIN_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.TEXT_PLAIN_TYPE);
 
         return super.sendRequest(httpRequest, InputStream.class);
     }
@@ -1614,12 +1609,12 @@ public abstract class TfvcHttpClientBase
         queryParameters.addIfNotNull("recursionLevel", recursionLevel); //$NON-NLS-1$
         addModelAsQueryParams(queryParameters, versionDescriptor);
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       TEXT_PLAIN_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.TEXT_PLAIN_TYPE);
 
         return super.sendRequest(httpRequest, InputStream.class);
     }
@@ -1660,11 +1655,11 @@ public abstract class TfvcHttpClientBase
         queryParameters.addIfNotNull("recursionLevel", recursionLevel); //$NON-NLS-1$
         addModelAsQueryParams(queryParameters, versionDescriptor);
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       TEXT_PLAIN_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.TEXT_PLAIN_TYPE);
 
         return super.sendRequest(httpRequest, InputStream.class);
     }
@@ -1711,12 +1706,12 @@ public abstract class TfvcHttpClientBase
         queryParameters.addIfNotNull("recursionLevel", recursionLevel); //$NON-NLS-1$
         addModelAsQueryParams(queryParameters, versionDescriptor);
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_ZIP_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_ZIP_TYPE);
 
         return super.sendRequest(httpRequest, InputStream.class);
     }
@@ -1763,12 +1758,12 @@ public abstract class TfvcHttpClientBase
         queryParameters.addIfNotNull("recursionLevel", recursionLevel); //$NON-NLS-1$
         addModelAsQueryParams(queryParameters, versionDescriptor);
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_ZIP_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_ZIP_TYPE);
 
         return super.sendRequest(httpRequest, InputStream.class);
     }
@@ -1809,11 +1804,11 @@ public abstract class TfvcHttpClientBase
         queryParameters.addIfNotNull("recursionLevel", recursionLevel); //$NON-NLS-1$
         addModelAsQueryParams(queryParameters, versionDescriptor);
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_ZIP_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_ZIP_TYPE);
 
         return super.sendRequest(httpRequest, InputStream.class);
     }
@@ -1844,12 +1839,12 @@ public abstract class TfvcHttpClientBase
         queryParameters.addIfNotNull("$top", top); //$NON-NLS-1$
         queryParameters.addIfNotNull("$skip", skip); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<TfvcItem>>() {});
     }
@@ -1880,12 +1875,12 @@ public abstract class TfvcHttpClientBase
         final NameValueCollection queryParameters = new NameValueCollection();
         addModelAsQueryParams(queryParameters, requestData);
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, TfvcLabel.class);
     }
@@ -1916,12 +1911,12 @@ public abstract class TfvcHttpClientBase
         final NameValueCollection queryParameters = new NameValueCollection();
         addModelAsQueryParams(queryParameters, requestData);
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, TfvcLabel.class);
     }
@@ -1948,12 +1943,12 @@ public abstract class TfvcHttpClientBase
         final NameValueCollection queryParameters = new NameValueCollection();
         addModelAsQueryParams(queryParameters, requestData);
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, TfvcLabel.class);
     }
@@ -1988,12 +1983,12 @@ public abstract class TfvcHttpClientBase
         queryParameters.addIfNotNull("$top", top); //$NON-NLS-1$
         queryParameters.addIfNotNull("$skip", skip); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<TfvcLabelRef>>() {});
     }
@@ -2028,12 +2023,12 @@ public abstract class TfvcHttpClientBase
         queryParameters.addIfNotNull("$top", top); //$NON-NLS-1$
         queryParameters.addIfNotNull("$skip", skip); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<TfvcLabelRef>>() {});
     }
@@ -2062,11 +2057,11 @@ public abstract class TfvcHttpClientBase
         queryParameters.addIfNotNull("$top", top); //$NON-NLS-1$
         queryParameters.addIfNotNull("$skip", skip); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<TfvcLabelRef>>() {});
     }
@@ -2095,11 +2090,11 @@ public abstract class TfvcHttpClientBase
         queryParameters.addIfNotNull("$top", top); //$NON-NLS-1$
         queryParameters.addIfNotNull("$skip", skip); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<TfvcChange>>() {});
     }
@@ -2124,11 +2119,11 @@ public abstract class TfvcHttpClientBase
         queryParameters.addIfNotEmpty("shelvesetId", shelvesetId); //$NON-NLS-1$
         addModelAsQueryParams(queryParameters, requestData);
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, TfvcShelveset.class);
     }
@@ -2157,11 +2152,11 @@ public abstract class TfvcHttpClientBase
         queryParameters.addIfNotNull("$top", top); //$NON-NLS-1$
         queryParameters.addIfNotNull("$skip", skip); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<TfvcShelvesetRef>>() {});
     }
@@ -2181,11 +2176,11 @@ public abstract class TfvcHttpClientBase
         final NameValueCollection queryParameters = new NameValueCollection();
         queryParameters.addIfNotEmpty("shelvesetId", shelvesetId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<AssociatedWorkItem>>() {});
     }

--- a/Rest/alm-tfs-client/src/main/generated/com/microsoft/alm/teamfoundation/testmanagement/webapi/ReleaseReference.java
+++ b/Rest/alm-tfs-client/src/main/generated/com/microsoft/alm/teamfoundation/testmanagement/webapi/ReleaseReference.java
@@ -24,6 +24,7 @@ public class ReleaseReference {
     private int environmentDefinitionId;
     private String environmentDefinitionName;
     private int environmentId;
+    private String environmentName;
     private int id;
     private String name;
 
@@ -57,6 +58,14 @@ public class ReleaseReference {
 
     public void setEnvironmentId(final int environmentId) {
         this.environmentId = environmentId;
+    }
+
+    public String getEnvironmentName() {
+        return environmentName;
+    }
+
+    public void setEnvironmentName(final String environmentName) {
+        this.environmentName = environmentName;
     }
 
     public int getId() {

--- a/Rest/alm-tfs-client/src/main/generated/com/microsoft/alm/teamfoundation/testmanagement/webapi/SuiteCreateModel.java
+++ b/Rest/alm-tfs-client/src/main/generated/com/microsoft/alm/teamfoundation/testmanagement/webapi/SuiteCreateModel.java
@@ -20,4 +20,40 @@ package com.microsoft.alm.teamfoundation.testmanagement.webapi;
  */
 public class SuiteCreateModel {
 
+    private String name;
+    private String queryString;
+    private Integer[] requirementIds;
+    private String suiteType;
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(final String name) {
+        this.name = name;
+    }
+
+    public String getQueryString() {
+        return queryString;
+    }
+
+    public void setQueryString(final String queryString) {
+        this.queryString = queryString;
+    }
+
+    public Integer[] getRequirementIds() {
+        return requirementIds;
+    }
+
+    public void setRequirementIds(final Integer[] requirementIds) {
+        this.requirementIds = requirementIds;
+    }
+
+    public String getSuiteType() {
+        return suiteType;
+    }
+
+    public void setSuiteType(final String suiteType) {
+        this.suiteType = suiteType;
+    }
 }

--- a/Rest/alm-tfs-client/src/main/generated/com/microsoft/alm/teamfoundation/testmanagement/webapi/TestHttpClientBase.java
+++ b/Rest/alm-tfs-client/src/main/generated/com/microsoft/alm/teamfoundation/testmanagement/webapi/TestHttpClientBase.java
@@ -24,8 +24,12 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import com.fasterxml.jackson.core.type.TypeReference;
+import com.microsoft.alm.client.HttpMethod;
 import com.microsoft.alm.client.model.NameValueCollection;
 import com.microsoft.alm.client.VssHttpClientBase;
+import com.microsoft.alm.client.VssMediaTypes;
+import com.microsoft.alm.client.VssRestClientHandler;
+import com.microsoft.alm.client.VssRestRequest;
 import com.microsoft.alm.teamfoundation.testmanagement.webapi.AggregatedDataForResultTrend;
 import com.microsoft.alm.teamfoundation.testmanagement.webapi.BuildCoverage;
 import com.microsoft.alm.teamfoundation.testmanagement.webapi.BuildReference;
@@ -69,6 +73,7 @@ import com.microsoft.alm.teamfoundation.testmanagement.webapi.TestRun;
 import com.microsoft.alm.teamfoundation.testmanagement.webapi.TestRunCoverage;
 import com.microsoft.alm.teamfoundation.testmanagement.webapi.TestRunStatistic;
 import com.microsoft.alm.teamfoundation.testmanagement.webapi.TestSession;
+import com.microsoft.alm.teamfoundation.testmanagement.webapi.TestSessionSource;
 import com.microsoft.alm.teamfoundation.testmanagement.webapi.TestSettings;
 import com.microsoft.alm.teamfoundation.testmanagement.webapi.TestSuite;
 import com.microsoft.alm.teamfoundation.testmanagement.webapi.TestSuiteCloneRequest;
@@ -92,22 +97,13 @@ public abstract class TestHttpClientBase
     * Create a new instance of TestHttpClientBase
     *
     * @param jaxrsClient
-    *            an initialized instance of a JAX-RS Client implementation
+    *            a DefaultRestClientHandler initialized with an instance of a JAX-RS Client implementation or
+    *            a TEERestClientHamdler initialized with TEE HTTP client implementation
     * @param baseUrl
-    *            a TFS project collection URL
+    *            a TFS services URL
     */
-    protected TestHttpClientBase(final Object jaxrsClient, final URI baseUrl) {
-        super(jaxrsClient, baseUrl);
-    }
-
-    /**
-    * Create a new instance of TestHttpClientBase
-    *
-    * @param tfsConnection
-    *            an initialized instance of a TfsTeamProjectCollection
-    */
-    protected TestHttpClientBase(final Object tfsConnection) {
-        super(tfsConnection);
+    protected TestHttpClientBase(final VssRestClientHandler clientHandler, final URI baseUrl) {
+        super(clientHandler, baseUrl);
     }
 
     @Override
@@ -147,11 +143,11 @@ public abstract class TestHttpClientBase
         routeValues.put("iterationId", iterationId); //$NON-NLS-1$
         routeValues.put("actionPath", actionPath); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<TestActionResultModel>>() {});
     }
@@ -188,11 +184,11 @@ public abstract class TestHttpClientBase
         routeValues.put("iterationId", iterationId); //$NON-NLS-1$
         routeValues.put("actionPath", actionPath); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<TestActionResultModel>>() {});
     }
@@ -234,14 +230,14 @@ public abstract class TestHttpClientBase
         queryParameters.put("iterationId", String.valueOf(iterationId)); //$NON-NLS-1$
         queryParameters.addIfNotEmpty("actionPath", actionPath); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.POST,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       attachmentRequestModel,
-                                                       APPLICATION_JSON_TYPE,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.POST,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               attachmentRequestModel,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, TestAttachmentReference.class);
     }
@@ -283,14 +279,14 @@ public abstract class TestHttpClientBase
         queryParameters.put("iterationId", String.valueOf(iterationId)); //$NON-NLS-1$
         queryParameters.addIfNotEmpty("actionPath", actionPath); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.POST,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       attachmentRequestModel,
-                                                       APPLICATION_JSON_TYPE,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.POST,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               attachmentRequestModel,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, TestAttachmentReference.class);
     }
@@ -322,13 +318,13 @@ public abstract class TestHttpClientBase
         routeValues.put("runId", runId); //$NON-NLS-1$
         routeValues.put("testCaseResultId", testCaseResultId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.POST,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       attachmentRequestModel,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.POST,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               attachmentRequestModel,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, TestAttachmentReference.class);
     }
@@ -360,13 +356,13 @@ public abstract class TestHttpClientBase
         routeValues.put("runId", runId); //$NON-NLS-1$
         routeValues.put("testCaseResultId", testCaseResultId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.POST,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       attachmentRequestModel,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.POST,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               attachmentRequestModel,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, TestAttachmentReference.class);
     }
@@ -399,11 +395,11 @@ public abstract class TestHttpClientBase
         routeValues.put("testCaseResultId", testCaseResultId); //$NON-NLS-1$
         routeValues.put("attachmentId", attachmentId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_OCTET_STREAM_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_OCTET_STREAM_TYPE);
 
         return super.sendRequest(httpRequest, InputStream.class);
     }
@@ -436,11 +432,11 @@ public abstract class TestHttpClientBase
         routeValues.put("testCaseResultId", testCaseResultId); //$NON-NLS-1$
         routeValues.put("attachmentId", attachmentId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_OCTET_STREAM_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_OCTET_STREAM_TYPE);
 
         return super.sendRequest(httpRequest, InputStream.class);
     }
@@ -469,11 +465,11 @@ public abstract class TestHttpClientBase
         routeValues.put("runId", runId); //$NON-NLS-1$
         routeValues.put("testCaseResultId", testCaseResultId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<TestAttachment>>() {});
     }
@@ -502,11 +498,11 @@ public abstract class TestHttpClientBase
         routeValues.put("runId", runId); //$NON-NLS-1$
         routeValues.put("testCaseResultId", testCaseResultId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<TestAttachment>>() {});
     }
@@ -539,11 +535,11 @@ public abstract class TestHttpClientBase
         routeValues.put("testCaseResultId", testCaseResultId); //$NON-NLS-1$
         routeValues.put("attachmentId", attachmentId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_ZIP_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_ZIP_TYPE);
 
         return super.sendRequest(httpRequest, InputStream.class);
     }
@@ -576,11 +572,11 @@ public abstract class TestHttpClientBase
         routeValues.put("testCaseResultId", testCaseResultId); //$NON-NLS-1$
         routeValues.put("attachmentId", attachmentId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_ZIP_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_ZIP_TYPE);
 
         return super.sendRequest(httpRequest, InputStream.class);
     }
@@ -608,13 +604,13 @@ public abstract class TestHttpClientBase
         routeValues.put("project", project); //$NON-NLS-1$
         routeValues.put("runId", runId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.POST,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       attachmentRequestModel,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.POST,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               attachmentRequestModel,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, TestAttachmentReference.class);
     }
@@ -642,13 +638,13 @@ public abstract class TestHttpClientBase
         routeValues.put("project", project); //$NON-NLS-1$
         routeValues.put("runId", runId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.POST,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       attachmentRequestModel,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.POST,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               attachmentRequestModel,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, TestAttachmentReference.class);
     }
@@ -677,11 +673,11 @@ public abstract class TestHttpClientBase
         routeValues.put("runId", runId); //$NON-NLS-1$
         routeValues.put("attachmentId", attachmentId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_OCTET_STREAM_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_OCTET_STREAM_TYPE);
 
         return super.sendRequest(httpRequest, InputStream.class);
     }
@@ -710,11 +706,11 @@ public abstract class TestHttpClientBase
         routeValues.put("runId", runId); //$NON-NLS-1$
         routeValues.put("attachmentId", attachmentId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_OCTET_STREAM_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_OCTET_STREAM_TYPE);
 
         return super.sendRequest(httpRequest, InputStream.class);
     }
@@ -739,11 +735,11 @@ public abstract class TestHttpClientBase
         routeValues.put("project", project); //$NON-NLS-1$
         routeValues.put("runId", runId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<TestAttachment>>() {});
     }
@@ -768,11 +764,11 @@ public abstract class TestHttpClientBase
         routeValues.put("project", project); //$NON-NLS-1$
         routeValues.put("runId", runId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<TestAttachment>>() {});
     }
@@ -801,11 +797,11 @@ public abstract class TestHttpClientBase
         routeValues.put("runId", runId); //$NON-NLS-1$
         routeValues.put("attachmentId", attachmentId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_ZIP_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_ZIP_TYPE);
 
         return super.sendRequest(httpRequest, InputStream.class);
     }
@@ -834,11 +830,11 @@ public abstract class TestHttpClientBase
         routeValues.put("runId", runId); //$NON-NLS-1$
         routeValues.put("attachmentId", attachmentId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_ZIP_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_ZIP_TYPE);
 
         return super.sendRequest(httpRequest, InputStream.class);
     }
@@ -867,11 +863,11 @@ public abstract class TestHttpClientBase
         routeValues.put("runId", runId); //$NON-NLS-1$
         routeValues.put("testCaseResultId", testCaseResultId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<WorkItemReference>>() {});
     }
@@ -900,11 +896,11 @@ public abstract class TestHttpClientBase
         routeValues.put("runId", runId); //$NON-NLS-1$
         routeValues.put("testCaseResultId", testCaseResultId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<WorkItemReference>>() {});
     }
@@ -935,12 +931,12 @@ public abstract class TestHttpClientBase
         final NameValueCollection queryParameters = new NameValueCollection();
         queryParameters.addIfNotNull("$includeDetails", includeDetails); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, CloneOperationInformation.class);
     }
@@ -971,12 +967,12 @@ public abstract class TestHttpClientBase
         final NameValueCollection queryParameters = new NameValueCollection();
         queryParameters.addIfNotNull("$includeDetails", includeDetails); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, CloneOperationInformation.class);
     }
@@ -1004,13 +1000,13 @@ public abstract class TestHttpClientBase
         routeValues.put("project", project); //$NON-NLS-1$
         routeValues.put("planId", planId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.POST,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       cloneRequestBody,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.POST,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               cloneRequestBody,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, CloneOperationInformation.class);
     }
@@ -1038,13 +1034,13 @@ public abstract class TestHttpClientBase
         routeValues.put("project", project); //$NON-NLS-1$
         routeValues.put("planId", planId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.POST,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       cloneRequestBody,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.POST,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               cloneRequestBody,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, CloneOperationInformation.class);
     }
@@ -1076,13 +1072,13 @@ public abstract class TestHttpClientBase
         routeValues.put("planId", planId); //$NON-NLS-1$
         routeValues.put("sourceSuiteId", sourceSuiteId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.POST,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       cloneRequestBody,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.POST,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               cloneRequestBody,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, CloneOperationInformation.class);
     }
@@ -1114,13 +1110,13 @@ public abstract class TestHttpClientBase
         routeValues.put("planId", planId); //$NON-NLS-1$
         routeValues.put("sourceSuiteId", sourceSuiteId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.POST,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       cloneRequestBody,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.POST,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               cloneRequestBody,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, CloneOperationInformation.class);
     }
@@ -1151,12 +1147,12 @@ public abstract class TestHttpClientBase
         queryParameters.put("buildId", String.valueOf(buildId)); //$NON-NLS-1$
         queryParameters.put("flags", String.valueOf(flags)); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<BuildCoverage>>() {});
     }
@@ -1187,12 +1183,12 @@ public abstract class TestHttpClientBase
         queryParameters.put("buildId", String.valueOf(buildId)); //$NON-NLS-1$
         queryParameters.put("flags", String.valueOf(flags)); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<BuildCoverage>>() {});
     }
@@ -1223,12 +1219,12 @@ public abstract class TestHttpClientBase
         queryParameters.put("buildId", String.valueOf(buildId)); //$NON-NLS-1$
         queryParameters.addIfNotNull("deltaBuildId", deltaBuildId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, CodeCoverageSummary.class);
     }
@@ -1259,12 +1255,12 @@ public abstract class TestHttpClientBase
         queryParameters.put("buildId", String.valueOf(buildId)); //$NON-NLS-1$
         queryParameters.addIfNotNull("deltaBuildId", deltaBuildId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, CodeCoverageSummary.class);
     }
@@ -1293,14 +1289,14 @@ public abstract class TestHttpClientBase
         final NameValueCollection queryParameters = new NameValueCollection();
         queryParameters.put("buildId", String.valueOf(buildId)); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.POST,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       coverageData,
-                                                       APPLICATION_JSON_TYPE,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.POST,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               coverageData,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         super.sendRequest(httpRequest);
     }
@@ -1329,14 +1325,14 @@ public abstract class TestHttpClientBase
         final NameValueCollection queryParameters = new NameValueCollection();
         queryParameters.put("buildId", String.valueOf(buildId)); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.POST,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       coverageData,
-                                                       APPLICATION_JSON_TYPE,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.POST,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               coverageData,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         super.sendRequest(httpRequest);
     }
@@ -1367,12 +1363,12 @@ public abstract class TestHttpClientBase
         final NameValueCollection queryParameters = new NameValueCollection();
         queryParameters.put("flags", String.valueOf(flags)); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<TestRunCoverage>>() {});
     }
@@ -1403,12 +1399,12 @@ public abstract class TestHttpClientBase
         final NameValueCollection queryParameters = new NameValueCollection();
         queryParameters.put("flags", String.valueOf(flags)); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<TestRunCoverage>>() {});
     }
@@ -1432,13 +1428,13 @@ public abstract class TestHttpClientBase
         final Map<String, Object> routeValues = new HashMap<String, Object>();
         routeValues.put("project", project); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.POST,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       testConfiguration,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.POST,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               testConfiguration,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, TestConfiguration.class);
     }
@@ -1462,13 +1458,13 @@ public abstract class TestHttpClientBase
         final Map<String, Object> routeValues = new HashMap<String, Object>();
         routeValues.put("project", project); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.POST,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       testConfiguration,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.POST,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               testConfiguration,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, TestConfiguration.class);
     }
@@ -1492,11 +1488,11 @@ public abstract class TestHttpClientBase
         routeValues.put("project", project); //$NON-NLS-1$
         routeValues.put("testConfigurationId", testConfigurationId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.DELETE,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.DELETE,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         super.sendRequest(httpRequest);
     }
@@ -1520,11 +1516,11 @@ public abstract class TestHttpClientBase
         routeValues.put("project", project); //$NON-NLS-1$
         routeValues.put("testConfigurationId", testConfigurationId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.DELETE,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.DELETE,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         super.sendRequest(httpRequest);
     }
@@ -1549,11 +1545,11 @@ public abstract class TestHttpClientBase
         routeValues.put("project", project); //$NON-NLS-1$
         routeValues.put("testConfigurationId", testConfigurationId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, TestConfiguration.class);
     }
@@ -1578,11 +1574,11 @@ public abstract class TestHttpClientBase
         routeValues.put("project", project); //$NON-NLS-1$
         routeValues.put("testConfigurationId", testConfigurationId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, TestConfiguration.class);
     }
@@ -1617,12 +1613,12 @@ public abstract class TestHttpClientBase
         queryParameters.addIfNotNull("$top", top); //$NON-NLS-1$
         queryParameters.addIfNotNull("includeAllProperties", includeAllProperties); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<TestConfiguration>>() {});
     }
@@ -1657,12 +1653,12 @@ public abstract class TestHttpClientBase
         queryParameters.addIfNotNull("$top", top); //$NON-NLS-1$
         queryParameters.addIfNotNull("includeAllProperties", includeAllProperties); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<TestConfiguration>>() {});
     }
@@ -1690,13 +1686,13 @@ public abstract class TestHttpClientBase
         routeValues.put("project", project); //$NON-NLS-1$
         routeValues.put("testConfigurationId", testConfigurationId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.PATCH,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       testConfiguration,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.PATCH,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               testConfiguration,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, TestConfiguration.class);
     }
@@ -1724,13 +1720,13 @@ public abstract class TestHttpClientBase
         routeValues.put("project", project); //$NON-NLS-1$
         routeValues.put("testConfigurationId", testConfigurationId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.PATCH,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       testConfiguration,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.PATCH,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               testConfiguration,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, TestConfiguration.class);
     }
@@ -1754,13 +1750,13 @@ public abstract class TestHttpClientBase
         final Map<String, Object> routeValues = new HashMap<String, Object>();
         routeValues.put("project", project); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.POST,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       newFields,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.POST,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               newFields,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<CustomTestFieldDefinition>>() {});
     }
@@ -1784,13 +1780,13 @@ public abstract class TestHttpClientBase
         final Map<String, Object> routeValues = new HashMap<String, Object>();
         routeValues.put("project", project); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.POST,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       newFields,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.POST,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               newFields,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<CustomTestFieldDefinition>>() {});
     }
@@ -1817,12 +1813,12 @@ public abstract class TestHttpClientBase
         final NameValueCollection queryParameters = new NameValueCollection();
         queryParameters.addIfNotNull("scopeFilter", scopeFilter); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<CustomTestFieldDefinition>>() {});
     }
@@ -1849,12 +1845,12 @@ public abstract class TestHttpClientBase
         final NameValueCollection queryParameters = new NameValueCollection();
         queryParameters.addIfNotNull("scopeFilter", scopeFilter); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<CustomTestFieldDefinition>>() {});
     }
@@ -1878,13 +1874,13 @@ public abstract class TestHttpClientBase
         final Map<String, Object> routeValues = new HashMap<String, Object>();
         routeValues.put("project", project); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.POST,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       filter,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.POST,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               filter,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, TestResultHistory.class);
     }
@@ -1908,13 +1904,13 @@ public abstract class TestHttpClientBase
         final Map<String, Object> routeValues = new HashMap<String, Object>();
         routeValues.put("project", project); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.POST,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       filter,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.POST,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               filter,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, TestResultHistory.class);
     }
@@ -1953,12 +1949,12 @@ public abstract class TestHttpClientBase
         final NameValueCollection queryParameters = new NameValueCollection();
         queryParameters.addIfNotNull("includeActionResults", includeActionResults); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, TestIterationDetailsModel.class);
     }
@@ -1997,12 +1993,12 @@ public abstract class TestHttpClientBase
         final NameValueCollection queryParameters = new NameValueCollection();
         queryParameters.addIfNotNull("includeActionResults", includeActionResults); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, TestIterationDetailsModel.class);
     }
@@ -2037,12 +2033,12 @@ public abstract class TestHttpClientBase
         final NameValueCollection queryParameters = new NameValueCollection();
         queryParameters.addIfNotNull("includeActionResults", includeActionResults); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<TestIterationDetailsModel>>() {});
     }
@@ -2077,12 +2073,12 @@ public abstract class TestHttpClientBase
         final NameValueCollection queryParameters = new NameValueCollection();
         queryParameters.addIfNotNull("includeActionResults", includeActionResults); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<TestIterationDetailsModel>>() {});
     }
@@ -2107,11 +2103,11 @@ public abstract class TestHttpClientBase
         routeValues.put("project", project); //$NON-NLS-1$
         routeValues.put("runId", runId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<TestMessageLogDetails>>() {});
     }
@@ -2136,11 +2132,11 @@ public abstract class TestHttpClientBase
         routeValues.put("project", project); //$NON-NLS-1$
         routeValues.put("runId", runId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<TestMessageLogDetails>>() {});
     }
@@ -2179,12 +2175,12 @@ public abstract class TestHttpClientBase
         final NameValueCollection queryParameters = new NameValueCollection();
         queryParameters.addIfNotEmpty("paramName", paramName); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<TestResultParameterModel>>() {});
     }
@@ -2223,12 +2219,12 @@ public abstract class TestHttpClientBase
         final NameValueCollection queryParameters = new NameValueCollection();
         queryParameters.addIfNotEmpty("paramName", paramName); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<TestResultParameterModel>>() {});
     }
@@ -2252,13 +2248,13 @@ public abstract class TestHttpClientBase
         final Map<String, Object> routeValues = new HashMap<String, Object>();
         routeValues.put("project", project); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.POST,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       testPlan,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.POST,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               testPlan,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, TestPlan.class);
     }
@@ -2282,13 +2278,13 @@ public abstract class TestHttpClientBase
         final Map<String, Object> routeValues = new HashMap<String, Object>();
         routeValues.put("project", project); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.POST,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       testPlan,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.POST,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               testPlan,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, TestPlan.class);
     }
@@ -2312,11 +2308,11 @@ public abstract class TestHttpClientBase
         routeValues.put("project", project); //$NON-NLS-1$
         routeValues.put("planId", planId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.DELETE,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.DELETE,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         super.sendRequest(httpRequest);
     }
@@ -2340,11 +2336,11 @@ public abstract class TestHttpClientBase
         routeValues.put("project", project); //$NON-NLS-1$
         routeValues.put("planId", planId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.DELETE,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.DELETE,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         super.sendRequest(httpRequest);
     }
@@ -2369,11 +2365,11 @@ public abstract class TestHttpClientBase
         routeValues.put("project", project); //$NON-NLS-1$
         routeValues.put("planId", planId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, TestPlan.class);
     }
@@ -2398,11 +2394,11 @@ public abstract class TestHttpClientBase
         routeValues.put("project", project); //$NON-NLS-1$
         routeValues.put("planId", planId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, TestPlan.class);
     }
@@ -2445,12 +2441,12 @@ public abstract class TestHttpClientBase
         queryParameters.addIfNotNull("includePlanDetails", includePlanDetails); //$NON-NLS-1$
         queryParameters.addIfNotNull("filterActivePlans", filterActivePlans); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<TestPlan>>() {});
     }
@@ -2493,12 +2489,12 @@ public abstract class TestHttpClientBase
         queryParameters.addIfNotNull("includePlanDetails", includePlanDetails); //$NON-NLS-1$
         queryParameters.addIfNotNull("filterActivePlans", filterActivePlans); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<TestPlan>>() {});
     }
@@ -2526,13 +2522,13 @@ public abstract class TestHttpClientBase
         routeValues.put("project", project); //$NON-NLS-1$
         routeValues.put("planId", planId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.PATCH,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       planUpdateModel,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.PATCH,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               planUpdateModel,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, TestPlan.class);
     }
@@ -2560,13 +2556,13 @@ public abstract class TestHttpClientBase
         routeValues.put("project", project); //$NON-NLS-1$
         routeValues.put("planId", planId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.PATCH,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       planUpdateModel,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.PATCH,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               planUpdateModel,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, TestPlan.class);
     }
@@ -2605,12 +2601,12 @@ public abstract class TestHttpClientBase
         final NameValueCollection queryParameters = new NameValueCollection();
         queryParameters.addIfNotEmpty("witFields", witFields); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, TestPoint.class);
     }
@@ -2649,12 +2645,12 @@ public abstract class TestHttpClientBase
         final NameValueCollection queryParameters = new NameValueCollection();
         queryParameters.addIfNotEmpty("witFields", witFields); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, TestPoint.class);
     }
@@ -2713,12 +2709,12 @@ public abstract class TestHttpClientBase
         queryParameters.addIfNotNull("$skip", skip); //$NON-NLS-1$
         queryParameters.addIfNotNull("$top", top); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<TestPoint>>() {});
     }
@@ -2777,12 +2773,12 @@ public abstract class TestHttpClientBase
         queryParameters.addIfNotNull("$skip", skip); //$NON-NLS-1$
         queryParameters.addIfNotNull("$top", top); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<TestPoint>>() {});
     }
@@ -2818,13 +2814,13 @@ public abstract class TestHttpClientBase
         routeValues.put("suiteId", suiteId); //$NON-NLS-1$
         routeValues.put("pointIds", pointIds); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.PATCH,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       pointUpdateModel,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.PATCH,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               pointUpdateModel,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<TestPoint>>() {});
     }
@@ -2860,13 +2856,13 @@ public abstract class TestHttpClientBase
         routeValues.put("suiteId", suiteId); //$NON-NLS-1$
         routeValues.put("pointIds", pointIds); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.PATCH,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       pointUpdateModel,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.PATCH,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               pointUpdateModel,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<TestPoint>>() {});
     }
@@ -2909,12 +2905,12 @@ public abstract class TestHttpClientBase
         queryParameters.addIfNotEmpty("$filter", filter); //$NON-NLS-1$
         queryParameters.addIfNotEmpty("$orderby", orderby); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, TestResultsDetails.class);
     }
@@ -2957,12 +2953,12 @@ public abstract class TestHttpClientBase
         queryParameters.addIfNotEmpty("$filter", filter); //$NON-NLS-1$
         queryParameters.addIfNotEmpty("$orderby", orderby); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, TestResultsDetails.class);
     }
@@ -3009,12 +3005,12 @@ public abstract class TestHttpClientBase
         queryParameters.addIfNotEmpty("$filter", filter); //$NON-NLS-1$
         queryParameters.addIfNotEmpty("$orderby", orderby); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, TestResultsDetails.class);
     }
@@ -3061,12 +3057,12 @@ public abstract class TestHttpClientBase
         queryParameters.addIfNotEmpty("$filter", filter); //$NON-NLS-1$
         queryParameters.addIfNotEmpty("$orderby", orderby); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, TestResultsDetails.class);
     }
@@ -3086,11 +3082,11 @@ public abstract class TestHttpClientBase
         final Map<String, Object> routeValues = new HashMap<String, Object>();
         routeValues.put("project", project); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, ResultRetentionSettings.class);
     }
@@ -3110,11 +3106,11 @@ public abstract class TestHttpClientBase
         final Map<String, Object> routeValues = new HashMap<String, Object>();
         routeValues.put("project", project); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, ResultRetentionSettings.class);
     }
@@ -3138,13 +3134,13 @@ public abstract class TestHttpClientBase
         final Map<String, Object> routeValues = new HashMap<String, Object>();
         routeValues.put("project", project); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.PATCH,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       retentionSettings,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.PATCH,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               retentionSettings,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, ResultRetentionSettings.class);
     }
@@ -3168,13 +3164,13 @@ public abstract class TestHttpClientBase
         final Map<String, Object> routeValues = new HashMap<String, Object>();
         routeValues.put("project", project); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.PATCH,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       retentionSettings,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.PATCH,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               retentionSettings,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, ResultRetentionSettings.class);
     }
@@ -3202,13 +3198,13 @@ public abstract class TestHttpClientBase
         routeValues.put("project", project); //$NON-NLS-1$
         routeValues.put("runId", runId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.POST,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       results,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.POST,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               results,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<TestCaseResult>>() {});
     }
@@ -3236,13 +3232,13 @@ public abstract class TestHttpClientBase
         routeValues.put("project", project); //$NON-NLS-1$
         routeValues.put("runId", runId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.POST,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       results,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.POST,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               results,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<TestCaseResult>>() {});
     }
@@ -3276,14 +3272,14 @@ public abstract class TestHttpClientBase
         final NameValueCollection queryParameters = new NameValueCollection();
         queryParameters.addIfNotNull("resultIds", resultIds); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.PATCH,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       result,
-                                                       APPLICATION_JSON_TYPE,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.PATCH,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               result,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<TestCaseResult>>() {});
     }
@@ -3317,14 +3313,14 @@ public abstract class TestHttpClientBase
         final NameValueCollection queryParameters = new NameValueCollection();
         queryParameters.addIfNotNull("resultIds", resultIds); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.PATCH,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       result,
-                                                       APPLICATION_JSON_TYPE,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.PATCH,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               result,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<TestCaseResult>>() {});
     }
@@ -3359,12 +3355,12 @@ public abstract class TestHttpClientBase
         final NameValueCollection queryParameters = new NameValueCollection();
         queryParameters.addIfNotNull("detailsToInclude", detailsToInclude); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, TestCaseResult.class);
     }
@@ -3399,12 +3395,12 @@ public abstract class TestHttpClientBase
         final NameValueCollection queryParameters = new NameValueCollection();
         queryParameters.addIfNotNull("detailsToInclude", detailsToInclude); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, TestCaseResult.class);
     }
@@ -3443,12 +3439,12 @@ public abstract class TestHttpClientBase
         queryParameters.addIfNotNull("$skip", skip); //$NON-NLS-1$
         queryParameters.addIfNotNull("$top", top); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<TestCaseResult>>() {});
     }
@@ -3487,12 +3483,12 @@ public abstract class TestHttpClientBase
         queryParameters.addIfNotNull("$skip", skip); //$NON-NLS-1$
         queryParameters.addIfNotNull("$top", top); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<TestCaseResult>>() {});
     }
@@ -3520,13 +3516,13 @@ public abstract class TestHttpClientBase
         routeValues.put("project", project); //$NON-NLS-1$
         routeValues.put("runId", runId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.PATCH,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       results,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.PATCH,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               results,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<TestCaseResult>>() {});
     }
@@ -3554,13 +3550,13 @@ public abstract class TestHttpClientBase
         routeValues.put("project", project); //$NON-NLS-1$
         routeValues.put("runId", runId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.PATCH,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       results,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.PATCH,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               results,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<TestCaseResult>>() {});
     }
@@ -3584,13 +3580,13 @@ public abstract class TestHttpClientBase
         final Map<String, Object> routeValues = new HashMap<String, Object>();
         routeValues.put("project", project); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.POST,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       query,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.POST,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               query,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, TestResultsQuery.class);
     }
@@ -3614,13 +3610,13 @@ public abstract class TestHttpClientBase
         final Map<String, Object> routeValues = new HashMap<String, Object>();
         routeValues.put("project", project); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.POST,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       query,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.POST,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               query,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, TestResultsQuery.class);
     }
@@ -3659,12 +3655,12 @@ public abstract class TestHttpClientBase
         queryParameters.addIfNotNull("includeFailureDetails", includeFailureDetails); //$NON-NLS-1$
         addModelAsQueryParams(queryParameters, buildToCompare);
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, TestResultSummary.class);
     }
@@ -3703,12 +3699,12 @@ public abstract class TestHttpClientBase
         queryParameters.addIfNotNull("includeFailureDetails", includeFailureDetails); //$NON-NLS-1$
         addModelAsQueryParams(queryParameters, buildToCompare);
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, TestResultSummary.class);
     }
@@ -3751,12 +3747,12 @@ public abstract class TestHttpClientBase
         queryParameters.addIfNotNull("includeFailureDetails", includeFailureDetails); //$NON-NLS-1$
         addModelAsQueryParams(queryParameters, releaseToCompare);
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, TestResultSummary.class);
     }
@@ -3799,12 +3795,12 @@ public abstract class TestHttpClientBase
         queryParameters.addIfNotNull("includeFailureDetails", includeFailureDetails); //$NON-NLS-1$
         addModelAsQueryParams(queryParameters, releaseToCompare);
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, TestResultSummary.class);
     }
@@ -3828,13 +3824,13 @@ public abstract class TestHttpClientBase
         final Map<String, Object> routeValues = new HashMap<String, Object>();
         routeValues.put("project", project); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.POST,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       releases,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.POST,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               releases,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<TestResultSummary>>() {});
     }
@@ -3858,13 +3854,13 @@ public abstract class TestHttpClientBase
         final Map<String, Object> routeValues = new HashMap<String, Object>();
         routeValues.put("project", project); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.POST,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       releases,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.POST,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               releases,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<TestResultSummary>>() {});
     }
@@ -3894,14 +3890,14 @@ public abstract class TestHttpClientBase
         final NameValueCollection queryParameters = new NameValueCollection();
         queryParameters.addIfNotNull("workItemIds", workItemIds); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.POST,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       resultsContext,
-                                                       APPLICATION_JSON_TYPE,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.POST,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               resultsContext,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<TestSummaryForWorkItem>>() {});
     }
@@ -3931,14 +3927,14 @@ public abstract class TestHttpClientBase
         final NameValueCollection queryParameters = new NameValueCollection();
         queryParameters.addIfNotNull("workItemIds", workItemIds); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.POST,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       resultsContext,
-                                                       APPLICATION_JSON_TYPE,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.POST,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               resultsContext,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<TestSummaryForWorkItem>>() {});
     }
@@ -3962,13 +3958,13 @@ public abstract class TestHttpClientBase
         final Map<String, Object> routeValues = new HashMap<String, Object>();
         routeValues.put("project", project); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.POST,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       filter,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.POST,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               filter,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<AggregatedDataForResultTrend>>() {});
     }
@@ -3992,13 +3988,13 @@ public abstract class TestHttpClientBase
         final Map<String, Object> routeValues = new HashMap<String, Object>();
         routeValues.put("project", project); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.POST,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       filter,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.POST,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               filter,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<AggregatedDataForResultTrend>>() {});
     }
@@ -4023,11 +4019,11 @@ public abstract class TestHttpClientBase
         routeValues.put("project", project); //$NON-NLS-1$
         routeValues.put("runId", runId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, TestRunStatistic.class);
     }
@@ -4052,11 +4048,11 @@ public abstract class TestHttpClientBase
         routeValues.put("project", project); //$NON-NLS-1$
         routeValues.put("runId", runId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, TestRunStatistic.class);
     }
@@ -4080,13 +4076,13 @@ public abstract class TestHttpClientBase
         final Map<String, Object> routeValues = new HashMap<String, Object>();
         routeValues.put("project", project); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.POST,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       testRun,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.POST,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               testRun,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, TestRun.class);
     }
@@ -4110,13 +4106,13 @@ public abstract class TestHttpClientBase
         final Map<String, Object> routeValues = new HashMap<String, Object>();
         routeValues.put("project", project); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.POST,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       testRun,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.POST,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               testRun,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, TestRun.class);
     }
@@ -4140,11 +4136,11 @@ public abstract class TestHttpClientBase
         routeValues.put("project", project); //$NON-NLS-1$
         routeValues.put("runId", runId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.DELETE,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.DELETE,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         super.sendRequest(httpRequest);
     }
@@ -4168,11 +4164,11 @@ public abstract class TestHttpClientBase
         routeValues.put("project", project); //$NON-NLS-1$
         routeValues.put("runId", runId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.DELETE,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.DELETE,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         super.sendRequest(httpRequest);
     }
@@ -4197,11 +4193,11 @@ public abstract class TestHttpClientBase
         routeValues.put("project", project); //$NON-NLS-1$
         routeValues.put("runId", runId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, TestRun.class);
     }
@@ -4226,11 +4222,11 @@ public abstract class TestHttpClientBase
         routeValues.put("project", project); //$NON-NLS-1$
         routeValues.put("runId", runId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, TestRun.class);
     }
@@ -4285,12 +4281,12 @@ public abstract class TestHttpClientBase
         queryParameters.addIfNotNull("$skip", skip); //$NON-NLS-1$
         queryParameters.addIfNotNull("$top", top); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<TestRun>>() {});
     }
@@ -4345,12 +4341,12 @@ public abstract class TestHttpClientBase
         queryParameters.addIfNotNull("$skip", skip); //$NON-NLS-1$
         queryParameters.addIfNotNull("$top", top); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<TestRun>>() {});
     }
@@ -4378,13 +4374,13 @@ public abstract class TestHttpClientBase
         routeValues.put("project", project); //$NON-NLS-1$
         routeValues.put("runId", runId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.PATCH,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       runUpdateModel,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.PATCH,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               runUpdateModel,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, TestRun.class);
     }
@@ -4412,13 +4408,13 @@ public abstract class TestHttpClientBase
         routeValues.put("project", project); //$NON-NLS-1$
         routeValues.put("runId", runId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.PATCH,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       runUpdateModel,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.PATCH,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               runUpdateModel,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, TestRun.class);
     }
@@ -4442,13 +4438,13 @@ public abstract class TestHttpClientBase
         final Map<String, Object> routeValues = new HashMap<String, Object>();
         routeValues.put("project", project); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.POST,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       testSession,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.POST,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               testSession,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, TestSession.class);
     }
@@ -4472,13 +4468,13 @@ public abstract class TestHttpClientBase
         final Map<String, Object> routeValues = new HashMap<String, Object>();
         routeValues.put("project", project); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.POST,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       testSession,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.POST,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               testSession,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, TestSession.class);
     }
@@ -4506,13 +4502,13 @@ public abstract class TestHttpClientBase
         routeValues.put("project", project); //$NON-NLS-1$
         routeValues.put("team", team); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.POST,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       testSession,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.POST,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               testSession,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, TestSession.class);
     }
@@ -4540,13 +4536,13 @@ public abstract class TestHttpClientBase
         routeValues.put("project", project); //$NON-NLS-1$
         routeValues.put("team", team); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.POST,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       testSession,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.POST,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               testSession,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, TestSession.class);
     }
@@ -4563,6 +4559,10 @@ public abstract class TestHttpClientBase
      * @param allSessions 
      *            
      * @param includeAllProperties 
+     *            
+     * @param source 
+     *            
+     * @param includeOnlyCompletedSessions 
      *            
      * @return ArrayList&lt;TestSession&gt;
      */
@@ -4571,7 +4571,9 @@ public abstract class TestHttpClientBase
         final String team, 
         final Integer period, 
         final Boolean allSessions, 
-        final Boolean includeAllProperties) { 
+        final Boolean includeAllProperties, 
+        final TestSessionSource source, 
+        final Boolean includeOnlyCompletedSessions) { 
 
         final UUID locationId = UUID.fromString("1500b4b4-6c69-4ca6-9b18-35e9e97fe2ac"); //$NON-NLS-1$
         final ApiResourceVersion apiVersion = new ApiResourceVersion("3.0-preview.1"); //$NON-NLS-1$
@@ -4584,13 +4586,15 @@ public abstract class TestHttpClientBase
         queryParameters.addIfNotNull("period", period); //$NON-NLS-1$
         queryParameters.addIfNotNull("allSessions", allSessions); //$NON-NLS-1$
         queryParameters.addIfNotNull("includeAllProperties", includeAllProperties); //$NON-NLS-1$
+        queryParameters.addIfNotNull("source", source); //$NON-NLS-1$
+        queryParameters.addIfNotNull("includeOnlyCompletedSessions", includeOnlyCompletedSessions); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<TestSession>>() {});
     }
@@ -4608,6 +4612,10 @@ public abstract class TestHttpClientBase
      *            
      * @param includeAllProperties 
      *            
+     * @param source 
+     *            
+     * @param includeOnlyCompletedSessions 
+     *            
      * @return ArrayList&lt;TestSession&gt;
      */
     public ArrayList<TestSession> getTestSessions(
@@ -4615,7 +4623,9 @@ public abstract class TestHttpClientBase
         final UUID team, 
         final Integer period, 
         final Boolean allSessions, 
-        final Boolean includeAllProperties) { 
+        final Boolean includeAllProperties, 
+        final TestSessionSource source, 
+        final Boolean includeOnlyCompletedSessions) { 
 
         final UUID locationId = UUID.fromString("1500b4b4-6c69-4ca6-9b18-35e9e97fe2ac"); //$NON-NLS-1$
         final ApiResourceVersion apiVersion = new ApiResourceVersion("3.0-preview.1"); //$NON-NLS-1$
@@ -4628,13 +4638,15 @@ public abstract class TestHttpClientBase
         queryParameters.addIfNotNull("period", period); //$NON-NLS-1$
         queryParameters.addIfNotNull("allSessions", allSessions); //$NON-NLS-1$
         queryParameters.addIfNotNull("includeAllProperties", includeAllProperties); //$NON-NLS-1$
+        queryParameters.addIfNotNull("source", source); //$NON-NLS-1$
+        queryParameters.addIfNotNull("includeOnlyCompletedSessions", includeOnlyCompletedSessions); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<TestSession>>() {});
     }
@@ -4650,13 +4662,19 @@ public abstract class TestHttpClientBase
      *            
      * @param includeAllProperties 
      *            
+     * @param source 
+     *            
+     * @param includeOnlyCompletedSessions 
+     *            
      * @return ArrayList&lt;TestSession&gt;
      */
     public ArrayList<TestSession> getTestSessions(
         final String project, 
         final Integer period, 
         final Boolean allSessions, 
-        final Boolean includeAllProperties) { 
+        final Boolean includeAllProperties, 
+        final TestSessionSource source, 
+        final Boolean includeOnlyCompletedSessions) { 
 
         final UUID locationId = UUID.fromString("1500b4b4-6c69-4ca6-9b18-35e9e97fe2ac"); //$NON-NLS-1$
         final ApiResourceVersion apiVersion = new ApiResourceVersion("3.0-preview.1"); //$NON-NLS-1$
@@ -4668,13 +4686,15 @@ public abstract class TestHttpClientBase
         queryParameters.addIfNotNull("period", period); //$NON-NLS-1$
         queryParameters.addIfNotNull("allSessions", allSessions); //$NON-NLS-1$
         queryParameters.addIfNotNull("includeAllProperties", includeAllProperties); //$NON-NLS-1$
+        queryParameters.addIfNotNull("source", source); //$NON-NLS-1$
+        queryParameters.addIfNotNull("includeOnlyCompletedSessions", includeOnlyCompletedSessions); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<TestSession>>() {});
     }
@@ -4690,13 +4710,19 @@ public abstract class TestHttpClientBase
      *            
      * @param includeAllProperties 
      *            
+     * @param source 
+     *            
+     * @param includeOnlyCompletedSessions 
+     *            
      * @return ArrayList&lt;TestSession&gt;
      */
     public ArrayList<TestSession> getTestSessions(
         final UUID project, 
         final Integer period, 
         final Boolean allSessions, 
-        final Boolean includeAllProperties) { 
+        final Boolean includeAllProperties, 
+        final TestSessionSource source, 
+        final Boolean includeOnlyCompletedSessions) { 
 
         final UUID locationId = UUID.fromString("1500b4b4-6c69-4ca6-9b18-35e9e97fe2ac"); //$NON-NLS-1$
         final ApiResourceVersion apiVersion = new ApiResourceVersion("3.0-preview.1"); //$NON-NLS-1$
@@ -4708,13 +4734,15 @@ public abstract class TestHttpClientBase
         queryParameters.addIfNotNull("period", period); //$NON-NLS-1$
         queryParameters.addIfNotNull("allSessions", allSessions); //$NON-NLS-1$
         queryParameters.addIfNotNull("includeAllProperties", includeAllProperties); //$NON-NLS-1$
+        queryParameters.addIfNotNull("source", source); //$NON-NLS-1$
+        queryParameters.addIfNotNull("includeOnlyCompletedSessions", includeOnlyCompletedSessions); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<TestSession>>() {});
     }
@@ -4738,13 +4766,13 @@ public abstract class TestHttpClientBase
         final Map<String, Object> routeValues = new HashMap<String, Object>();
         routeValues.put("project", project); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.PATCH,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       testSession,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.PATCH,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               testSession,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, TestSession.class);
     }
@@ -4768,13 +4796,13 @@ public abstract class TestHttpClientBase
         final Map<String, Object> routeValues = new HashMap<String, Object>();
         routeValues.put("project", project); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.PATCH,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       testSession,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.PATCH,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               testSession,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, TestSession.class);
     }
@@ -4802,13 +4830,13 @@ public abstract class TestHttpClientBase
         routeValues.put("project", project); //$NON-NLS-1$
         routeValues.put("team", team); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.PATCH,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       testSession,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.PATCH,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               testSession,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, TestSession.class);
     }
@@ -4836,13 +4864,13 @@ public abstract class TestHttpClientBase
         routeValues.put("project", project); //$NON-NLS-1$
         routeValues.put("team", team); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.PATCH,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       testSession,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.PATCH,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               testSession,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, TestSession.class);
     }
@@ -4867,11 +4895,11 @@ public abstract class TestHttpClientBase
         routeValues.put("project", project); //$NON-NLS-1$
         routeValues.put("suiteId", suiteId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<SuiteEntry>>() {});
     }
@@ -4896,11 +4924,11 @@ public abstract class TestHttpClientBase
         routeValues.put("project", project); //$NON-NLS-1$
         routeValues.put("suiteId", suiteId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<SuiteEntry>>() {});
     }
@@ -4928,13 +4956,13 @@ public abstract class TestHttpClientBase
         routeValues.put("project", project); //$NON-NLS-1$
         routeValues.put("suiteId", suiteId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.PATCH,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       suiteEntries,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.PATCH,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               suiteEntries,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<SuiteEntry>>() {});
     }
@@ -4962,13 +4990,13 @@ public abstract class TestHttpClientBase
         routeValues.put("project", project); //$NON-NLS-1$
         routeValues.put("suiteId", suiteId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.PATCH,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       suiteEntries,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.PATCH,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               suiteEntries,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<SuiteEntry>>() {});
     }
@@ -5001,11 +5029,11 @@ public abstract class TestHttpClientBase
         routeValues.put("suiteId", suiteId); //$NON-NLS-1$
         routeValues.put("testCaseIds", testCaseIds); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.POST,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.POST,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<SuiteTestCase>>() {});
     }
@@ -5038,11 +5066,11 @@ public abstract class TestHttpClientBase
         routeValues.put("suiteId", suiteId); //$NON-NLS-1$
         routeValues.put("testCaseIds", testCaseIds); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.POST,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.POST,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<SuiteTestCase>>() {});
     }
@@ -5075,11 +5103,11 @@ public abstract class TestHttpClientBase
         routeValues.put("suiteId", suiteId); //$NON-NLS-1$
         routeValues.put("testCaseIds", testCaseIds); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, SuiteTestCase.class);
     }
@@ -5112,11 +5140,11 @@ public abstract class TestHttpClientBase
         routeValues.put("suiteId", suiteId); //$NON-NLS-1$
         routeValues.put("testCaseIds", testCaseIds); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, SuiteTestCase.class);
     }
@@ -5145,11 +5173,11 @@ public abstract class TestHttpClientBase
         routeValues.put("planId", planId); //$NON-NLS-1$
         routeValues.put("suiteId", suiteId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<SuiteTestCase>>() {});
     }
@@ -5178,11 +5206,11 @@ public abstract class TestHttpClientBase
         routeValues.put("planId", planId); //$NON-NLS-1$
         routeValues.put("suiteId", suiteId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<SuiteTestCase>>() {});
     }
@@ -5214,11 +5242,11 @@ public abstract class TestHttpClientBase
         routeValues.put("suiteId", suiteId); //$NON-NLS-1$
         routeValues.put("testCaseIds", testCaseIds); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.DELETE,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.DELETE,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         super.sendRequest(httpRequest);
     }
@@ -5250,11 +5278,11 @@ public abstract class TestHttpClientBase
         routeValues.put("suiteId", suiteId); //$NON-NLS-1$
         routeValues.put("testCaseIds", testCaseIds); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.DELETE,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.DELETE,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         super.sendRequest(httpRequest);
     }
@@ -5286,13 +5314,13 @@ public abstract class TestHttpClientBase
         routeValues.put("planId", planId); //$NON-NLS-1$
         routeValues.put("suiteId", suiteId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.POST,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       testSuite,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.POST,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               testSuite,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<TestSuite>>() {});
     }
@@ -5324,13 +5352,13 @@ public abstract class TestHttpClientBase
         routeValues.put("planId", planId); //$NON-NLS-1$
         routeValues.put("suiteId", suiteId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.POST,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       testSuite,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.POST,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               testSuite,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<TestSuite>>() {});
     }
@@ -5358,11 +5386,11 @@ public abstract class TestHttpClientBase
         routeValues.put("planId", planId); //$NON-NLS-1$
         routeValues.put("suiteId", suiteId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.DELETE,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.DELETE,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         super.sendRequest(httpRequest);
     }
@@ -5390,11 +5418,11 @@ public abstract class TestHttpClientBase
         routeValues.put("planId", planId); //$NON-NLS-1$
         routeValues.put("suiteId", suiteId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.DELETE,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.DELETE,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         super.sendRequest(httpRequest);
     }
@@ -5429,12 +5457,12 @@ public abstract class TestHttpClientBase
         final NameValueCollection queryParameters = new NameValueCollection();
         queryParameters.addIfNotNull("includeChildSuites", includeChildSuites); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, TestSuite.class);
     }
@@ -5469,12 +5497,12 @@ public abstract class TestHttpClientBase
         final NameValueCollection queryParameters = new NameValueCollection();
         queryParameters.addIfNotNull("includeChildSuites", includeChildSuites); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, TestSuite.class);
     }
@@ -5517,12 +5545,12 @@ public abstract class TestHttpClientBase
         queryParameters.addIfNotNull("$top", top); //$NON-NLS-1$
         queryParameters.addIfNotNull("$asTreeView", asTreeView); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<TestSuite>>() {});
     }
@@ -5565,12 +5593,12 @@ public abstract class TestHttpClientBase
         queryParameters.addIfNotNull("$top", top); //$NON-NLS-1$
         queryParameters.addIfNotNull("$asTreeView", asTreeView); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<TestSuite>>() {});
     }
@@ -5602,13 +5630,13 @@ public abstract class TestHttpClientBase
         routeValues.put("planId", planId); //$NON-NLS-1$
         routeValues.put("suiteId", suiteId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.PATCH,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       suiteUpdateModel,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.PATCH,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               suiteUpdateModel,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, TestSuite.class);
     }
@@ -5640,13 +5668,13 @@ public abstract class TestHttpClientBase
         routeValues.put("planId", planId); //$NON-NLS-1$
         routeValues.put("suiteId", suiteId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.PATCH,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       suiteUpdateModel,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.PATCH,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               suiteUpdateModel,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, TestSuite.class);
     }
@@ -5666,11 +5694,11 @@ public abstract class TestHttpClientBase
         final NameValueCollection queryParameters = new NameValueCollection();
         queryParameters.put("testCaseId", String.valueOf(testCaseId)); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<TestSuite>>() {});
     }
@@ -5694,13 +5722,13 @@ public abstract class TestHttpClientBase
         final Map<String, Object> routeValues = new HashMap<String, Object>();
         routeValues.put("project", project); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.POST,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       testSettings,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.POST,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               testSettings,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, int.class);
     }
@@ -5724,13 +5752,13 @@ public abstract class TestHttpClientBase
         final Map<String, Object> routeValues = new HashMap<String, Object>();
         routeValues.put("project", project); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.POST,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       testSettings,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.POST,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               testSettings,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, int.class);
     }
@@ -5754,11 +5782,11 @@ public abstract class TestHttpClientBase
         routeValues.put("project", project); //$NON-NLS-1$
         routeValues.put("testSettingsId", testSettingsId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.DELETE,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.DELETE,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         super.sendRequest(httpRequest);
     }
@@ -5782,11 +5810,11 @@ public abstract class TestHttpClientBase
         routeValues.put("project", project); //$NON-NLS-1$
         routeValues.put("testSettingsId", testSettingsId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.DELETE,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.DELETE,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         super.sendRequest(httpRequest);
     }
@@ -5811,11 +5839,11 @@ public abstract class TestHttpClientBase
         routeValues.put("project", project); //$NON-NLS-1$
         routeValues.put("testSettingsId", testSettingsId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, TestSettings.class);
     }
@@ -5840,11 +5868,11 @@ public abstract class TestHttpClientBase
         routeValues.put("project", project); //$NON-NLS-1$
         routeValues.put("testSettingsId", testSettingsId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, TestSettings.class);
     }
@@ -5868,13 +5896,13 @@ public abstract class TestHttpClientBase
         final Map<String, Object> routeValues = new HashMap<String, Object>();
         routeValues.put("project", project); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.POST,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       testVariable,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.POST,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               testVariable,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, TestVariable.class);
     }
@@ -5898,13 +5926,13 @@ public abstract class TestHttpClientBase
         final Map<String, Object> routeValues = new HashMap<String, Object>();
         routeValues.put("project", project); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.POST,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       testVariable,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.POST,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               testVariable,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, TestVariable.class);
     }
@@ -5928,11 +5956,11 @@ public abstract class TestHttpClientBase
         routeValues.put("project", project); //$NON-NLS-1$
         routeValues.put("testVariableId", testVariableId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.DELETE,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.DELETE,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         super.sendRequest(httpRequest);
     }
@@ -5956,11 +5984,11 @@ public abstract class TestHttpClientBase
         routeValues.put("project", project); //$NON-NLS-1$
         routeValues.put("testVariableId", testVariableId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.DELETE,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.DELETE,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         super.sendRequest(httpRequest);
     }
@@ -5985,11 +6013,11 @@ public abstract class TestHttpClientBase
         routeValues.put("project", project); //$NON-NLS-1$
         routeValues.put("testVariableId", testVariableId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, TestVariable.class);
     }
@@ -6014,11 +6042,11 @@ public abstract class TestHttpClientBase
         routeValues.put("project", project); //$NON-NLS-1$
         routeValues.put("testVariableId", testVariableId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, TestVariable.class);
     }
@@ -6049,12 +6077,12 @@ public abstract class TestHttpClientBase
         queryParameters.addIfNotNull("$skip", skip); //$NON-NLS-1$
         queryParameters.addIfNotNull("$top", top); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<TestVariable>>() {});
     }
@@ -6085,12 +6113,12 @@ public abstract class TestHttpClientBase
         queryParameters.addIfNotNull("$skip", skip); //$NON-NLS-1$
         queryParameters.addIfNotNull("$top", top); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<TestVariable>>() {});
     }
@@ -6118,13 +6146,13 @@ public abstract class TestHttpClientBase
         routeValues.put("project", project); //$NON-NLS-1$
         routeValues.put("testVariableId", testVariableId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.PATCH,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       testVariable,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.PATCH,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               testVariable,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, TestVariable.class);
     }
@@ -6152,13 +6180,13 @@ public abstract class TestHttpClientBase
         routeValues.put("project", project); //$NON-NLS-1$
         routeValues.put("testVariableId", testVariableId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.PATCH,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       testVariable,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.PATCH,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               testVariable,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, TestVariable.class);
     }
@@ -6182,13 +6210,13 @@ public abstract class TestHttpClientBase
         final Map<String, Object> routeValues = new HashMap<String, Object>();
         routeValues.put("project", project); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.POST,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       workItemToTestLinks,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.POST,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               workItemToTestLinks,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, WorkItemToTestLinks.class);
     }
@@ -6212,13 +6240,13 @@ public abstract class TestHttpClientBase
         final Map<String, Object> routeValues = new HashMap<String, Object>();
         routeValues.put("project", project); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.POST,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       workItemToTestLinks,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.POST,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               workItemToTestLinks,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, WorkItemToTestLinks.class);
     }
@@ -6249,12 +6277,12 @@ public abstract class TestHttpClientBase
         queryParameters.addIfNotEmpty("testName", testName); //$NON-NLS-1$
         queryParameters.put("workItemId", String.valueOf(workItemId)); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.DELETE,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.DELETE,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, boolean.class);
     }
@@ -6285,12 +6313,12 @@ public abstract class TestHttpClientBase
         queryParameters.addIfNotEmpty("testName", testName); //$NON-NLS-1$
         queryParameters.put("workItemId", String.valueOf(workItemId)); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.DELETE,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.DELETE,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, boolean.class);
     }
@@ -6317,12 +6345,12 @@ public abstract class TestHttpClientBase
         final NameValueCollection queryParameters = new NameValueCollection();
         queryParameters.addIfNotEmpty("testName", testName); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.POST,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.POST,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, TestToWorkItemLinks.class);
     }
@@ -6349,12 +6377,12 @@ public abstract class TestHttpClientBase
         final NameValueCollection queryParameters = new NameValueCollection();
         queryParameters.addIfNotEmpty("testName", testName); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.POST,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.POST,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, TestToWorkItemLinks.class);
     }
@@ -6401,12 +6429,12 @@ public abstract class TestHttpClientBase
         queryParameters.addIfNotNull("days", days); //$NON-NLS-1$
         queryParameters.addIfNotNull("$workItemCount", workItemCount); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<WorkItemReference>>() {});
     }
@@ -6453,12 +6481,12 @@ public abstract class TestHttpClientBase
         queryParameters.addIfNotNull("days", days); //$NON-NLS-1$
         queryParameters.addIfNotNull("$workItemCount", workItemCount); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<WorkItemReference>>() {});
     }

--- a/Rest/alm-tfs-client/src/main/generated/com/microsoft/alm/teamfoundation/testmanagement/webapi/TestRun.java
+++ b/Rest/alm-tfs-client/src/main/generated/com/microsoft/alm/teamfoundation/testmanagement/webapi/TestRun.java
@@ -52,6 +52,7 @@ public class TestRun {
     private ShallowReference plan;
     private String postProcessState;
     private ShallowReference project;
+    private ReleaseReference release;
     private String releaseEnvironmentUri;
     private String releaseUri;
     private int revision;
@@ -291,6 +292,14 @@ public class TestRun {
 
     public void setProject(final ShallowReference project) {
         this.project = project;
+    }
+
+    public ReleaseReference getRelease() {
+        return release;
+    }
+
+    public void setRelease(final ReleaseReference release) {
+        this.release = release;
     }
 
     public String getReleaseEnvironmentUri() {

--- a/Rest/alm-tfs-client/src/main/generated/com/microsoft/alm/teamfoundation/testmanagement/webapi/TestSessionState.java
+++ b/Rest/alm-tfs-client/src/main/generated/com/microsoft/alm/teamfoundation/testmanagement/webapi/TestSessionState.java
@@ -40,6 +40,10 @@ public enum TestSessionState {
     * The session has completed.
     */
     COMPLETED(4),
+    /**
+    * This is required for Feedback session which are declined
+    */
+    DECLINED(5),
     ;
 
     private int value;
@@ -74,6 +78,10 @@ public enum TestSessionState {
 
         if (name.equals("COMPLETED")) { //$NON-NLS-1$
             return "completed"; //$NON-NLS-1$
+        }
+
+        if (name.equals("DECLINED")) { //$NON-NLS-1$
+            return "declined"; //$NON-NLS-1$
         }
 
         return null;

--- a/Rest/alm-tfs-client/src/main/generated/com/microsoft/alm/teamfoundation/work/webapi/CreatePlan.java
+++ b/Rest/alm-tfs-client/src/main/generated/com/microsoft/alm/teamfoundation/work/webapi/CreatePlan.java
@@ -1,0 +1,77 @@
+// @formatter:off
+/*
+* ---------------------------------------------------------
+* Copyright(C) Microsoft Corporation. All rights reserved.
+* Licensed under the MIT license. See License.txt in the project root.
+* ---------------------------------------------------------
+*
+* ---------------------------------------------------------
+* Generated file, DO NOT EDIT
+* ---------------------------------------------------------
+*
+* See following wiki page for instructions on how to regenerate:
+*   https://vsowiki.com/index.php?title=Rest_Client_Generation
+*/
+
+package com.microsoft.alm.teamfoundation.work.webapi;
+
+
+/** 
+ */
+public class CreatePlan {
+
+    /**
+    * Name of the plan to create.
+    */
+    private String name;
+    /**
+    * Plan properties.
+    */
+    private Object properties;
+    /**
+    * Type of plan to create.
+    */
+    private PlanType type;
+
+    /**
+    * Name of the plan to create.
+    */
+    public String getName() {
+        return name;
+    }
+
+    /**
+    * Name of the plan to create.
+    */
+    public void setName(final String name) {
+        this.name = name;
+    }
+
+    /**
+    * Plan properties.
+    */
+    public Object getProperties() {
+        return properties;
+    }
+
+    /**
+    * Plan properties.
+    */
+    public void setProperties(final Object properties) {
+        this.properties = properties;
+    }
+
+    /**
+    * Type of plan to create.
+    */
+    public PlanType getType() {
+        return type;
+    }
+
+    /**
+    * Type of plan to create.
+    */
+    public void setType(final PlanType type) {
+        this.type = type;
+    }
+}

--- a/Rest/alm-tfs-client/src/main/generated/com/microsoft/alm/teamfoundation/work/webapi/DeliveryViewData.java
+++ b/Rest/alm-tfs-client/src/main/generated/com/microsoft/alm/teamfoundation/work/webapi/DeliveryViewData.java
@@ -1,0 +1,64 @@
+// @formatter:off
+/*
+* ---------------------------------------------------------
+* Copyright(C) Microsoft Corporation. All rights reserved.
+* Licensed under the MIT license. See License.txt in the project root.
+* ---------------------------------------------------------
+*
+* ---------------------------------------------------------
+* Generated file, DO NOT EDIT
+* ---------------------------------------------------------
+*
+* See following wiki page for instructions on how to regenerate:
+*   https://vsowiki.com/index.php?title=Rest_Client_Generation
+*/
+
+package com.microsoft.alm.teamfoundation.work.webapi;
+
+import java.util.ArrayList;
+import java.util.Date;
+
+/** 
+ * Data contract for Data of Delivery View
+ * 
+ */
+public class DeliveryViewData
+    extends PlanViewData {
+
+    private Date endDate;
+    private ArrayList<String> fieldReferenceNames;
+    private Date startDate;
+    private ArrayList<TimelineTeamData> teams;
+
+    public Date getEndDate() {
+        return endDate;
+    }
+
+    public void setEndDate(final Date endDate) {
+        this.endDate = endDate;
+    }
+
+    public ArrayList<String> getFieldReferenceNames() {
+        return fieldReferenceNames;
+    }
+
+    public void setFieldReferenceNames(final ArrayList<String> fieldReferenceNames) {
+        this.fieldReferenceNames = fieldReferenceNames;
+    }
+
+    public Date getStartDate() {
+        return startDate;
+    }
+
+    public void setStartDate(final Date startDate) {
+        this.startDate = startDate;
+    }
+
+    public ArrayList<TimelineTeamData> getTeams() {
+        return teams;
+    }
+
+    public void setTeams(final ArrayList<TimelineTeamData> teams) {
+        this.teams = teams;
+    }
+}

--- a/Rest/alm-tfs-client/src/main/generated/com/microsoft/alm/teamfoundation/work/webapi/DeliveryViewProperyCollection.java
+++ b/Rest/alm-tfs-client/src/main/generated/com/microsoft/alm/teamfoundation/work/webapi/DeliveryViewProperyCollection.java
@@ -1,0 +1,36 @@
+// @formatter:off
+/*
+* ---------------------------------------------------------
+* Copyright(C) Microsoft Corporation. All rights reserved.
+* Licensed under the MIT license. See License.txt in the project root.
+* ---------------------------------------------------------
+*
+* ---------------------------------------------------------
+* Generated file, DO NOT EDIT
+* ---------------------------------------------------------
+*
+* See following wiki page for instructions on how to regenerate:
+*   https://vsowiki.com/index.php?title=Rest_Client_Generation
+*/
+
+package com.microsoft.alm.teamfoundation.work.webapi;
+
+import java.util.ArrayList;
+
+/** 
+ * Collection of properties, specific to the DeliveryTimelineView
+ * 
+ */
+public class DeliveryViewProperyCollection
+    extends PlanPropertyCollection {
+
+    private ArrayList<TeamWorkItemTypeMapping> teamWorkItemTypeMapping;
+
+    public ArrayList<TeamWorkItemTypeMapping> getTeamWorkItemTypeMapping() {
+        return teamWorkItemTypeMapping;
+    }
+
+    public void setTeamWorkItemTypeMapping(final ArrayList<TeamWorkItemTypeMapping> teamWorkItemTypeMapping) {
+        this.teamWorkItemTypeMapping = teamWorkItemTypeMapping;
+    }
+}

--- a/Rest/alm-tfs-client/src/main/generated/com/microsoft/alm/teamfoundation/work/webapi/Plan.java
+++ b/Rest/alm-tfs-client/src/main/generated/com/microsoft/alm/teamfoundation/work/webapi/Plan.java
@@ -1,0 +1,153 @@
+// @formatter:off
+/*
+* ---------------------------------------------------------
+* Copyright(C) Microsoft Corporation. All rights reserved.
+* Licensed under the MIT license. See License.txt in the project root.
+* ---------------------------------------------------------
+*
+* ---------------------------------------------------------
+* Generated file, DO NOT EDIT
+* ---------------------------------------------------------
+*
+* See following wiki page for instructions on how to regenerate:
+*   https://vsowiki.com/index.php?title=Rest_Client_Generation
+*/
+
+package com.microsoft.alm.teamfoundation.work.webapi;
+
+import java.util.Date;
+import java.util.UUID;
+
+/** 
+ * Data contract for the plan definition
+ * 
+ */
+public class Plan {
+
+    /**
+    * Date when the plan was created
+    */
+    private Date createdDate;
+    /**
+    * Id of the plan
+    */
+    private UUID id;
+    /**
+    * Name of the plan
+    */
+    private String name;
+    /**
+    * OwnerId of the plan, typically same as the TFID of the team under which this plan has been created
+    */
+    private UUID ownerId;
+    /**
+    * The PlanPropertyCollection instance associated with the plan. These are dependent on the type of the plan. For example, DeliveryTimelineView, it would be of type DeliveryViewProperyCollection.
+    */
+    private Object properties;
+    /**
+    * Type of the plan
+    */
+    private PlanType type;
+    /**
+    * The resource url to locate the plan via rest api
+    */
+    private String url;
+
+    /**
+    * Date when the plan was created
+    */
+    public Date getCreatedDate() {
+        return createdDate;
+    }
+
+    /**
+    * Date when the plan was created
+    */
+    public void setCreatedDate(final Date createdDate) {
+        this.createdDate = createdDate;
+    }
+
+    /**
+    * Id of the plan
+    */
+    public UUID getId() {
+        return id;
+    }
+
+    /**
+    * Id of the plan
+    */
+    public void setId(final UUID id) {
+        this.id = id;
+    }
+
+    /**
+    * Name of the plan
+    */
+    public String getName() {
+        return name;
+    }
+
+    /**
+    * Name of the plan
+    */
+    public void setName(final String name) {
+        this.name = name;
+    }
+
+    /**
+    * OwnerId of the plan, typically same as the TFID of the team under which this plan has been created
+    */
+    public UUID getOwnerId() {
+        return ownerId;
+    }
+
+    /**
+    * OwnerId of the plan, typically same as the TFID of the team under which this plan has been created
+    */
+    public void setOwnerId(final UUID ownerId) {
+        this.ownerId = ownerId;
+    }
+
+    /**
+    * The PlanPropertyCollection instance associated with the plan. These are dependent on the type of the plan. For example, DeliveryTimelineView, it would be of type DeliveryViewProperyCollection.
+    */
+    public Object getProperties() {
+        return properties;
+    }
+
+    /**
+    * The PlanPropertyCollection instance associated with the plan. These are dependent on the type of the plan. For example, DeliveryTimelineView, it would be of type DeliveryViewProperyCollection.
+    */
+    public void setProperties(final Object properties) {
+        this.properties = properties;
+    }
+
+    /**
+    * Type of the plan
+    */
+    public PlanType getType() {
+        return type;
+    }
+
+    /**
+    * Type of the plan
+    */
+    public void setType(final PlanType type) {
+        this.type = type;
+    }
+
+    /**
+    * The resource url to locate the plan via rest api
+    */
+    public String getUrl() {
+        return url;
+    }
+
+    /**
+    * The resource url to locate the plan via rest api
+    */
+    public void setUrl(final String url) {
+        this.url = url;
+    }
+}

--- a/Rest/alm-tfs-client/src/main/generated/com/microsoft/alm/teamfoundation/work/webapi/PlanPropertyCollection.java
+++ b/Rest/alm-tfs-client/src/main/generated/com/microsoft/alm/teamfoundation/work/webapi/PlanPropertyCollection.java
@@ -1,0 +1,25 @@
+// @formatter:off
+/*
+* ---------------------------------------------------------
+* Copyright(C) Microsoft Corporation. All rights reserved.
+* Licensed under the MIT license. See License.txt in the project root.
+* ---------------------------------------------------------
+*
+* ---------------------------------------------------------
+* Generated file, DO NOT EDIT
+* ---------------------------------------------------------
+*
+* See following wiki page for instructions on how to regenerate:
+*   https://vsowiki.com/index.php?title=Rest_Client_Generation
+*/
+
+package com.microsoft.alm.teamfoundation.work.webapi;
+
+
+/** 
+ * Base class for properties of a scaled agile plan
+ * 
+ */
+public class PlanPropertyCollection {
+
+}

--- a/Rest/alm-tfs-client/src/main/generated/com/microsoft/alm/teamfoundation/work/webapi/PlanType.java
+++ b/Rest/alm-tfs-client/src/main/generated/com/microsoft/alm/teamfoundation/work/webapi/PlanType.java
@@ -1,0 +1,46 @@
+// @formatter:off
+/*
+* ---------------------------------------------------------
+* Copyright(C) Microsoft Corporation. All rights reserved.
+* Licensed under the MIT license. See License.txt in the project root.
+* ---------------------------------------------------------
+*
+* ---------------------------------------------------------
+* Generated file, DO NOT EDIT
+* ---------------------------------------------------------
+*
+* See following wiki page for instructions on how to regenerate:
+*   https://vsowiki.com/index.php?title=Rest_Client_Generation
+*/
+
+package com.microsoft.alm.teamfoundation.work.webapi;
+
+
+/** 
+ */
+public enum PlanType {
+
+    DELIVERY_TIMELINE_VIEW(0),
+    ;
+
+    private int value;
+
+    private PlanType(final int value) {
+        this.value = value;
+    }
+
+    public int getValue() {
+        return value;
+    }
+
+    @Override
+    public String toString() {
+        final String name = super.toString();
+
+        if (name.equals("DELIVERY_TIMELINE_VIEW")) { //$NON-NLS-1$
+            return "deliveryTimelineView"; //$NON-NLS-1$
+        }
+
+        return null;
+    }
+}

--- a/Rest/alm-tfs-client/src/main/generated/com/microsoft/alm/teamfoundation/work/webapi/PlanViewData.java
+++ b/Rest/alm-tfs-client/src/main/generated/com/microsoft/alm/teamfoundation/work/webapi/PlanViewData.java
@@ -1,0 +1,44 @@
+// @formatter:off
+/*
+* ---------------------------------------------------------
+* Copyright(C) Microsoft Corporation. All rights reserved.
+* Licensed under the MIT license. See License.txt in the project root.
+* ---------------------------------------------------------
+*
+* ---------------------------------------------------------
+* Generated file, DO NOT EDIT
+* ---------------------------------------------------------
+*
+* See following wiki page for instructions on how to regenerate:
+*   https://vsowiki.com/index.php?title=Rest_Client_Generation
+*/
+
+package com.microsoft.alm.teamfoundation.work.webapi;
+
+import java.util.UUID;
+
+/** 
+ * Base class for plan view data contracts. Anything common goes here.
+ * 
+ */
+public class PlanViewData {
+
+    private UUID id;
+    private String name;
+
+    public UUID getId() {
+        return id;
+    }
+
+    public void setId(final UUID id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(final String name) {
+        this.name = name;
+    }
+}

--- a/Rest/alm-tfs-client/src/main/generated/com/microsoft/alm/teamfoundation/work/webapi/TeamWorkItemTypeMapping.java
+++ b/Rest/alm-tfs-client/src/main/generated/com/microsoft/alm/teamfoundation/work/webapi/TeamWorkItemTypeMapping.java
@@ -1,0 +1,45 @@
+// @formatter:off
+/*
+* ---------------------------------------------------------
+* Copyright(C) Microsoft Corporation. All rights reserved.
+* Licensed under the MIT license. See License.txt in the project root.
+* ---------------------------------------------------------
+*
+* ---------------------------------------------------------
+* Generated file, DO NOT EDIT
+* ---------------------------------------------------------
+*
+* See following wiki page for instructions on how to regenerate:
+*   https://vsowiki.com/index.php?title=Rest_Client_Generation
+*/
+
+package com.microsoft.alm.teamfoundation.work.webapi;
+
+import java.util.ArrayList;
+import java.util.UUID;
+
+/** 
+ * Mapping of teams to the corresponding workitem types
+ * 
+ */
+public class TeamWorkItemTypeMapping {
+
+    private UUID teamId;
+    private ArrayList<String> workItemTypeNames;
+
+    public UUID getTeamId() {
+        return teamId;
+    }
+
+    public void setTeamId(final UUID teamId) {
+        this.teamId = teamId;
+    }
+
+    public ArrayList<String> getWorkItemTypeNames() {
+        return workItemTypeNames;
+    }
+
+    public void setWorkItemTypeNames(final ArrayList<String> workItemTypeNames) {
+        this.workItemTypeNames = workItemTypeNames;
+    }
+}

--- a/Rest/alm-tfs-client/src/main/generated/com/microsoft/alm/teamfoundation/work/webapi/TimelineIterationStatus.java
+++ b/Rest/alm-tfs-client/src/main/generated/com/microsoft/alm/teamfoundation/work/webapi/TimelineIterationStatus.java
@@ -1,0 +1,41 @@
+// @formatter:off
+/*
+* ---------------------------------------------------------
+* Copyright(C) Microsoft Corporation. All rights reserved.
+* Licensed under the MIT license. See License.txt in the project root.
+* ---------------------------------------------------------
+*
+* ---------------------------------------------------------
+* Generated file, DO NOT EDIT
+* ---------------------------------------------------------
+*
+* See following wiki page for instructions on how to regenerate:
+*   https://vsowiki.com/index.php?title=Rest_Client_Generation
+*/
+
+package com.microsoft.alm.teamfoundation.work.webapi;
+
+
+/** 
+ */
+public class TimelineIterationStatus {
+
+    private String message;
+    private TimelineIterationStatusCode type;
+
+    public String getMessage() {
+        return message;
+    }
+
+    public void setMessage(final String message) {
+        this.message = message;
+    }
+
+    public TimelineIterationStatusCode getType() {
+        return type;
+    }
+
+    public void setType(final TimelineIterationStatusCode type) {
+        this.type = type;
+    }
+}

--- a/Rest/alm-tfs-client/src/main/generated/com/microsoft/alm/teamfoundation/work/webapi/TimelineIterationStatusCode.java
+++ b/Rest/alm-tfs-client/src/main/generated/com/microsoft/alm/teamfoundation/work/webapi/TimelineIterationStatusCode.java
@@ -1,0 +1,57 @@
+// @formatter:off
+/*
+* ---------------------------------------------------------
+* Copyright(C) Microsoft Corporation. All rights reserved.
+* Licensed under the MIT license. See License.txt in the project root.
+* ---------------------------------------------------------
+*
+* ---------------------------------------------------------
+* Generated file, DO NOT EDIT
+* ---------------------------------------------------------
+*
+* See following wiki page for instructions on how to regenerate:
+*   https://vsowiki.com/index.php?title=Rest_Client_Generation
+*/
+
+package com.microsoft.alm.teamfoundation.work.webapi;
+
+
+/** 
+ */
+public enum TimelineIterationStatusCode {
+
+    /**
+    * No error - iteration data is good.
+    */
+    O_K(0),
+    /**
+    * This iteration overlaps with another iteration, no data is returned for this iteration.
+    */
+    IS_OVERLAPPING(1),
+    ;
+
+    private int value;
+
+    private TimelineIterationStatusCode(final int value) {
+        this.value = value;
+    }
+
+    public int getValue() {
+        return value;
+    }
+
+    @Override
+    public String toString() {
+        final String name = super.toString();
+
+        if (name.equals("O_K")) { //$NON-NLS-1$
+            return "oK"; //$NON-NLS-1$
+        }
+
+        if (name.equals("IS_OVERLAPPING")) { //$NON-NLS-1$
+            return "isOverlapping"; //$NON-NLS-1$
+        }
+
+        return null;
+    }
+}

--- a/Rest/alm-tfs-client/src/main/generated/com/microsoft/alm/teamfoundation/work/webapi/TimelineTeamData.java
+++ b/Rest/alm-tfs-client/src/main/generated/com/microsoft/alm/teamfoundation/work/webapi/TimelineTeamData.java
@@ -1,0 +1,109 @@
+// @formatter:off
+/*
+* ---------------------------------------------------------
+* Copyright(C) Microsoft Corporation. All rights reserved.
+* Licensed under the MIT license. See License.txt in the project root.
+* ---------------------------------------------------------
+*
+* ---------------------------------------------------------
+* Generated file, DO NOT EDIT
+* ---------------------------------------------------------
+*
+* See following wiki page for instructions on how to regenerate:
+*   https://vsowiki.com/index.php?title=Rest_Client_Generation
+*/
+
+package com.microsoft.alm.teamfoundation.work.webapi;
+
+import java.util.ArrayList;
+import java.util.UUID;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/** 
+ */
+public class TimelineTeamData {
+
+    private UUID id;
+    private boolean isExpanded;
+    private ArrayList<TimelineTeamIteration> iterations;
+    private String name;
+    private UUID projectId;
+    /**
+    * Status for this team.
+    */
+    private TimelineTeamStatus status;
+    /**
+    * Colors for the work item types.
+    */
+    private ArrayList<WorkItemColor> workItemTypeColors;
+
+    public UUID getId() {
+        return id;
+    }
+
+    public void setId(final UUID id) {
+        this.id = id;
+    }
+
+    @JsonProperty("isExpanded")
+    public boolean isExpanded() {
+        return isExpanded;
+    }
+
+    @JsonProperty("isExpanded")
+    public void setExpanded(final boolean isExpanded) {
+        this.isExpanded = isExpanded;
+    }
+
+    public ArrayList<TimelineTeamIteration> getIterations() {
+        return iterations;
+    }
+
+    public void setIterations(final ArrayList<TimelineTeamIteration> iterations) {
+        this.iterations = iterations;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(final String name) {
+        this.name = name;
+    }
+
+    public UUID getProjectId() {
+        return projectId;
+    }
+
+    public void setProjectId(final UUID projectId) {
+        this.projectId = projectId;
+    }
+
+    /**
+    * Status for this team.
+    */
+    public TimelineTeamStatus getStatus() {
+        return status;
+    }
+
+    /**
+    * Status for this team.
+    */
+    public void setStatus(final TimelineTeamStatus status) {
+        this.status = status;
+    }
+
+    /**
+    * Colors for the work item types.
+    */
+    public ArrayList<WorkItemColor> getWorkItemTypeColors() {
+        return workItemTypeColors;
+    }
+
+    /**
+    * Colors for the work item types.
+    */
+    public void setWorkItemTypeColors(final ArrayList<WorkItemColor> workItemTypeColors) {
+        this.workItemTypeColors = workItemTypeColors;
+    }
+}

--- a/Rest/alm-tfs-client/src/main/generated/com/microsoft/alm/teamfoundation/work/webapi/TimelineTeamIteration.java
+++ b/Rest/alm-tfs-client/src/main/generated/com/microsoft/alm/teamfoundation/work/webapi/TimelineTeamIteration.java
@@ -1,0 +1,88 @@
+// @formatter:off
+/*
+* ---------------------------------------------------------
+* Copyright(C) Microsoft Corporation. All rights reserved.
+* Licensed under the MIT license. See License.txt in the project root.
+* ---------------------------------------------------------
+*
+* ---------------------------------------------------------
+* Generated file, DO NOT EDIT
+* ---------------------------------------------------------
+*
+* See following wiki page for instructions on how to regenerate:
+*   https://vsowiki.com/index.php?title=Rest_Client_Generation
+*/
+
+package com.microsoft.alm.teamfoundation.work.webapi;
+
+import java.util.ArrayList;
+import java.util.Date;
+
+/** 
+ */
+public class TimelineTeamIteration {
+
+    private Date finishDate;
+    private String name;
+    private String path;
+    private Date startDate;
+    private TimelineIterationStatus status;
+    private ArrayList<Integer> workItemIds;
+    private ArrayList<Object[]> workItems;
+
+    public Date getFinishDate() {
+        return finishDate;
+    }
+
+    public void setFinishDate(final Date finishDate) {
+        this.finishDate = finishDate;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(final String name) {
+        this.name = name;
+    }
+
+    public String getPath() {
+        return path;
+    }
+
+    public void setPath(final String path) {
+        this.path = path;
+    }
+
+    public Date getStartDate() {
+        return startDate;
+    }
+
+    public void setStartDate(final Date startDate) {
+        this.startDate = startDate;
+    }
+
+    public TimelineIterationStatus getStatus() {
+        return status;
+    }
+
+    public void setStatus(final TimelineIterationStatus status) {
+        this.status = status;
+    }
+
+    public ArrayList<Integer> getWorkItemIds() {
+        return workItemIds;
+    }
+
+    public void setWorkItemIds(final ArrayList<Integer> workItemIds) {
+        this.workItemIds = workItemIds;
+    }
+
+    public ArrayList<Object[]> getWorkItems() {
+        return workItems;
+    }
+
+    public void setWorkItems(final ArrayList<Object[]> workItems) {
+        this.workItems = workItems;
+    }
+}

--- a/Rest/alm-tfs-client/src/main/generated/com/microsoft/alm/teamfoundation/work/webapi/TimelineTeamStatus.java
+++ b/Rest/alm-tfs-client/src/main/generated/com/microsoft/alm/teamfoundation/work/webapi/TimelineTeamStatus.java
@@ -1,0 +1,41 @@
+// @formatter:off
+/*
+* ---------------------------------------------------------
+* Copyright(C) Microsoft Corporation. All rights reserved.
+* Licensed under the MIT license. See License.txt in the project root.
+* ---------------------------------------------------------
+*
+* ---------------------------------------------------------
+* Generated file, DO NOT EDIT
+* ---------------------------------------------------------
+*
+* See following wiki page for instructions on how to regenerate:
+*   https://vsowiki.com/index.php?title=Rest_Client_Generation
+*/
+
+package com.microsoft.alm.teamfoundation.work.webapi;
+
+
+/** 
+ */
+public class TimelineTeamStatus {
+
+    private String message;
+    private TimelineTeamStatusCode type;
+
+    public String getMessage() {
+        return message;
+    }
+
+    public void setMessage(final String message) {
+        this.message = message;
+    }
+
+    public TimelineTeamStatusCode getType() {
+        return type;
+    }
+
+    public void setType(final TimelineTeamStatusCode type) {
+        this.type = type;
+    }
+}

--- a/Rest/alm-tfs-client/src/main/generated/com/microsoft/alm/teamfoundation/work/webapi/TimelineTeamStatusCode.java
+++ b/Rest/alm-tfs-client/src/main/generated/com/microsoft/alm/teamfoundation/work/webapi/TimelineTeamStatusCode.java
@@ -1,0 +1,73 @@
+// @formatter:off
+/*
+* ---------------------------------------------------------
+* Copyright(C) Microsoft Corporation. All rights reserved.
+* Licensed under the MIT license. See License.txt in the project root.
+* ---------------------------------------------------------
+*
+* ---------------------------------------------------------
+* Generated file, DO NOT EDIT
+* ---------------------------------------------------------
+*
+* See following wiki page for instructions on how to regenerate:
+*   https://vsowiki.com/index.php?title=Rest_Client_Generation
+*/
+
+package com.microsoft.alm.teamfoundation.work.webapi;
+
+
+/** 
+ */
+public enum TimelineTeamStatusCode {
+
+    /**
+    * No error - all data for team is good.
+    */
+    O_K(0),
+    /**
+    * Team does not exist or access is denied.
+    */
+    DOESNT_EXIST_OR_ACCESS_DENIED(1),
+    /**
+    * Maximum number of teams was exceeded. No team data will be returned for this team.
+    */
+    MAX_TEAMS_EXCEEDED(2),
+    /**
+    * Maximum number of team fields (ie Area paths) have been exceeded. No team data will be returned for this team.
+    */
+    MAX_TEAM_FIELDS_EXCEEDED(3),
+    ;
+
+    private int value;
+
+    private TimelineTeamStatusCode(final int value) {
+        this.value = value;
+    }
+
+    public int getValue() {
+        return value;
+    }
+
+    @Override
+    public String toString() {
+        final String name = super.toString();
+
+        if (name.equals("O_K")) { //$NON-NLS-1$
+            return "oK"; //$NON-NLS-1$
+        }
+
+        if (name.equals("DOESNT_EXIST_OR_ACCESS_DENIED")) { //$NON-NLS-1$
+            return "doesntExistOrAccessDenied"; //$NON-NLS-1$
+        }
+
+        if (name.equals("MAX_TEAMS_EXCEEDED")) { //$NON-NLS-1$
+            return "maxTeamsExceeded"; //$NON-NLS-1$
+        }
+
+        if (name.equals("MAX_TEAM_FIELDS_EXCEEDED")) { //$NON-NLS-1$
+            return "maxTeamFieldsExceeded"; //$NON-NLS-1$
+        }
+
+        return null;
+    }
+}

--- a/Rest/alm-tfs-client/src/main/generated/com/microsoft/alm/teamfoundation/work/webapi/WorkHttpClientBase.java
+++ b/Rest/alm-tfs-client/src/main/generated/com/microsoft/alm/teamfoundation/work/webapi/WorkHttpClientBase.java
@@ -17,13 +17,18 @@ package com.microsoft.alm.teamfoundation.work.webapi;
 
 import java.net.URI;
 import java.util.ArrayList;
+import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import com.fasterxml.jackson.core.type.TypeReference;
+import com.microsoft.alm.client.HttpMethod;
 import com.microsoft.alm.client.model.NameValueCollection;
 import com.microsoft.alm.client.VssHttpClientBase;
+import com.microsoft.alm.client.VssMediaTypes;
+import com.microsoft.alm.client.VssRestClientHandler;
+import com.microsoft.alm.client.VssRestRequest;
 import com.microsoft.alm.teamfoundation.work.webapi.Board;
 import com.microsoft.alm.teamfoundation.work.webapi.BoardCardRuleSettings;
 import com.microsoft.alm.teamfoundation.work.webapi.BoardCardSettings;
@@ -37,7 +42,10 @@ import com.microsoft.alm.teamfoundation.work.webapi.BoardSuggestedValue;
 import com.microsoft.alm.teamfoundation.work.webapi.BoardUserSettings;
 import com.microsoft.alm.teamfoundation.work.webapi.CapacityPatch;
 import com.microsoft.alm.teamfoundation.work.webapi.contracts.ProcessConfiguration;
+import com.microsoft.alm.teamfoundation.work.webapi.CreatePlan;
+import com.microsoft.alm.teamfoundation.work.webapi.DeliveryViewData;
 import com.microsoft.alm.teamfoundation.work.webapi.ParentChildWIMap;
+import com.microsoft.alm.teamfoundation.work.webapi.Plan;
 import com.microsoft.alm.teamfoundation.work.webapi.TeamFieldValues;
 import com.microsoft.alm.teamfoundation.work.webapi.TeamFieldValuesPatch;
 import com.microsoft.alm.teamfoundation.work.webapi.TeamMemberCapacity;
@@ -61,22 +69,13 @@ public abstract class WorkHttpClientBase
     * Create a new instance of WorkHttpClientBase
     *
     * @param jaxrsClient
-    *            an initialized instance of a JAX-RS Client implementation
+    *            a DefaultRestClientHandler initialized with an instance of a JAX-RS Client implementation or
+    *            a TEERestClientHamdler initialized with TEE HTTP client implementation
     * @param baseUrl
-    *            a TFS project collection URL
+    *            a TFS services URL
     */
-    protected WorkHttpClientBase(final Object jaxrsClient, final URI baseUrl) {
-        super(jaxrsClient, baseUrl);
-    }
-
-    /**
-    * Create a new instance of WorkHttpClientBase
-    *
-    * @param tfsConnection
-    *            an initialized instance of a TfsTeamProjectCollection
-    */
-    protected WorkHttpClientBase(final Object tfsConnection) {
-        super(tfsConnection);
+    protected WorkHttpClientBase(final VssRestClientHandler clientHandler, final URI baseUrl) {
+        super(clientHandler, baseUrl);
     }
 
     @Override
@@ -94,10 +93,10 @@ public abstract class WorkHttpClientBase
         final UUID locationId = UUID.fromString("eb7ec5a3-1ba3-4fd1-b834-49a5a387e57d"); //$NON-NLS-1$
         final ApiResourceVersion apiVersion = new ApiResourceVersion("3.0-preview.1"); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<BoardSuggestedValue>>() {});
     }
@@ -117,11 +116,11 @@ public abstract class WorkHttpClientBase
         final Map<String, Object> routeValues = new HashMap<String, Object>();
         routeValues.put("project", project); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<BoardSuggestedValue>>() {});
     }
@@ -141,11 +140,11 @@ public abstract class WorkHttpClientBase
         final Map<String, Object> routeValues = new HashMap<String, Object>();
         routeValues.put("project", project); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<BoardSuggestedValue>>() {});
     }
@@ -170,11 +169,11 @@ public abstract class WorkHttpClientBase
         routeValues.put("project", project); //$NON-NLS-1$
         routeValues.put("board", board); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, BoardFilterSettings.class);
     }
@@ -199,11 +198,11 @@ public abstract class WorkHttpClientBase
         routeValues.put("project", project); //$NON-NLS-1$
         routeValues.put("board", board); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, BoardFilterSettings.class);
     }
@@ -232,11 +231,11 @@ public abstract class WorkHttpClientBase
         routeValues.put("team", team); //$NON-NLS-1$
         routeValues.put("board", board); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, BoardFilterSettings.class);
     }
@@ -265,11 +264,11 @@ public abstract class WorkHttpClientBase
         routeValues.put("team", team); //$NON-NLS-1$
         routeValues.put("board", board); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, BoardFilterSettings.class);
     }
@@ -297,13 +296,13 @@ public abstract class WorkHttpClientBase
         routeValues.put("project", project); //$NON-NLS-1$
         routeValues.put("board", board); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.PATCH,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       filterSettings,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.PATCH,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               filterSettings,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, BoardFilterSettings.class);
     }
@@ -331,13 +330,13 @@ public abstract class WorkHttpClientBase
         routeValues.put("project", project); //$NON-NLS-1$
         routeValues.put("board", board); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.PATCH,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       filterSettings,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.PATCH,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               filterSettings,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, BoardFilterSettings.class);
     }
@@ -369,13 +368,13 @@ public abstract class WorkHttpClientBase
         routeValues.put("team", team); //$NON-NLS-1$
         routeValues.put("board", board); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.PATCH,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       filterSettings,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.PATCH,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               filterSettings,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, BoardFilterSettings.class);
     }
@@ -407,13 +406,13 @@ public abstract class WorkHttpClientBase
         routeValues.put("team", team); //$NON-NLS-1$
         routeValues.put("board", board); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.PATCH,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       filterSettings,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.PATCH,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               filterSettings,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, BoardFilterSettings.class);
     }
@@ -448,12 +447,12 @@ public abstract class WorkHttpClientBase
         queryParameters.addIfNotEmpty("childBacklogContextCategoryRefName", childBacklogContextCategoryRefName); //$NON-NLS-1$
         queryParameters.addIfNotNull("workitemIds", workitemIds); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<ParentChildWIMap>>() {});
     }
@@ -488,12 +487,12 @@ public abstract class WorkHttpClientBase
         queryParameters.addIfNotEmpty("childBacklogContextCategoryRefName", childBacklogContextCategoryRefName); //$NON-NLS-1$
         queryParameters.addIfNotNull("workitemIds", workitemIds); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<ParentChildWIMap>>() {});
     }
@@ -524,12 +523,12 @@ public abstract class WorkHttpClientBase
         queryParameters.addIfNotEmpty("childBacklogContextCategoryRefName", childBacklogContextCategoryRefName); //$NON-NLS-1$
         queryParameters.addIfNotNull("workitemIds", workitemIds); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<ParentChildWIMap>>() {});
     }
@@ -560,12 +559,12 @@ public abstract class WorkHttpClientBase
         queryParameters.addIfNotEmpty("childBacklogContextCategoryRefName", childBacklogContextCategoryRefName); //$NON-NLS-1$
         queryParameters.addIfNotNull("workitemIds", workitemIds); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<ParentChildWIMap>>() {});
     }
@@ -580,10 +579,10 @@ public abstract class WorkHttpClientBase
         final UUID locationId = UUID.fromString("bb494cc6-a0f5-4c6c-8dca-ea6912e79eb9"); //$NON-NLS-1$
         final ApiResourceVersion apiVersion = new ApiResourceVersion("3.0-preview.1"); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<BoardSuggestedValue>>() {});
     }
@@ -603,11 +602,11 @@ public abstract class WorkHttpClientBase
         final Map<String, Object> routeValues = new HashMap<String, Object>();
         routeValues.put("project", project); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<BoardSuggestedValue>>() {});
     }
@@ -627,11 +626,11 @@ public abstract class WorkHttpClientBase
         final Map<String, Object> routeValues = new HashMap<String, Object>();
         routeValues.put("project", project); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<BoardSuggestedValue>>() {});
     }
@@ -656,11 +655,11 @@ public abstract class WorkHttpClientBase
         routeValues.put("project", project); //$NON-NLS-1$
         routeValues.put("id", id); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, Board.class);
     }
@@ -685,11 +684,11 @@ public abstract class WorkHttpClientBase
         routeValues.put("project", project); //$NON-NLS-1$
         routeValues.put("id", id); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, Board.class);
     }
@@ -718,11 +717,11 @@ public abstract class WorkHttpClientBase
         routeValues.put("team", team); //$NON-NLS-1$
         routeValues.put("id", id); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, Board.class);
     }
@@ -751,11 +750,11 @@ public abstract class WorkHttpClientBase
         routeValues.put("team", team); //$NON-NLS-1$
         routeValues.put("id", id); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, Board.class);
     }
@@ -775,11 +774,11 @@ public abstract class WorkHttpClientBase
         final Map<String, Object> routeValues = new HashMap<String, Object>();
         routeValues.put("project", project); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<BoardReference>>() {});
     }
@@ -799,11 +798,11 @@ public abstract class WorkHttpClientBase
         final Map<String, Object> routeValues = new HashMap<String, Object>();
         routeValues.put("project", project); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<BoardReference>>() {});
     }
@@ -828,11 +827,11 @@ public abstract class WorkHttpClientBase
         routeValues.put("project", project); //$NON-NLS-1$
         routeValues.put("team", team); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<BoardReference>>() {});
     }
@@ -857,11 +856,11 @@ public abstract class WorkHttpClientBase
         routeValues.put("project", project); //$NON-NLS-1$
         routeValues.put("team", team); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<BoardReference>>() {});
     }
@@ -889,13 +888,13 @@ public abstract class WorkHttpClientBase
         routeValues.put("project", project); //$NON-NLS-1$
         routeValues.put("id", id); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.PUT,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       options,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.PUT,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               options,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<HashMap<String, String>>() {});
     }
@@ -923,13 +922,13 @@ public abstract class WorkHttpClientBase
         routeValues.put("project", project); //$NON-NLS-1$
         routeValues.put("id", id); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.PUT,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       options,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.PUT,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               options,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<HashMap<String, String>>() {});
     }
@@ -961,13 +960,13 @@ public abstract class WorkHttpClientBase
         routeValues.put("team", team); //$NON-NLS-1$
         routeValues.put("id", id); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.PUT,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       options,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.PUT,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               options,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<HashMap<String, String>>() {});
     }
@@ -999,13 +998,13 @@ public abstract class WorkHttpClientBase
         routeValues.put("team", team); //$NON-NLS-1$
         routeValues.put("id", id); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.PUT,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       options,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.PUT,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               options,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<HashMap<String, String>>() {});
     }
@@ -1030,11 +1029,11 @@ public abstract class WorkHttpClientBase
         routeValues.put("project", project); //$NON-NLS-1$
         routeValues.put("board", board); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, BoardUserSettings.class);
     }
@@ -1059,11 +1058,11 @@ public abstract class WorkHttpClientBase
         routeValues.put("project", project); //$NON-NLS-1$
         routeValues.put("board", board); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, BoardUserSettings.class);
     }
@@ -1092,11 +1091,11 @@ public abstract class WorkHttpClientBase
         routeValues.put("team", team); //$NON-NLS-1$
         routeValues.put("board", board); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, BoardUserSettings.class);
     }
@@ -1125,11 +1124,11 @@ public abstract class WorkHttpClientBase
         routeValues.put("team", team); //$NON-NLS-1$
         routeValues.put("board", board); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, BoardUserSettings.class);
     }
@@ -1157,13 +1156,13 @@ public abstract class WorkHttpClientBase
         routeValues.put("project", project); //$NON-NLS-1$
         routeValues.put("board", board); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.PATCH,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       boardUserSettings,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.PATCH,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               boardUserSettings,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, BoardUserSettings.class);
     }
@@ -1191,13 +1190,13 @@ public abstract class WorkHttpClientBase
         routeValues.put("project", project); //$NON-NLS-1$
         routeValues.put("board", board); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.PATCH,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       boardUserSettings,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.PATCH,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               boardUserSettings,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, BoardUserSettings.class);
     }
@@ -1229,13 +1228,13 @@ public abstract class WorkHttpClientBase
         routeValues.put("team", team); //$NON-NLS-1$
         routeValues.put("board", board); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.PATCH,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       boardUserSettings,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.PATCH,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               boardUserSettings,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, BoardUserSettings.class);
     }
@@ -1267,13 +1266,13 @@ public abstract class WorkHttpClientBase
         routeValues.put("team", team); //$NON-NLS-1$
         routeValues.put("board", board); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.PATCH,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       boardUserSettings,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.PATCH,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               boardUserSettings,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, BoardUserSettings.class);
     }
@@ -1298,11 +1297,11 @@ public abstract class WorkHttpClientBase
         routeValues.put("project", project); //$NON-NLS-1$
         routeValues.put("iterationId", iterationId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<TeamMemberCapacity>>() {});
     }
@@ -1327,11 +1326,11 @@ public abstract class WorkHttpClientBase
         routeValues.put("project", project); //$NON-NLS-1$
         routeValues.put("iterationId", iterationId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<TeamMemberCapacity>>() {});
     }
@@ -1360,11 +1359,11 @@ public abstract class WorkHttpClientBase
         routeValues.put("team", team); //$NON-NLS-1$
         routeValues.put("iterationId", iterationId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<TeamMemberCapacity>>() {});
     }
@@ -1393,11 +1392,11 @@ public abstract class WorkHttpClientBase
         routeValues.put("team", team); //$NON-NLS-1$
         routeValues.put("iterationId", iterationId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<TeamMemberCapacity>>() {});
     }
@@ -1426,11 +1425,11 @@ public abstract class WorkHttpClientBase
         routeValues.put("iterationId", iterationId); //$NON-NLS-1$
         routeValues.put("teamMemberId", teamMemberId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, TeamMemberCapacity.class);
     }
@@ -1459,11 +1458,11 @@ public abstract class WorkHttpClientBase
         routeValues.put("iterationId", iterationId); //$NON-NLS-1$
         routeValues.put("teamMemberId", teamMemberId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, TeamMemberCapacity.class);
     }
@@ -1496,11 +1495,11 @@ public abstract class WorkHttpClientBase
         routeValues.put("iterationId", iterationId); //$NON-NLS-1$
         routeValues.put("teamMemberId", teamMemberId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, TeamMemberCapacity.class);
     }
@@ -1533,11 +1532,11 @@ public abstract class WorkHttpClientBase
         routeValues.put("iterationId", iterationId); //$NON-NLS-1$
         routeValues.put("teamMemberId", teamMemberId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, TeamMemberCapacity.class);
     }
@@ -1565,13 +1564,13 @@ public abstract class WorkHttpClientBase
         routeValues.put("project", project); //$NON-NLS-1$
         routeValues.put("iterationId", iterationId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.PUT,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       capacities,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.PUT,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               capacities,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<TeamMemberCapacity>>() {});
     }
@@ -1599,13 +1598,13 @@ public abstract class WorkHttpClientBase
         routeValues.put("project", project); //$NON-NLS-1$
         routeValues.put("iterationId", iterationId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.PUT,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       capacities,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.PUT,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               capacities,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<TeamMemberCapacity>>() {});
     }
@@ -1637,13 +1636,13 @@ public abstract class WorkHttpClientBase
         routeValues.put("team", team); //$NON-NLS-1$
         routeValues.put("iterationId", iterationId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.PUT,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       capacities,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.PUT,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               capacities,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<TeamMemberCapacity>>() {});
     }
@@ -1675,13 +1674,13 @@ public abstract class WorkHttpClientBase
         routeValues.put("team", team); //$NON-NLS-1$
         routeValues.put("iterationId", iterationId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.PUT,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       capacities,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.PUT,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               capacities,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<TeamMemberCapacity>>() {});
     }
@@ -1713,13 +1712,13 @@ public abstract class WorkHttpClientBase
         routeValues.put("iterationId", iterationId); //$NON-NLS-1$
         routeValues.put("teamMemberId", teamMemberId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.PATCH,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       patch,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.PATCH,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               patch,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, TeamMemberCapacity.class);
     }
@@ -1751,13 +1750,13 @@ public abstract class WorkHttpClientBase
         routeValues.put("iterationId", iterationId); //$NON-NLS-1$
         routeValues.put("teamMemberId", teamMemberId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.PATCH,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       patch,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.PATCH,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               patch,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, TeamMemberCapacity.class);
     }
@@ -1793,13 +1792,13 @@ public abstract class WorkHttpClientBase
         routeValues.put("iterationId", iterationId); //$NON-NLS-1$
         routeValues.put("teamMemberId", teamMemberId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.PATCH,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       patch,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.PATCH,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               patch,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, TeamMemberCapacity.class);
     }
@@ -1835,13 +1834,13 @@ public abstract class WorkHttpClientBase
         routeValues.put("iterationId", iterationId); //$NON-NLS-1$
         routeValues.put("teamMemberId", teamMemberId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.PATCH,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       patch,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.PATCH,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               patch,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, TeamMemberCapacity.class);
     }
@@ -1866,11 +1865,11 @@ public abstract class WorkHttpClientBase
         routeValues.put("project", project); //$NON-NLS-1$
         routeValues.put("board", board); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, BoardCardRuleSettings.class);
     }
@@ -1895,11 +1894,11 @@ public abstract class WorkHttpClientBase
         routeValues.put("project", project); //$NON-NLS-1$
         routeValues.put("board", board); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, BoardCardRuleSettings.class);
     }
@@ -1928,11 +1927,11 @@ public abstract class WorkHttpClientBase
         routeValues.put("team", team); //$NON-NLS-1$
         routeValues.put("board", board); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, BoardCardRuleSettings.class);
     }
@@ -1961,11 +1960,11 @@ public abstract class WorkHttpClientBase
         routeValues.put("team", team); //$NON-NLS-1$
         routeValues.put("board", board); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, BoardCardRuleSettings.class);
     }
@@ -1993,13 +1992,13 @@ public abstract class WorkHttpClientBase
         routeValues.put("project", project); //$NON-NLS-1$
         routeValues.put("board", board); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.PATCH,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       boardCardRuleSettings,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.PATCH,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               boardCardRuleSettings,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, BoardCardRuleSettings.class);
     }
@@ -2027,13 +2026,13 @@ public abstract class WorkHttpClientBase
         routeValues.put("project", project); //$NON-NLS-1$
         routeValues.put("board", board); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.PATCH,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       boardCardRuleSettings,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.PATCH,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               boardCardRuleSettings,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, BoardCardRuleSettings.class);
     }
@@ -2065,13 +2064,13 @@ public abstract class WorkHttpClientBase
         routeValues.put("team", team); //$NON-NLS-1$
         routeValues.put("board", board); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.PATCH,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       boardCardRuleSettings,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.PATCH,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               boardCardRuleSettings,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, BoardCardRuleSettings.class);
     }
@@ -2103,13 +2102,13 @@ public abstract class WorkHttpClientBase
         routeValues.put("team", team); //$NON-NLS-1$
         routeValues.put("board", board); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.PATCH,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       boardCardRuleSettings,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.PATCH,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               boardCardRuleSettings,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, BoardCardRuleSettings.class);
     }
@@ -2134,11 +2133,11 @@ public abstract class WorkHttpClientBase
         routeValues.put("project", project); //$NON-NLS-1$
         routeValues.put("board", board); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, BoardCardSettings.class);
     }
@@ -2163,11 +2162,11 @@ public abstract class WorkHttpClientBase
         routeValues.put("project", project); //$NON-NLS-1$
         routeValues.put("board", board); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, BoardCardSettings.class);
     }
@@ -2196,11 +2195,11 @@ public abstract class WorkHttpClientBase
         routeValues.put("team", team); //$NON-NLS-1$
         routeValues.put("board", board); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, BoardCardSettings.class);
     }
@@ -2229,11 +2228,11 @@ public abstract class WorkHttpClientBase
         routeValues.put("team", team); //$NON-NLS-1$
         routeValues.put("board", board); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, BoardCardSettings.class);
     }
@@ -2261,13 +2260,13 @@ public abstract class WorkHttpClientBase
         routeValues.put("project", project); //$NON-NLS-1$
         routeValues.put("board", board); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.PUT,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       boardCardSettingsToSave,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.PUT,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               boardCardSettingsToSave,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, BoardCardSettings.class);
     }
@@ -2295,13 +2294,13 @@ public abstract class WorkHttpClientBase
         routeValues.put("project", project); //$NON-NLS-1$
         routeValues.put("board", board); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.PUT,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       boardCardSettingsToSave,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.PUT,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               boardCardSettingsToSave,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, BoardCardSettings.class);
     }
@@ -2333,13 +2332,13 @@ public abstract class WorkHttpClientBase
         routeValues.put("team", team); //$NON-NLS-1$
         routeValues.put("board", board); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.PUT,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       boardCardSettingsToSave,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.PUT,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               boardCardSettingsToSave,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, BoardCardSettings.class);
     }
@@ -2371,13 +2370,13 @@ public abstract class WorkHttpClientBase
         routeValues.put("team", team); //$NON-NLS-1$
         routeValues.put("board", board); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.PUT,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       boardCardSettingsToSave,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.PUT,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               boardCardSettingsToSave,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, BoardCardSettings.class);
     }
@@ -2406,11 +2405,11 @@ public abstract class WorkHttpClientBase
         routeValues.put("board", board); //$NON-NLS-1$
         routeValues.put("name", name); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, BoardChart.class);
     }
@@ -2439,11 +2438,11 @@ public abstract class WorkHttpClientBase
         routeValues.put("board", board); //$NON-NLS-1$
         routeValues.put("name", name); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, BoardChart.class);
     }
@@ -2476,11 +2475,11 @@ public abstract class WorkHttpClientBase
         routeValues.put("board", board); //$NON-NLS-1$
         routeValues.put("name", name); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, BoardChart.class);
     }
@@ -2513,11 +2512,11 @@ public abstract class WorkHttpClientBase
         routeValues.put("board", board); //$NON-NLS-1$
         routeValues.put("name", name); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, BoardChart.class);
     }
@@ -2542,11 +2541,11 @@ public abstract class WorkHttpClientBase
         routeValues.put("project", project); //$NON-NLS-1$
         routeValues.put("board", board); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<BoardChartReference>>() {});
     }
@@ -2571,11 +2570,11 @@ public abstract class WorkHttpClientBase
         routeValues.put("project", project); //$NON-NLS-1$
         routeValues.put("board", board); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<BoardChartReference>>() {});
     }
@@ -2604,11 +2603,11 @@ public abstract class WorkHttpClientBase
         routeValues.put("team", team); //$NON-NLS-1$
         routeValues.put("board", board); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<BoardChartReference>>() {});
     }
@@ -2637,11 +2636,11 @@ public abstract class WorkHttpClientBase
         routeValues.put("team", team); //$NON-NLS-1$
         routeValues.put("board", board); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<BoardChartReference>>() {});
     }
@@ -2673,13 +2672,13 @@ public abstract class WorkHttpClientBase
         routeValues.put("board", board); //$NON-NLS-1$
         routeValues.put("name", name); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.PATCH,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       chart,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.PATCH,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               chart,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, BoardChart.class);
     }
@@ -2711,13 +2710,13 @@ public abstract class WorkHttpClientBase
         routeValues.put("board", board); //$NON-NLS-1$
         routeValues.put("name", name); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.PATCH,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       chart,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.PATCH,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               chart,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, BoardChart.class);
     }
@@ -2753,13 +2752,13 @@ public abstract class WorkHttpClientBase
         routeValues.put("board", board); //$NON-NLS-1$
         routeValues.put("name", name); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.PATCH,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       chart,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.PATCH,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               chart,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, BoardChart.class);
     }
@@ -2795,13 +2794,13 @@ public abstract class WorkHttpClientBase
         routeValues.put("board", board); //$NON-NLS-1$
         routeValues.put("name", name); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.PATCH,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       chart,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.PATCH,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               chart,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, BoardChart.class);
     }
@@ -2826,11 +2825,11 @@ public abstract class WorkHttpClientBase
         routeValues.put("project", project); //$NON-NLS-1$
         routeValues.put("board", board); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<BoardColumn>>() {});
     }
@@ -2855,11 +2854,11 @@ public abstract class WorkHttpClientBase
         routeValues.put("project", project); //$NON-NLS-1$
         routeValues.put("board", board); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<BoardColumn>>() {});
     }
@@ -2888,11 +2887,11 @@ public abstract class WorkHttpClientBase
         routeValues.put("team", team); //$NON-NLS-1$
         routeValues.put("board", board); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<BoardColumn>>() {});
     }
@@ -2921,11 +2920,11 @@ public abstract class WorkHttpClientBase
         routeValues.put("team", team); //$NON-NLS-1$
         routeValues.put("board", board); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<BoardColumn>>() {});
     }
@@ -2953,13 +2952,13 @@ public abstract class WorkHttpClientBase
         routeValues.put("project", project); //$NON-NLS-1$
         routeValues.put("board", board); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.PUT,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       boardColumns,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.PUT,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               boardColumns,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<BoardColumn>>() {});
     }
@@ -2987,13 +2986,13 @@ public abstract class WorkHttpClientBase
         routeValues.put("project", project); //$NON-NLS-1$
         routeValues.put("board", board); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.PUT,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       boardColumns,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.PUT,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               boardColumns,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<BoardColumn>>() {});
     }
@@ -3025,13 +3024,13 @@ public abstract class WorkHttpClientBase
         routeValues.put("team", team); //$NON-NLS-1$
         routeValues.put("board", board); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.PUT,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       boardColumns,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.PUT,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               boardColumns,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<BoardColumn>>() {});
     }
@@ -3063,15 +3062,199 @@ public abstract class WorkHttpClientBase
         routeValues.put("team", team); //$NON-NLS-1$
         routeValues.put("board", board); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.PUT,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       boardColumns,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.PUT,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               boardColumns,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<BoardColumn>>() {});
+    }
+
+    /** 
+     * [Preview API 3.0-preview.1] Get Delivery View Data
+     * 
+     * @param project 
+     *            Project ID or project name
+     * @param team 
+     *            Team ID or team name
+     * @param id 
+     *            Identifier for delivery view
+     * @param startDate 
+     *            The start date of timeline
+     * @param endDate 
+     *            The end date of timeline
+     * @param teamIds 
+     *            The comma-separated list of ids of teams
+     * @return DeliveryViewData
+     */
+    public DeliveryViewData getDeliveryTimelineData(
+        final String project, 
+        final String team, 
+        final String id, 
+        final Date startDate, 
+        final Date endDate, 
+        final List<UUID> teamIds) { 
+
+        final UUID locationId = UUID.fromString("bdd0834e-101f-49f0-a6ae-509f384a12b4"); //$NON-NLS-1$
+        final ApiResourceVersion apiVersion = new ApiResourceVersion("3.0-preview.1"); //$NON-NLS-1$
+
+        final Map<String, Object> routeValues = new HashMap<String, Object>();
+        routeValues.put("project", project); //$NON-NLS-1$
+        routeValues.put("team", team); //$NON-NLS-1$
+        routeValues.put("id", id); //$NON-NLS-1$
+
+        final NameValueCollection queryParameters = new NameValueCollection();
+        queryParameters.addIfNotNull("startDate", startDate); //$NON-NLS-1$
+        queryParameters.addIfNotNull("endDate", endDate); //$NON-NLS-1$
+        queryParameters.addIfNotNull("teamIds", teamIds); //$NON-NLS-1$
+
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
+
+        return super.sendRequest(httpRequest, DeliveryViewData.class);
+    }
+
+    /** 
+     * [Preview API 3.0-preview.1] Get Delivery View Data
+     * 
+     * @param project 
+     *            Project ID
+     * @param team 
+     *            Team ID
+     * @param id 
+     *            Identifier for delivery view
+     * @param startDate 
+     *            The start date of timeline
+     * @param endDate 
+     *            The end date of timeline
+     * @param teamIds 
+     *            The comma-separated list of ids of teams
+     * @return DeliveryViewData
+     */
+    public DeliveryViewData getDeliveryTimelineData(
+        final UUID project, 
+        final UUID team, 
+        final String id, 
+        final Date startDate, 
+        final Date endDate, 
+        final List<UUID> teamIds) { 
+
+        final UUID locationId = UUID.fromString("bdd0834e-101f-49f0-a6ae-509f384a12b4"); //$NON-NLS-1$
+        final ApiResourceVersion apiVersion = new ApiResourceVersion("3.0-preview.1"); //$NON-NLS-1$
+
+        final Map<String, Object> routeValues = new HashMap<String, Object>();
+        routeValues.put("project", project); //$NON-NLS-1$
+        routeValues.put("team", team); //$NON-NLS-1$
+        routeValues.put("id", id); //$NON-NLS-1$
+
+        final NameValueCollection queryParameters = new NameValueCollection();
+        queryParameters.addIfNotNull("startDate", startDate); //$NON-NLS-1$
+        queryParameters.addIfNotNull("endDate", endDate); //$NON-NLS-1$
+        queryParameters.addIfNotNull("teamIds", teamIds); //$NON-NLS-1$
+
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
+
+        return super.sendRequest(httpRequest, DeliveryViewData.class);
+    }
+
+    /** 
+     * [Preview API 3.0-preview.1] Get Delivery View Data
+     * 
+     * @param project 
+     *            Project ID or project name
+     * @param id 
+     *            Identifier for delivery view
+     * @param startDate 
+     *            The start date of timeline
+     * @param endDate 
+     *            The end date of timeline
+     * @param teamIds 
+     *            The comma-separated list of ids of teams
+     * @return DeliveryViewData
+     */
+    public DeliveryViewData getDeliveryTimelineData(
+        final String project, 
+        final String id, 
+        final Date startDate, 
+        final Date endDate, 
+        final List<UUID> teamIds) { 
+
+        final UUID locationId = UUID.fromString("bdd0834e-101f-49f0-a6ae-509f384a12b4"); //$NON-NLS-1$
+        final ApiResourceVersion apiVersion = new ApiResourceVersion("3.0-preview.1"); //$NON-NLS-1$
+
+        final Map<String, Object> routeValues = new HashMap<String, Object>();
+        routeValues.put("project", project); //$NON-NLS-1$
+        routeValues.put("id", id); //$NON-NLS-1$
+
+        final NameValueCollection queryParameters = new NameValueCollection();
+        queryParameters.addIfNotNull("startDate", startDate); //$NON-NLS-1$
+        queryParameters.addIfNotNull("endDate", endDate); //$NON-NLS-1$
+        queryParameters.addIfNotNull("teamIds", teamIds); //$NON-NLS-1$
+
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
+
+        return super.sendRequest(httpRequest, DeliveryViewData.class);
+    }
+
+    /** 
+     * [Preview API 3.0-preview.1] Get Delivery View Data
+     * 
+     * @param project 
+     *            Project ID
+     * @param id 
+     *            Identifier for delivery view
+     * @param startDate 
+     *            The start date of timeline
+     * @param endDate 
+     *            The end date of timeline
+     * @param teamIds 
+     *            The comma-separated list of ids of teams
+     * @return DeliveryViewData
+     */
+    public DeliveryViewData getDeliveryTimelineData(
+        final UUID project, 
+        final String id, 
+        final Date startDate, 
+        final Date endDate, 
+        final List<UUID> teamIds) { 
+
+        final UUID locationId = UUID.fromString("bdd0834e-101f-49f0-a6ae-509f384a12b4"); //$NON-NLS-1$
+        final ApiResourceVersion apiVersion = new ApiResourceVersion("3.0-preview.1"); //$NON-NLS-1$
+
+        final Map<String, Object> routeValues = new HashMap<String, Object>();
+        routeValues.put("project", project); //$NON-NLS-1$
+        routeValues.put("id", id); //$NON-NLS-1$
+
+        final NameValueCollection queryParameters = new NameValueCollection();
+        queryParameters.addIfNotNull("startDate", startDate); //$NON-NLS-1$
+        queryParameters.addIfNotNull("endDate", endDate); //$NON-NLS-1$
+        queryParameters.addIfNotNull("teamIds", teamIds); //$NON-NLS-1$
+
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
+
+        return super.sendRequest(httpRequest, DeliveryViewData.class);
     }
 
     /** 
@@ -3093,11 +3276,11 @@ public abstract class WorkHttpClientBase
         routeValues.put("project", project); //$NON-NLS-1$
         routeValues.put("id", id); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.DELETE,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.DELETE,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         super.sendRequest(httpRequest);
     }
@@ -3121,11 +3304,11 @@ public abstract class WorkHttpClientBase
         routeValues.put("project", project); //$NON-NLS-1$
         routeValues.put("id", id); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.DELETE,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.DELETE,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         super.sendRequest(httpRequest);
     }
@@ -3153,11 +3336,11 @@ public abstract class WorkHttpClientBase
         routeValues.put("team", team); //$NON-NLS-1$
         routeValues.put("id", id); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.DELETE,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.DELETE,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         super.sendRequest(httpRequest);
     }
@@ -3185,11 +3368,11 @@ public abstract class WorkHttpClientBase
         routeValues.put("team", team); //$NON-NLS-1$
         routeValues.put("id", id); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.DELETE,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.DELETE,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         super.sendRequest(httpRequest);
     }
@@ -3214,11 +3397,11 @@ public abstract class WorkHttpClientBase
         routeValues.put("project", project); //$NON-NLS-1$
         routeValues.put("id", id); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, TeamSettingsIteration.class);
     }
@@ -3243,11 +3426,11 @@ public abstract class WorkHttpClientBase
         routeValues.put("project", project); //$NON-NLS-1$
         routeValues.put("id", id); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, TeamSettingsIteration.class);
     }
@@ -3276,11 +3459,11 @@ public abstract class WorkHttpClientBase
         routeValues.put("team", team); //$NON-NLS-1$
         routeValues.put("id", id); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, TeamSettingsIteration.class);
     }
@@ -3309,11 +3492,11 @@ public abstract class WorkHttpClientBase
         routeValues.put("team", team); //$NON-NLS-1$
         routeValues.put("id", id); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, TeamSettingsIteration.class);
     }
@@ -3344,12 +3527,12 @@ public abstract class WorkHttpClientBase
         final NameValueCollection queryParameters = new NameValueCollection();
         queryParameters.addIfNotEmpty("$timeframe", timeframe); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<TeamSettingsIteration>>() {});
     }
@@ -3380,12 +3563,12 @@ public abstract class WorkHttpClientBase
         final NameValueCollection queryParameters = new NameValueCollection();
         queryParameters.addIfNotEmpty("$timeframe", timeframe); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<TeamSettingsIteration>>() {});
     }
@@ -3412,12 +3595,12 @@ public abstract class WorkHttpClientBase
         final NameValueCollection queryParameters = new NameValueCollection();
         queryParameters.addIfNotEmpty("$timeframe", timeframe); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<TeamSettingsIteration>>() {});
     }
@@ -3444,12 +3627,12 @@ public abstract class WorkHttpClientBase
         final NameValueCollection queryParameters = new NameValueCollection();
         queryParameters.addIfNotEmpty("$timeframe", timeframe); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<TeamSettingsIteration>>() {});
     }
@@ -3473,13 +3656,13 @@ public abstract class WorkHttpClientBase
         final Map<String, Object> routeValues = new HashMap<String, Object>();
         routeValues.put("project", project); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.POST,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       iteration,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.POST,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               iteration,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, TeamSettingsIteration.class);
     }
@@ -3503,13 +3686,13 @@ public abstract class WorkHttpClientBase
         final Map<String, Object> routeValues = new HashMap<String, Object>();
         routeValues.put("project", project); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.POST,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       iteration,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.POST,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               iteration,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, TeamSettingsIteration.class);
     }
@@ -3537,13 +3720,13 @@ public abstract class WorkHttpClientBase
         routeValues.put("project", project); //$NON-NLS-1$
         routeValues.put("team", team); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.POST,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       iteration,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.POST,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               iteration,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, TeamSettingsIteration.class);
     }
@@ -3571,15 +3754,497 @@ public abstract class WorkHttpClientBase
         routeValues.put("project", project); //$NON-NLS-1$
         routeValues.put("team", team); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.POST,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       iteration,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.POST,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               iteration,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, TeamSettingsIteration.class);
+    }
+
+    /** 
+     * [Preview API 3.0-preview.1] Add a new plan for the team
+     * 
+     * @param postedPlan 
+     *            Plan definition
+     * @param project 
+     *            Project ID or project name
+     * @return Plan
+     */
+    public Plan createPlan(
+        final CreatePlan postedPlan, 
+        final String project) { 
+
+        final UUID locationId = UUID.fromString("0b42cb47-cd73-4810-ac90-19c9ba147453"); //$NON-NLS-1$
+        final ApiResourceVersion apiVersion = new ApiResourceVersion("3.0-preview.1"); //$NON-NLS-1$
+
+        final Map<String, Object> routeValues = new HashMap<String, Object>();
+        routeValues.put("project", project); //$NON-NLS-1$
+
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.POST,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               postedPlan,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
+
+        return super.sendRequest(httpRequest, Plan.class);
+    }
+
+    /** 
+     * [Preview API 3.0-preview.1] Add a new plan for the team
+     * 
+     * @param postedPlan 
+     *            Plan definition
+     * @param project 
+     *            Project ID
+     * @return Plan
+     */
+    public Plan createPlan(
+        final CreatePlan postedPlan, 
+        final UUID project) { 
+
+        final UUID locationId = UUID.fromString("0b42cb47-cd73-4810-ac90-19c9ba147453"); //$NON-NLS-1$
+        final ApiResourceVersion apiVersion = new ApiResourceVersion("3.0-preview.1"); //$NON-NLS-1$
+
+        final Map<String, Object> routeValues = new HashMap<String, Object>();
+        routeValues.put("project", project); //$NON-NLS-1$
+
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.POST,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               postedPlan,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
+
+        return super.sendRequest(httpRequest, Plan.class);
+    }
+
+    /** 
+     * [Preview API 3.0-preview.1] Add a new plan for the team
+     * 
+     * @param postedPlan 
+     *            Plan definition
+     * @param project 
+     *            Project ID or project name
+     * @param team 
+     *            Team ID or team name
+     * @return Plan
+     */
+    public Plan createPlan(
+        final CreatePlan postedPlan, 
+        final String project, 
+        final String team) { 
+
+        final UUID locationId = UUID.fromString("0b42cb47-cd73-4810-ac90-19c9ba147453"); //$NON-NLS-1$
+        final ApiResourceVersion apiVersion = new ApiResourceVersion("3.0-preview.1"); //$NON-NLS-1$
+
+        final Map<String, Object> routeValues = new HashMap<String, Object>();
+        routeValues.put("project", project); //$NON-NLS-1$
+        routeValues.put("team", team); //$NON-NLS-1$
+
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.POST,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               postedPlan,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
+
+        return super.sendRequest(httpRequest, Plan.class);
+    }
+
+    /** 
+     * [Preview API 3.0-preview.1] Add a new plan for the team
+     * 
+     * @param postedPlan 
+     *            Plan definition
+     * @param project 
+     *            Project ID
+     * @param team 
+     *            Team ID
+     * @return Plan
+     */
+    public Plan createPlan(
+        final CreatePlan postedPlan, 
+        final UUID project, 
+        final UUID team) { 
+
+        final UUID locationId = UUID.fromString("0b42cb47-cd73-4810-ac90-19c9ba147453"); //$NON-NLS-1$
+        final ApiResourceVersion apiVersion = new ApiResourceVersion("3.0-preview.1"); //$NON-NLS-1$
+
+        final Map<String, Object> routeValues = new HashMap<String, Object>();
+        routeValues.put("project", project); //$NON-NLS-1$
+        routeValues.put("team", team); //$NON-NLS-1$
+
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.POST,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               postedPlan,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
+
+        return super.sendRequest(httpRequest, Plan.class);
+    }
+
+    /** 
+     * [Preview API 3.0-preview.1] Delete the specified plan
+     * 
+     * @param project 
+     *            Project ID or project name
+     * @param id 
+     *            Identifier of the plan
+     * @return String
+     */
+    public String deletePlan(
+        final String project, 
+        final String id) { 
+
+        final UUID locationId = UUID.fromString("0b42cb47-cd73-4810-ac90-19c9ba147453"); //$NON-NLS-1$
+        final ApiResourceVersion apiVersion = new ApiResourceVersion("3.0-preview.1"); //$NON-NLS-1$
+
+        final Map<String, Object> routeValues = new HashMap<String, Object>();
+        routeValues.put("project", project); //$NON-NLS-1$
+        routeValues.put("id", id); //$NON-NLS-1$
+
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.DELETE,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
+
+        return super.sendRequest(httpRequest, String.class);
+    }
+
+    /** 
+     * [Preview API 3.0-preview.1] Delete the specified plan
+     * 
+     * @param project 
+     *            Project ID
+     * @param id 
+     *            Identifier of the plan
+     * @return String
+     */
+    public String deletePlan(
+        final UUID project, 
+        final String id) { 
+
+        final UUID locationId = UUID.fromString("0b42cb47-cd73-4810-ac90-19c9ba147453"); //$NON-NLS-1$
+        final ApiResourceVersion apiVersion = new ApiResourceVersion("3.0-preview.1"); //$NON-NLS-1$
+
+        final Map<String, Object> routeValues = new HashMap<String, Object>();
+        routeValues.put("project", project); //$NON-NLS-1$
+        routeValues.put("id", id); //$NON-NLS-1$
+
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.DELETE,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
+
+        return super.sendRequest(httpRequest, String.class);
+    }
+
+    /** 
+     * [Preview API 3.0-preview.1] Delete the specified plan
+     * 
+     * @param project 
+     *            Project ID or project name
+     * @param team 
+     *            Team ID or team name
+     * @param id 
+     *            Identifier of the plan
+     * @return String
+     */
+    public String deletePlan(
+        final String project, 
+        final String team, 
+        final String id) { 
+
+        final UUID locationId = UUID.fromString("0b42cb47-cd73-4810-ac90-19c9ba147453"); //$NON-NLS-1$
+        final ApiResourceVersion apiVersion = new ApiResourceVersion("3.0-preview.1"); //$NON-NLS-1$
+
+        final Map<String, Object> routeValues = new HashMap<String, Object>();
+        routeValues.put("project", project); //$NON-NLS-1$
+        routeValues.put("team", team); //$NON-NLS-1$
+        routeValues.put("id", id); //$NON-NLS-1$
+
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.DELETE,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
+
+        return super.sendRequest(httpRequest, String.class);
+    }
+
+    /** 
+     * [Preview API 3.0-preview.1] Delete the specified plan
+     * 
+     * @param project 
+     *            Project ID
+     * @param team 
+     *            Team ID
+     * @param id 
+     *            Identifier of the plan
+     * @return String
+     */
+    public String deletePlan(
+        final UUID project, 
+        final UUID team, 
+        final String id) { 
+
+        final UUID locationId = UUID.fromString("0b42cb47-cd73-4810-ac90-19c9ba147453"); //$NON-NLS-1$
+        final ApiResourceVersion apiVersion = new ApiResourceVersion("3.0-preview.1"); //$NON-NLS-1$
+
+        final Map<String, Object> routeValues = new HashMap<String, Object>();
+        routeValues.put("project", project); //$NON-NLS-1$
+        routeValues.put("team", team); //$NON-NLS-1$
+        routeValues.put("id", id); //$NON-NLS-1$
+
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.DELETE,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
+
+        return super.sendRequest(httpRequest, String.class);
+    }
+
+    /** 
+     * [Preview API 3.0-preview.1] Get the information for the specified plan
+     * 
+     * @param project 
+     *            Project ID or project name
+     * @param id 
+     *            Identifier of the plan
+     * @return Plan
+     */
+    public Plan getPlan(
+        final String project, 
+        final String id) { 
+
+        final UUID locationId = UUID.fromString("0b42cb47-cd73-4810-ac90-19c9ba147453"); //$NON-NLS-1$
+        final ApiResourceVersion apiVersion = new ApiResourceVersion("3.0-preview.1"); //$NON-NLS-1$
+
+        final Map<String, Object> routeValues = new HashMap<String, Object>();
+        routeValues.put("project", project); //$NON-NLS-1$
+        routeValues.put("id", id); //$NON-NLS-1$
+
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
+
+        return super.sendRequest(httpRequest, Plan.class);
+    }
+
+    /** 
+     * [Preview API 3.0-preview.1] Get the information for the specified plan
+     * 
+     * @param project 
+     *            Project ID
+     * @param id 
+     *            Identifier of the plan
+     * @return Plan
+     */
+    public Plan getPlan(
+        final UUID project, 
+        final String id) { 
+
+        final UUID locationId = UUID.fromString("0b42cb47-cd73-4810-ac90-19c9ba147453"); //$NON-NLS-1$
+        final ApiResourceVersion apiVersion = new ApiResourceVersion("3.0-preview.1"); //$NON-NLS-1$
+
+        final Map<String, Object> routeValues = new HashMap<String, Object>();
+        routeValues.put("project", project); //$NON-NLS-1$
+        routeValues.put("id", id); //$NON-NLS-1$
+
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
+
+        return super.sendRequest(httpRequest, Plan.class);
+    }
+
+    /** 
+     * [Preview API 3.0-preview.1] Get the information for the specified plan
+     * 
+     * @param project 
+     *            Project ID or project name
+     * @param team 
+     *            Team ID or team name
+     * @param id 
+     *            Identifier of the plan
+     * @return Plan
+     */
+    public Plan getPlan(
+        final String project, 
+        final String team, 
+        final String id) { 
+
+        final UUID locationId = UUID.fromString("0b42cb47-cd73-4810-ac90-19c9ba147453"); //$NON-NLS-1$
+        final ApiResourceVersion apiVersion = new ApiResourceVersion("3.0-preview.1"); //$NON-NLS-1$
+
+        final Map<String, Object> routeValues = new HashMap<String, Object>();
+        routeValues.put("project", project); //$NON-NLS-1$
+        routeValues.put("team", team); //$NON-NLS-1$
+        routeValues.put("id", id); //$NON-NLS-1$
+
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
+
+        return super.sendRequest(httpRequest, Plan.class);
+    }
+
+    /** 
+     * [Preview API 3.0-preview.1] Get the information for the specified plan
+     * 
+     * @param project 
+     *            Project ID
+     * @param team 
+     *            Team ID
+     * @param id 
+     *            Identifier of the plan
+     * @return Plan
+     */
+    public Plan getPlan(
+        final UUID project, 
+        final UUID team, 
+        final String id) { 
+
+        final UUID locationId = UUID.fromString("0b42cb47-cd73-4810-ac90-19c9ba147453"); //$NON-NLS-1$
+        final ApiResourceVersion apiVersion = new ApiResourceVersion("3.0-preview.1"); //$NON-NLS-1$
+
+        final Map<String, Object> routeValues = new HashMap<String, Object>();
+        routeValues.put("project", project); //$NON-NLS-1$
+        routeValues.put("team", team); //$NON-NLS-1$
+        routeValues.put("id", id); //$NON-NLS-1$
+
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
+
+        return super.sendRequest(httpRequest, Plan.class);
+    }
+
+    /** 
+     * [Preview API 3.0-preview.1]
+     * 
+     * @param project 
+     *            Project ID or project name
+     * @return ArrayList&lt;Plan&gt;
+     */
+    public ArrayList<Plan> getPlans(final String project) { 
+
+        final UUID locationId = UUID.fromString("0b42cb47-cd73-4810-ac90-19c9ba147453"); //$NON-NLS-1$
+        final ApiResourceVersion apiVersion = new ApiResourceVersion("3.0-preview.1"); //$NON-NLS-1$
+
+        final Map<String, Object> routeValues = new HashMap<String, Object>();
+        routeValues.put("project", project); //$NON-NLS-1$
+
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
+
+        return super.sendRequest(httpRequest, new TypeReference<ArrayList<Plan>>() {});
+    }
+
+    /** 
+     * [Preview API 3.0-preview.1]
+     * 
+     * @param project 
+     *            Project ID
+     * @return ArrayList&lt;Plan&gt;
+     */
+    public ArrayList<Plan> getPlans(final UUID project) { 
+
+        final UUID locationId = UUID.fromString("0b42cb47-cd73-4810-ac90-19c9ba147453"); //$NON-NLS-1$
+        final ApiResourceVersion apiVersion = new ApiResourceVersion("3.0-preview.1"); //$NON-NLS-1$
+
+        final Map<String, Object> routeValues = new HashMap<String, Object>();
+        routeValues.put("project", project); //$NON-NLS-1$
+
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
+
+        return super.sendRequest(httpRequest, new TypeReference<ArrayList<Plan>>() {});
+    }
+
+    /** 
+     * [Preview API 3.0-preview.1]
+     * 
+     * @param project 
+     *            Project ID or project name
+     * @param team 
+     *            Team ID or team name
+     * @return ArrayList&lt;Plan&gt;
+     */
+    public ArrayList<Plan> getPlans(
+        final String project, 
+        final String team) { 
+
+        final UUID locationId = UUID.fromString("0b42cb47-cd73-4810-ac90-19c9ba147453"); //$NON-NLS-1$
+        final ApiResourceVersion apiVersion = new ApiResourceVersion("3.0-preview.1"); //$NON-NLS-1$
+
+        final Map<String, Object> routeValues = new HashMap<String, Object>();
+        routeValues.put("project", project); //$NON-NLS-1$
+        routeValues.put("team", team); //$NON-NLS-1$
+
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
+
+        return super.sendRequest(httpRequest, new TypeReference<ArrayList<Plan>>() {});
+    }
+
+    /** 
+     * [Preview API 3.0-preview.1]
+     * 
+     * @param project 
+     *            Project ID
+     * @param team 
+     *            Team ID
+     * @return ArrayList&lt;Plan&gt;
+     */
+    public ArrayList<Plan> getPlans(
+        final UUID project, 
+        final UUID team) { 
+
+        final UUID locationId = UUID.fromString("0b42cb47-cd73-4810-ac90-19c9ba147453"); //$NON-NLS-1$
+        final ApiResourceVersion apiVersion = new ApiResourceVersion("3.0-preview.1"); //$NON-NLS-1$
+
+        final Map<String, Object> routeValues = new HashMap<String, Object>();
+        routeValues.put("project", project); //$NON-NLS-1$
+        routeValues.put("team", team); //$NON-NLS-1$
+
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
+
+        return super.sendRequest(httpRequest, new TypeReference<ArrayList<Plan>>() {});
     }
 
     /** 
@@ -3597,11 +4262,11 @@ public abstract class WorkHttpClientBase
         final Map<String, Object> routeValues = new HashMap<String, Object>();
         routeValues.put("project", project); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, ProcessConfiguration.class);
     }
@@ -3621,11 +4286,11 @@ public abstract class WorkHttpClientBase
         final Map<String, Object> routeValues = new HashMap<String, Object>();
         routeValues.put("project", project); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, ProcessConfiguration.class);
     }
@@ -3650,11 +4315,11 @@ public abstract class WorkHttpClientBase
         routeValues.put("project", project); //$NON-NLS-1$
         routeValues.put("board", board); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<BoardRow>>() {});
     }
@@ -3679,11 +4344,11 @@ public abstract class WorkHttpClientBase
         routeValues.put("project", project); //$NON-NLS-1$
         routeValues.put("board", board); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<BoardRow>>() {});
     }
@@ -3712,11 +4377,11 @@ public abstract class WorkHttpClientBase
         routeValues.put("team", team); //$NON-NLS-1$
         routeValues.put("board", board); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<BoardRow>>() {});
     }
@@ -3745,11 +4410,11 @@ public abstract class WorkHttpClientBase
         routeValues.put("team", team); //$NON-NLS-1$
         routeValues.put("board", board); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<BoardRow>>() {});
     }
@@ -3777,13 +4442,13 @@ public abstract class WorkHttpClientBase
         routeValues.put("project", project); //$NON-NLS-1$
         routeValues.put("board", board); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.PUT,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       boardRows,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.PUT,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               boardRows,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<BoardRow>>() {});
     }
@@ -3811,13 +4476,13 @@ public abstract class WorkHttpClientBase
         routeValues.put("project", project); //$NON-NLS-1$
         routeValues.put("board", board); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.PUT,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       boardRows,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.PUT,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               boardRows,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<BoardRow>>() {});
     }
@@ -3849,13 +4514,13 @@ public abstract class WorkHttpClientBase
         routeValues.put("team", team); //$NON-NLS-1$
         routeValues.put("board", board); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.PUT,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       boardRows,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.PUT,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               boardRows,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<BoardRow>>() {});
     }
@@ -3887,13 +4552,13 @@ public abstract class WorkHttpClientBase
         routeValues.put("team", team); //$NON-NLS-1$
         routeValues.put("board", board); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.PUT,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       boardRows,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.PUT,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               boardRows,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<BoardRow>>() {});
     }
@@ -3918,11 +4583,11 @@ public abstract class WorkHttpClientBase
         routeValues.put("project", project); //$NON-NLS-1$
         routeValues.put("iterationId", iterationId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, TeamSettingsDaysOff.class);
     }
@@ -3947,11 +4612,11 @@ public abstract class WorkHttpClientBase
         routeValues.put("project", project); //$NON-NLS-1$
         routeValues.put("iterationId", iterationId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, TeamSettingsDaysOff.class);
     }
@@ -3980,11 +4645,11 @@ public abstract class WorkHttpClientBase
         routeValues.put("team", team); //$NON-NLS-1$
         routeValues.put("iterationId", iterationId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, TeamSettingsDaysOff.class);
     }
@@ -4013,11 +4678,11 @@ public abstract class WorkHttpClientBase
         routeValues.put("team", team); //$NON-NLS-1$
         routeValues.put("iterationId", iterationId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, TeamSettingsDaysOff.class);
     }
@@ -4045,13 +4710,13 @@ public abstract class WorkHttpClientBase
         routeValues.put("project", project); //$NON-NLS-1$
         routeValues.put("iterationId", iterationId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.PATCH,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       daysOffPatch,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.PATCH,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               daysOffPatch,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, TeamSettingsDaysOff.class);
     }
@@ -4079,13 +4744,13 @@ public abstract class WorkHttpClientBase
         routeValues.put("project", project); //$NON-NLS-1$
         routeValues.put("iterationId", iterationId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.PATCH,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       daysOffPatch,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.PATCH,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               daysOffPatch,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, TeamSettingsDaysOff.class);
     }
@@ -4117,13 +4782,13 @@ public abstract class WorkHttpClientBase
         routeValues.put("team", team); //$NON-NLS-1$
         routeValues.put("iterationId", iterationId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.PATCH,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       daysOffPatch,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.PATCH,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               daysOffPatch,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, TeamSettingsDaysOff.class);
     }
@@ -4155,13 +4820,13 @@ public abstract class WorkHttpClientBase
         routeValues.put("team", team); //$NON-NLS-1$
         routeValues.put("iterationId", iterationId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.PATCH,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       daysOffPatch,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.PATCH,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               daysOffPatch,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, TeamSettingsDaysOff.class);
     }
@@ -4181,11 +4846,11 @@ public abstract class WorkHttpClientBase
         final Map<String, Object> routeValues = new HashMap<String, Object>();
         routeValues.put("project", project); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, TeamFieldValues.class);
     }
@@ -4205,11 +4870,11 @@ public abstract class WorkHttpClientBase
         final Map<String, Object> routeValues = new HashMap<String, Object>();
         routeValues.put("project", project); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, TeamFieldValues.class);
     }
@@ -4234,11 +4899,11 @@ public abstract class WorkHttpClientBase
         routeValues.put("project", project); //$NON-NLS-1$
         routeValues.put("team", team); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, TeamFieldValues.class);
     }
@@ -4263,11 +4928,11 @@ public abstract class WorkHttpClientBase
         routeValues.put("project", project); //$NON-NLS-1$
         routeValues.put("team", team); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, TeamFieldValues.class);
     }
@@ -4291,13 +4956,13 @@ public abstract class WorkHttpClientBase
         final Map<String, Object> routeValues = new HashMap<String, Object>();
         routeValues.put("project", project); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.PATCH,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       patch,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.PATCH,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               patch,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, TeamFieldValues.class);
     }
@@ -4321,13 +4986,13 @@ public abstract class WorkHttpClientBase
         final Map<String, Object> routeValues = new HashMap<String, Object>();
         routeValues.put("project", project); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.PATCH,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       patch,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.PATCH,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               patch,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, TeamFieldValues.class);
     }
@@ -4355,13 +5020,13 @@ public abstract class WorkHttpClientBase
         routeValues.put("project", project); //$NON-NLS-1$
         routeValues.put("team", team); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.PATCH,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       patch,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.PATCH,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               patch,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, TeamFieldValues.class);
     }
@@ -4389,13 +5054,13 @@ public abstract class WorkHttpClientBase
         routeValues.put("project", project); //$NON-NLS-1$
         routeValues.put("team", team); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.PATCH,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       patch,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.PATCH,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               patch,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, TeamFieldValues.class);
     }
@@ -4415,11 +5080,11 @@ public abstract class WorkHttpClientBase
         final Map<String, Object> routeValues = new HashMap<String, Object>();
         routeValues.put("project", project); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, TeamSetting.class);
     }
@@ -4439,11 +5104,11 @@ public abstract class WorkHttpClientBase
         final Map<String, Object> routeValues = new HashMap<String, Object>();
         routeValues.put("project", project); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, TeamSetting.class);
     }
@@ -4468,11 +5133,11 @@ public abstract class WorkHttpClientBase
         routeValues.put("project", project); //$NON-NLS-1$
         routeValues.put("team", team); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, TeamSetting.class);
     }
@@ -4497,11 +5162,11 @@ public abstract class WorkHttpClientBase
         routeValues.put("project", project); //$NON-NLS-1$
         routeValues.put("team", team); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, TeamSetting.class);
     }
@@ -4525,13 +5190,13 @@ public abstract class WorkHttpClientBase
         final Map<String, Object> routeValues = new HashMap<String, Object>();
         routeValues.put("project", project); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.PATCH,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       teamSettingsPatch,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.PATCH,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               teamSettingsPatch,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, TeamSetting.class);
     }
@@ -4555,13 +5220,13 @@ public abstract class WorkHttpClientBase
         final Map<String, Object> routeValues = new HashMap<String, Object>();
         routeValues.put("project", project); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.PATCH,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       teamSettingsPatch,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.PATCH,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               teamSettingsPatch,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, TeamSetting.class);
     }
@@ -4589,13 +5254,13 @@ public abstract class WorkHttpClientBase
         routeValues.put("project", project); //$NON-NLS-1$
         routeValues.put("team", team); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.PATCH,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       teamSettingsPatch,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.PATCH,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               teamSettingsPatch,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, TeamSetting.class);
     }
@@ -4623,13 +5288,13 @@ public abstract class WorkHttpClientBase
         routeValues.put("project", project); //$NON-NLS-1$
         routeValues.put("team", team); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.PATCH,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       teamSettingsPatch,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.PATCH,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               teamSettingsPatch,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, TeamSetting.class);
     }

--- a/Rest/alm-tfs-client/src/main/generated/com/microsoft/alm/teamfoundation/work/webapi/WorkItemColor.java
+++ b/Rest/alm-tfs-client/src/main/generated/com/microsoft/alm/teamfoundation/work/webapi/WorkItemColor.java
@@ -1,0 +1,43 @@
+// @formatter:off
+/*
+* ---------------------------------------------------------
+* Copyright(C) Microsoft Corporation. All rights reserved.
+* Licensed under the MIT license. See License.txt in the project root.
+* ---------------------------------------------------------
+*
+* ---------------------------------------------------------
+* Generated file, DO NOT EDIT
+* ---------------------------------------------------------
+*
+* See following wiki page for instructions on how to regenerate:
+*   https://vsowiki.com/index.php?title=Rest_Client_Generation
+*/
+
+package com.microsoft.alm.teamfoundation.work.webapi;
+
+
+/** 
+ * Work item color.
+ * 
+ */
+public class WorkItemColor {
+
+    private String primaryColor;
+    private String workItemTypeName;
+
+    public String getPrimaryColor() {
+        return primaryColor;
+    }
+
+    public void setPrimaryColor(final String primaryColor) {
+        this.primaryColor = primaryColor;
+    }
+
+    public String getWorkItemTypeName() {
+        return workItemTypeName;
+    }
+
+    public void setWorkItemTypeName(final String workItemTypeName) {
+        this.workItemTypeName = workItemTypeName;
+    }
+}

--- a/Rest/alm-tfs-client/src/main/generated/com/microsoft/alm/teamfoundation/workitemtracking/webapi/WorkItemTrackingHttpClientBase.java
+++ b/Rest/alm-tfs-client/src/main/generated/com/microsoft/alm/teamfoundation/workitemtracking/webapi/WorkItemTrackingHttpClientBase.java
@@ -24,12 +24,17 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import com.fasterxml.jackson.core.type.TypeReference;
+import com.microsoft.alm.client.HttpMethod;
 import com.microsoft.alm.client.model.NameValueCollection;
 import com.microsoft.alm.client.VssHttpClientBase;
+import com.microsoft.alm.client.VssMediaTypes;
+import com.microsoft.alm.client.VssRestClientHandler;
+import com.microsoft.alm.client.VssRestRequest;
 import com.microsoft.alm.teamfoundation.workitemtracking.webapi.models.AttachmentReference;
 import com.microsoft.alm.teamfoundation.workitemtracking.webapi.models.CommentSortOrder;
 import com.microsoft.alm.teamfoundation.workitemtracking.webapi.models.FieldDependentRule;
 import com.microsoft.alm.teamfoundation.workitemtracking.webapi.models.FieldsToEvaluate;
+import com.microsoft.alm.teamfoundation.workitemtracking.webapi.models.GetFieldsExpand;
 import com.microsoft.alm.teamfoundation.workitemtracking.webapi.models.ProvisioningResult;
 import com.microsoft.alm.teamfoundation.workitemtracking.webapi.models.QueryExpand;
 import com.microsoft.alm.teamfoundation.workitemtracking.webapi.models.QueryHierarchyItem;
@@ -72,22 +77,13 @@ public abstract class WorkItemTrackingHttpClientBase
     * Create a new instance of WorkItemTrackingHttpClientBase
     *
     * @param jaxrsClient
-    *            an initialized instance of a JAX-RS Client implementation
+    *            a DefaultRestClientHandler initialized with an instance of a JAX-RS Client implementation or
+    *            a TEERestClientHamdler initialized with TEE HTTP client implementation
     * @param baseUrl
-    *            a TFS project collection URL
+    *            a TFS services URL
     */
-    protected WorkItemTrackingHttpClientBase(final Object jaxrsClient, final URI baseUrl) {
-        super(jaxrsClient, baseUrl);
-    }
-
-    /**
-    * Create a new instance of WorkItemTrackingHttpClientBase
-    *
-    * @param tfsConnection
-    *            an initialized instance of a TfsTeamProjectCollection
-    */
-    protected WorkItemTrackingHttpClientBase(final Object tfsConnection) {
-        super(tfsConnection);
+    protected WorkItemTrackingHttpClientBase(final VssRestClientHandler clientHandler, final URI baseUrl) {
+        super(clientHandler, baseUrl);
     }
 
     @Override
@@ -118,13 +114,13 @@ public abstract class WorkItemTrackingHttpClientBase
         queryParameters.addIfNotEmpty("fileName", fileName); //$NON-NLS-1$
         queryParameters.addIfNotEmpty("uploadType", uploadType); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.POST,
-                                                       locationId,
-                                                       apiVersion,
-                                                       uploadStream,
-                                                       APPLICATION_OCTET_STREAM_TYPE,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.POST,
+                                                               locationId,
+                                                               apiVersion,
+                                                               uploadStream,
+                                                               VssMediaTypes.APPLICATION_OCTET_STREAM_TYPE,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, AttachmentReference.class);
     }
@@ -151,12 +147,12 @@ public abstract class WorkItemTrackingHttpClientBase
         final NameValueCollection queryParameters = new NameValueCollection();
         queryParameters.addIfNotEmpty("fileName", fileName); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_OCTET_STREAM_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_OCTET_STREAM_TYPE);
 
         return super.sendRequest(httpRequest, InputStream.class);
     }
@@ -183,12 +179,12 @@ public abstract class WorkItemTrackingHttpClientBase
         final NameValueCollection queryParameters = new NameValueCollection();
         queryParameters.addIfNotEmpty("fileName", fileName); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_ZIP_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_ZIP_TYPE);
 
         return super.sendRequest(httpRequest, InputStream.class);
     }
@@ -215,12 +211,12 @@ public abstract class WorkItemTrackingHttpClientBase
         final NameValueCollection queryParameters = new NameValueCollection();
         queryParameters.addIfNotNull("$depth", depth); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<WorkItemClassificationNode>>() {});
     }
@@ -247,12 +243,12 @@ public abstract class WorkItemTrackingHttpClientBase
         final NameValueCollection queryParameters = new NameValueCollection();
         queryParameters.addIfNotNull("$depth", depth); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<WorkItemClassificationNode>>() {});
     }
@@ -284,13 +280,13 @@ public abstract class WorkItemTrackingHttpClientBase
         routeValues.put("structureGroup", structureGroup); //$NON-NLS-1$
         routeValues.put("path", path); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.POST,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       postedNode,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.POST,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               postedNode,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, WorkItemClassificationNode.class);
     }
@@ -322,13 +318,13 @@ public abstract class WorkItemTrackingHttpClientBase
         routeValues.put("structureGroup", structureGroup); //$NON-NLS-1$
         routeValues.put("path", path); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.POST,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       postedNode,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.POST,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               postedNode,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, WorkItemClassificationNode.class);
     }
@@ -362,12 +358,12 @@ public abstract class WorkItemTrackingHttpClientBase
         final NameValueCollection queryParameters = new NameValueCollection();
         queryParameters.addIfNotNull("$reclassifyId", reclassifyId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.DELETE,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.DELETE,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         super.sendRequest(httpRequest);
     }
@@ -401,12 +397,12 @@ public abstract class WorkItemTrackingHttpClientBase
         final NameValueCollection queryParameters = new NameValueCollection();
         queryParameters.addIfNotNull("$reclassifyId", reclassifyId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.DELETE,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.DELETE,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         super.sendRequest(httpRequest);
     }
@@ -441,12 +437,12 @@ public abstract class WorkItemTrackingHttpClientBase
         final NameValueCollection queryParameters = new NameValueCollection();
         queryParameters.addIfNotNull("$depth", depth); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, WorkItemClassificationNode.class);
     }
@@ -481,12 +477,12 @@ public abstract class WorkItemTrackingHttpClientBase
         final NameValueCollection queryParameters = new NameValueCollection();
         queryParameters.addIfNotNull("$depth", depth); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, WorkItemClassificationNode.class);
     }
@@ -518,13 +514,13 @@ public abstract class WorkItemTrackingHttpClientBase
         routeValues.put("structureGroup", structureGroup); //$NON-NLS-1$
         routeValues.put("path", path); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.PATCH,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       postedNode,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.PATCH,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               postedNode,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, WorkItemClassificationNode.class);
     }
@@ -556,13 +552,13 @@ public abstract class WorkItemTrackingHttpClientBase
         routeValues.put("structureGroup", structureGroup); //$NON-NLS-1$
         routeValues.put("path", path); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.PATCH,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       postedNode,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.PATCH,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               postedNode,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, WorkItemClassificationNode.class);
     }
@@ -587,11 +583,11 @@ public abstract class WorkItemTrackingHttpClientBase
         routeValues.put("id", id); //$NON-NLS-1$
         routeValues.put("revision", revision); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, WorkItemComment.class);
     }
@@ -626,21 +622,21 @@ public abstract class WorkItemTrackingHttpClientBase
         queryParameters.addIfNotNull("$top", top); //$NON-NLS-1$
         queryParameters.addIfNotNull("order", order); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, WorkItemComments.class);
     }
 
     /** 
-     * [Preview API 3.0-preview.2]
+     * [Preview API 3.0-preview.2] Gets information on a specific field.
      * 
      * @param field 
-     *            
+     *            Field name
      * @return WorkItemField
      */
     public WorkItemField getField(final String field) { 
@@ -651,29 +647,35 @@ public abstract class WorkItemTrackingHttpClientBase
         final Map<String, Object> routeValues = new HashMap<String, Object>();
         routeValues.put("field", field); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, WorkItemField.class);
     }
 
     /** 
-     * [Preview API 3.0-preview.2]
+     * [Preview API 3.0-preview.2] Returns information for all fields.
      * 
+     * @param expand 
+     *            Use ExtensionFields to include extension fields, otherwise exclude them. Unless the feature flag for this parameter is enabled, extension fields are always included.
      * @return ArrayList&lt;WorkItemField&gt;
      */
-    public ArrayList<WorkItemField> getFields() { 
+    public ArrayList<WorkItemField> getFields(final GetFieldsExpand expand) { 
 
         final UUID locationId = UUID.fromString("b51fd764-e5c2-4b9b-aaf7-3395cf4bdd94"); //$NON-NLS-1$
         final ApiResourceVersion apiVersion = new ApiResourceVersion("3.0-preview.2"); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final NameValueCollection queryParameters = new NameValueCollection();
+        queryParameters.addIfNotNull("$expand", expand); //$NON-NLS-1$
+
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<WorkItemField>>() {});
     }
@@ -704,12 +706,12 @@ public abstract class WorkItemTrackingHttpClientBase
         queryParameters.addIfNotNull("$top", top); //$NON-NLS-1$
         queryParameters.addIfNotNull("$skip", skip); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<WorkItemHistory>>() {});
     }
@@ -734,11 +736,11 @@ public abstract class WorkItemTrackingHttpClientBase
         routeValues.put("id", id); //$NON-NLS-1$
         routeValues.put("revisionNumber", revisionNumber); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, WorkItemHistory.class);
     }
@@ -766,13 +768,13 @@ public abstract class WorkItemTrackingHttpClientBase
         routeValues.put("project", project); //$NON-NLS-1$
         routeValues.put("query", query); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.POST,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       postedQuery,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.POST,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               postedQuery,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, QueryHierarchyItem.class);
     }
@@ -800,13 +802,13 @@ public abstract class WorkItemTrackingHttpClientBase
         routeValues.put("project", project); //$NON-NLS-1$
         routeValues.put("query", query); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.POST,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       postedQuery,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.POST,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               postedQuery,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, QueryHierarchyItem.class);
     }
@@ -830,11 +832,11 @@ public abstract class WorkItemTrackingHttpClientBase
         routeValues.put("project", project); //$NON-NLS-1$
         routeValues.put("query", query); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.DELETE,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.DELETE,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         super.sendRequest(httpRequest);
     }
@@ -858,11 +860,11 @@ public abstract class WorkItemTrackingHttpClientBase
         routeValues.put("project", project); //$NON-NLS-1$
         routeValues.put("query", query); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.DELETE,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.DELETE,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         super.sendRequest(httpRequest);
     }
@@ -897,12 +899,12 @@ public abstract class WorkItemTrackingHttpClientBase
         queryParameters.addIfNotNull("$depth", depth); //$NON-NLS-1$
         queryParameters.addIfNotNull("$includeDeleted", includeDeleted); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<QueryHierarchyItem>>() {});
     }
@@ -937,12 +939,12 @@ public abstract class WorkItemTrackingHttpClientBase
         queryParameters.addIfNotNull("$depth", depth); //$NON-NLS-1$
         queryParameters.addIfNotNull("$includeDeleted", includeDeleted); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<QueryHierarchyItem>>() {});
     }
@@ -981,12 +983,12 @@ public abstract class WorkItemTrackingHttpClientBase
         queryParameters.addIfNotNull("$depth", depth); //$NON-NLS-1$
         queryParameters.addIfNotNull("$includeDeleted", includeDeleted); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, QueryHierarchyItem.class);
     }
@@ -1025,12 +1027,12 @@ public abstract class WorkItemTrackingHttpClientBase
         queryParameters.addIfNotNull("$depth", depth); //$NON-NLS-1$
         queryParameters.addIfNotNull("$includeDeleted", includeDeleted); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, QueryHierarchyItem.class);
     }
@@ -1064,14 +1066,14 @@ public abstract class WorkItemTrackingHttpClientBase
         final NameValueCollection queryParameters = new NameValueCollection();
         queryParameters.addIfNotNull("$undeleteDescendants", undeleteDescendants); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.PATCH,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryUpdate,
-                                                       APPLICATION_JSON_TYPE,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.PATCH,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryUpdate,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, QueryHierarchyItem.class);
     }
@@ -1105,14 +1107,14 @@ public abstract class WorkItemTrackingHttpClientBase
         final NameValueCollection queryParameters = new NameValueCollection();
         queryParameters.addIfNotNull("$undeleteDescendants", undeleteDescendants); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.PATCH,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryUpdate,
-                                                       APPLICATION_JSON_TYPE,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.PATCH,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryUpdate,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, QueryHierarchyItem.class);
     }
@@ -1131,11 +1133,11 @@ public abstract class WorkItemTrackingHttpClientBase
         final Map<String, Object> routeValues = new HashMap<String, Object>();
         routeValues.put("id", id); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.DELETE,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.DELETE,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         super.sendRequest(httpRequest);
     }
@@ -1159,11 +1161,11 @@ public abstract class WorkItemTrackingHttpClientBase
         routeValues.put("project", project); //$NON-NLS-1$
         routeValues.put("id", id); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.DELETE,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.DELETE,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         super.sendRequest(httpRequest);
     }
@@ -1187,11 +1189,11 @@ public abstract class WorkItemTrackingHttpClientBase
         routeValues.put("project", project); //$NON-NLS-1$
         routeValues.put("id", id); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.DELETE,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.DELETE,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         super.sendRequest(httpRequest);
     }
@@ -1211,11 +1213,11 @@ public abstract class WorkItemTrackingHttpClientBase
         final Map<String, Object> routeValues = new HashMap<String, Object>();
         routeValues.put("id", id); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, WorkItemDelete.class);
     }
@@ -1240,11 +1242,11 @@ public abstract class WorkItemTrackingHttpClientBase
         routeValues.put("project", project); //$NON-NLS-1$
         routeValues.put("id", id); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, WorkItemDelete.class);
     }
@@ -1269,11 +1271,11 @@ public abstract class WorkItemTrackingHttpClientBase
         routeValues.put("project", project); //$NON-NLS-1$
         routeValues.put("id", id); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, WorkItemDelete.class);
     }
@@ -1288,10 +1290,10 @@ public abstract class WorkItemTrackingHttpClientBase
         final UUID locationId = UUID.fromString("b70d8d39-926c-465e-b927-b1bf0e5ca0e0"); //$NON-NLS-1$
         final ApiResourceVersion apiVersion = new ApiResourceVersion("3.0-preview.1"); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<WorkItemDeleteReference>>() {});
     }
@@ -1311,11 +1313,11 @@ public abstract class WorkItemTrackingHttpClientBase
         final Map<String, Object> routeValues = new HashMap<String, Object>();
         routeValues.put("project", project); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<WorkItemDeleteReference>>() {});
     }
@@ -1335,11 +1337,11 @@ public abstract class WorkItemTrackingHttpClientBase
         final Map<String, Object> routeValues = new HashMap<String, Object>();
         routeValues.put("project", project); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<WorkItemDeleteReference>>() {});
     }
@@ -1366,12 +1368,12 @@ public abstract class WorkItemTrackingHttpClientBase
         final NameValueCollection queryParameters = new NameValueCollection();
         queryParameters.addIfNotNull("ids", ids); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<WorkItemDeleteReference>>() {});
     }
@@ -1398,12 +1400,12 @@ public abstract class WorkItemTrackingHttpClientBase
         final NameValueCollection queryParameters = new NameValueCollection();
         queryParameters.addIfNotNull("ids", ids); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<WorkItemDeleteReference>>() {});
     }
@@ -1423,11 +1425,11 @@ public abstract class WorkItemTrackingHttpClientBase
         final NameValueCollection queryParameters = new NameValueCollection();
         queryParameters.addIfNotNull("ids", ids); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<WorkItemDeleteReference>>() {});
     }
@@ -1451,13 +1453,13 @@ public abstract class WorkItemTrackingHttpClientBase
         final Map<String, Object> routeValues = new HashMap<String, Object>();
         routeValues.put("id", id); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.PATCH,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       payload,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.PATCH,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               payload,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, WorkItemDelete.class);
     }
@@ -1485,13 +1487,13 @@ public abstract class WorkItemTrackingHttpClientBase
         routeValues.put("project", project); //$NON-NLS-1$
         routeValues.put("id", id); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.PATCH,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       payload,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.PATCH,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               payload,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, WorkItemDelete.class);
     }
@@ -1519,13 +1521,13 @@ public abstract class WorkItemTrackingHttpClientBase
         routeValues.put("project", project); //$NON-NLS-1$
         routeValues.put("id", id); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.PATCH,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       payload,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.PATCH,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               payload,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, WorkItemDelete.class);
     }
@@ -1556,12 +1558,12 @@ public abstract class WorkItemTrackingHttpClientBase
         final NameValueCollection queryParameters = new NameValueCollection();
         queryParameters.addIfNotNull("$expand", expand); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, WorkItem.class);
     }
@@ -1596,12 +1598,12 @@ public abstract class WorkItemTrackingHttpClientBase
         queryParameters.addIfNotNull("$skip", skip); //$NON-NLS-1$
         queryParameters.addIfNotNull("$expand", expand); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<WorkItem>>() {});
     }
@@ -1617,12 +1619,12 @@ public abstract class WorkItemTrackingHttpClientBase
         final UUID locationId = UUID.fromString("1a3a1536-dca6-4509-b9c3-dd9bb2981506"); //$NON-NLS-1$
         final ApiResourceVersion apiVersion = new ApiResourceVersion("3.0-preview.1"); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.POST,
-                                                       locationId,
-                                                       apiVersion,
-                                                       ruleEngineInput,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.POST,
+                                                               locationId,
+                                                               apiVersion,
+                                                               ruleEngineInput,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         super.sendRequest(httpRequest);
     }
@@ -1647,11 +1649,11 @@ public abstract class WorkItemTrackingHttpClientBase
         routeValues.put("id", id); //$NON-NLS-1$
         routeValues.put("updateNumber", updateNumber); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, WorkItemUpdate.class);
     }
@@ -1682,12 +1684,12 @@ public abstract class WorkItemTrackingHttpClientBase
         queryParameters.addIfNotNull("$top", top); //$NON-NLS-1$
         queryParameters.addIfNotNull("$skip", skip); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<WorkItemUpdate>>() {});
     }
@@ -1715,13 +1717,13 @@ public abstract class WorkItemTrackingHttpClientBase
         queryParameters.addIfNotNull("timePrecision", timePrecision); //$NON-NLS-1$
         queryParameters.addIfNotNull("$top", top); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.POST,
-                                                       locationId,
-                                                       apiVersion,
-                                                       wiql,
-                                                       APPLICATION_JSON_TYPE,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.POST,
+                                                               locationId,
+                                                               apiVersion,
+                                                               wiql,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, WorkItemQueryResult.class);
     }
@@ -1755,14 +1757,14 @@ public abstract class WorkItemTrackingHttpClientBase
         queryParameters.addIfNotNull("timePrecision", timePrecision); //$NON-NLS-1$
         queryParameters.addIfNotNull("$top", top); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.POST,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       wiql,
-                                                       APPLICATION_JSON_TYPE,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.POST,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               wiql,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, WorkItemQueryResult.class);
     }
@@ -1796,14 +1798,14 @@ public abstract class WorkItemTrackingHttpClientBase
         queryParameters.addIfNotNull("timePrecision", timePrecision); //$NON-NLS-1$
         queryParameters.addIfNotNull("$top", top); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.POST,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       wiql,
-                                                       APPLICATION_JSON_TYPE,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.POST,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               wiql,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, WorkItemQueryResult.class);
     }
@@ -1841,14 +1843,14 @@ public abstract class WorkItemTrackingHttpClientBase
         queryParameters.addIfNotNull("timePrecision", timePrecision); //$NON-NLS-1$
         queryParameters.addIfNotNull("$top", top); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.POST,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       wiql,
-                                                       APPLICATION_JSON_TYPE,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.POST,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               wiql,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, WorkItemQueryResult.class);
     }
@@ -1886,14 +1888,14 @@ public abstract class WorkItemTrackingHttpClientBase
         queryParameters.addIfNotNull("timePrecision", timePrecision); //$NON-NLS-1$
         queryParameters.addIfNotNull("$top", top); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.POST,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       wiql,
-                                                       APPLICATION_JSON_TYPE,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.POST,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               wiql,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, WorkItemQueryResult.class);
     }
@@ -1928,12 +1930,12 @@ public abstract class WorkItemTrackingHttpClientBase
         final NameValueCollection queryParameters = new NameValueCollection();
         queryParameters.addIfNotNull("timePrecision", timePrecision); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, WorkItemQueryResult.class);
     }
@@ -1968,12 +1970,12 @@ public abstract class WorkItemTrackingHttpClientBase
         final NameValueCollection queryParameters = new NameValueCollection();
         queryParameters.addIfNotNull("timePrecision", timePrecision); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, WorkItemQueryResult.class);
     }
@@ -2004,12 +2006,12 @@ public abstract class WorkItemTrackingHttpClientBase
         final NameValueCollection queryParameters = new NameValueCollection();
         queryParameters.addIfNotNull("timePrecision", timePrecision); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, WorkItemQueryResult.class);
     }
@@ -2040,12 +2042,12 @@ public abstract class WorkItemTrackingHttpClientBase
         final NameValueCollection queryParameters = new NameValueCollection();
         queryParameters.addIfNotNull("timePrecision", timePrecision); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, WorkItemQueryResult.class);
     }
@@ -2072,12 +2074,12 @@ public abstract class WorkItemTrackingHttpClientBase
         final NameValueCollection queryParameters = new NameValueCollection();
         queryParameters.addIfNotNull("timePrecision", timePrecision); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, WorkItemQueryResult.class);
     }
@@ -2112,12 +2114,12 @@ public abstract class WorkItemTrackingHttpClientBase
         queryParameters.addIfNotEmpty("continuationToken", continuationToken); //$NON-NLS-1$
         queryParameters.addIfNotNull("startDateTime", startDateTime); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, ReportingWorkItemLinksBatch.class);
     }
@@ -2152,12 +2154,12 @@ public abstract class WorkItemTrackingHttpClientBase
         queryParameters.addIfNotEmpty("continuationToken", continuationToken); //$NON-NLS-1$
         queryParameters.addIfNotNull("startDateTime", startDateTime); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, ReportingWorkItemLinksBatch.class);
     }
@@ -2186,11 +2188,11 @@ public abstract class WorkItemTrackingHttpClientBase
         queryParameters.addIfNotEmpty("continuationToken", continuationToken); //$NON-NLS-1$
         queryParameters.addIfNotNull("startDateTime", startDateTime); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, ReportingWorkItemLinksBatch.class);
     }
@@ -2210,11 +2212,11 @@ public abstract class WorkItemTrackingHttpClientBase
         final Map<String, Object> routeValues = new HashMap<String, Object>();
         routeValues.put("relation", relation); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, WorkItemRelationType.class);
     }
@@ -2229,10 +2231,10 @@ public abstract class WorkItemTrackingHttpClientBase
         final UUID locationId = UUID.fromString("f5d33bc9-5b49-4a3c-a9bd-f3cd46dd2165"); //$NON-NLS-1$
         final ApiResourceVersion apiVersion = new ApiResourceVersion("3.0-preview.2"); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<WorkItemRelationType>>() {});
     }
@@ -2291,12 +2293,12 @@ public abstract class WorkItemTrackingHttpClientBase
         queryParameters.addIfNotNull("includeLatestOnly", includeLatestOnly); //$NON-NLS-1$
         queryParameters.addIfNotNull("$expand", expand); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, ReportingWorkItemRevisionsBatch.class);
     }
@@ -2355,12 +2357,12 @@ public abstract class WorkItemTrackingHttpClientBase
         queryParameters.addIfNotNull("includeLatestOnly", includeLatestOnly); //$NON-NLS-1$
         queryParameters.addIfNotNull("$expand", expand); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, ReportingWorkItemRevisionsBatch.class);
     }
@@ -2413,11 +2415,11 @@ public abstract class WorkItemTrackingHttpClientBase
         queryParameters.addIfNotNull("includeLatestOnly", includeLatestOnly); //$NON-NLS-1$
         queryParameters.addIfNotNull("$expand", expand); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, ReportingWorkItemRevisionsBatch.class);
     }
@@ -2449,13 +2451,13 @@ public abstract class WorkItemTrackingHttpClientBase
         queryParameters.addIfNotNull("startDateTime", startDateTime); //$NON-NLS-1$
         queryParameters.addIfNotNull("$expand", expand); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.POST,
-                                                       locationId,
-                                                       apiVersion,
-                                                       filter,
-                                                       APPLICATION_JSON_TYPE,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.POST,
+                                                               locationId,
+                                                               apiVersion,
+                                                               filter,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, ReportingWorkItemRevisionsBatch.class);
     }
@@ -2493,14 +2495,14 @@ public abstract class WorkItemTrackingHttpClientBase
         queryParameters.addIfNotNull("startDateTime", startDateTime); //$NON-NLS-1$
         queryParameters.addIfNotNull("$expand", expand); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.POST,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       filter,
-                                                       APPLICATION_JSON_TYPE,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.POST,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               filter,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, ReportingWorkItemRevisionsBatch.class);
     }
@@ -2538,14 +2540,14 @@ public abstract class WorkItemTrackingHttpClientBase
         queryParameters.addIfNotNull("startDateTime", startDateTime); //$NON-NLS-1$
         queryParameters.addIfNotNull("$expand", expand); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.POST,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       filter,
-                                                       APPLICATION_JSON_TYPE,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.POST,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               filter,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, ReportingWorkItemRevisionsBatch.class);
     }
@@ -2572,12 +2574,12 @@ public abstract class WorkItemTrackingHttpClientBase
         final NameValueCollection queryParameters = new NameValueCollection();
         queryParameters.addIfNotNull("destroy", destroy); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.DELETE,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.DELETE,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, WorkItemDelete.class);
     }
@@ -2612,12 +2614,12 @@ public abstract class WorkItemTrackingHttpClientBase
         queryParameters.addIfNotNull("asOf", asOf); //$NON-NLS-1$
         queryParameters.addIfNotNull("$expand", expand); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, WorkItem.class);
     }
@@ -2650,11 +2652,11 @@ public abstract class WorkItemTrackingHttpClientBase
         queryParameters.addIfNotNull("asOf", asOf); //$NON-NLS-1$
         queryParameters.addIfNotNull("$expand", expand); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<WorkItem>>() {});
     }
@@ -2688,14 +2690,14 @@ public abstract class WorkItemTrackingHttpClientBase
         queryParameters.addIfNotNull("validateOnly", validateOnly); //$NON-NLS-1$
         queryParameters.addIfNotNull("bypassRules", bypassRules); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.PATCH,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       document,
-                                                       APPLICATION_JSON_PATCH_TYPE,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.PATCH,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               document,
+                                                               VssMediaTypes.APPLICATION_JSON_PATCH_TYPE,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, WorkItem.class);
     }
@@ -2733,14 +2735,14 @@ public abstract class WorkItemTrackingHttpClientBase
         queryParameters.addIfNotNull("validateOnly", validateOnly); //$NON-NLS-1$
         queryParameters.addIfNotNull("bypassRules", bypassRules); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.POST,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       document,
-                                                       APPLICATION_JSON_PATCH_TYPE,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.POST,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               document,
+                                                               VssMediaTypes.APPLICATION_JSON_PATCH_TYPE,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, WorkItem.class);
     }
@@ -2778,14 +2780,14 @@ public abstract class WorkItemTrackingHttpClientBase
         queryParameters.addIfNotNull("validateOnly", validateOnly); //$NON-NLS-1$
         queryParameters.addIfNotNull("bypassRules", bypassRules); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.POST,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       document,
-                                                       APPLICATION_JSON_PATCH_TYPE,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.POST,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               document,
+                                                               VssMediaTypes.APPLICATION_JSON_PATCH_TYPE,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, WorkItem.class);
     }
@@ -2824,12 +2826,12 @@ public abstract class WorkItemTrackingHttpClientBase
         queryParameters.addIfNotNull("asOf", asOf); //$NON-NLS-1$
         queryParameters.addIfNotNull("$expand", expand); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, WorkItem.class);
     }
@@ -2868,12 +2870,12 @@ public abstract class WorkItemTrackingHttpClientBase
         queryParameters.addIfNotNull("asOf", asOf); //$NON-NLS-1$
         queryParameters.addIfNotNull("$expand", expand); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, WorkItem.class);
     }
@@ -2893,11 +2895,11 @@ public abstract class WorkItemTrackingHttpClientBase
         final Map<String, Object> routeValues = new HashMap<String, Object>();
         routeValues.put("project", project); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<WorkItemTypeCategory>>() {});
     }
@@ -2917,11 +2919,11 @@ public abstract class WorkItemTrackingHttpClientBase
         final Map<String, Object> routeValues = new HashMap<String, Object>();
         routeValues.put("project", project); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<WorkItemTypeCategory>>() {});
     }
@@ -2946,11 +2948,11 @@ public abstract class WorkItemTrackingHttpClientBase
         routeValues.put("project", project); //$NON-NLS-1$
         routeValues.put("category", category); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, WorkItemTypeCategory.class);
     }
@@ -2975,11 +2977,11 @@ public abstract class WorkItemTrackingHttpClientBase
         routeValues.put("project", project); //$NON-NLS-1$
         routeValues.put("category", category); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, WorkItemTypeCategory.class);
     }
@@ -3004,11 +3006,11 @@ public abstract class WorkItemTrackingHttpClientBase
         routeValues.put("project", project); //$NON-NLS-1$
         routeValues.put("type", type); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, WorkItemType.class);
     }
@@ -3033,11 +3035,11 @@ public abstract class WorkItemTrackingHttpClientBase
         routeValues.put("project", project); //$NON-NLS-1$
         routeValues.put("type", type); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, WorkItemType.class);
     }
@@ -3057,11 +3059,11 @@ public abstract class WorkItemTrackingHttpClientBase
         final Map<String, Object> routeValues = new HashMap<String, Object>();
         routeValues.put("project", project); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<WorkItemType>>() {});
     }
@@ -3081,11 +3083,11 @@ public abstract class WorkItemTrackingHttpClientBase
         final Map<String, Object> routeValues = new HashMap<String, Object>();
         routeValues.put("project", project); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<WorkItemType>>() {});
     }
@@ -3114,11 +3116,11 @@ public abstract class WorkItemTrackingHttpClientBase
         routeValues.put("type", type); //$NON-NLS-1$
         routeValues.put("field", field); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, FieldDependentRule.class);
     }
@@ -3147,11 +3149,11 @@ public abstract class WorkItemTrackingHttpClientBase
         routeValues.put("type", type); //$NON-NLS-1$
         routeValues.put("field", field); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, FieldDependentRule.class);
     }
@@ -3182,12 +3184,12 @@ public abstract class WorkItemTrackingHttpClientBase
         final NameValueCollection queryParameters = new NameValueCollection();
         queryParameters.addIfNotNull("exportGlobalLists", exportGlobalLists); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, WorkItemTypeTemplate.class);
     }
@@ -3218,12 +3220,12 @@ public abstract class WorkItemTrackingHttpClientBase
         final NameValueCollection queryParameters = new NameValueCollection();
         queryParameters.addIfNotNull("exportGlobalLists", exportGlobalLists); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, WorkItemTypeTemplate.class);
     }
@@ -3250,12 +3252,12 @@ public abstract class WorkItemTrackingHttpClientBase
         final NameValueCollection queryParameters = new NameValueCollection();
         queryParameters.addIfNotNull("exportGlobalLists", exportGlobalLists); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, WorkItemTypeTemplate.class);
     }
@@ -3272,12 +3274,12 @@ public abstract class WorkItemTrackingHttpClientBase
         final UUID locationId = UUID.fromString("8637ac8b-5eb6-4f90-b3f7-4f2ff576a459"); //$NON-NLS-1$
         final ApiResourceVersion apiVersion = new ApiResourceVersion("3.0-preview.1"); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.POST,
-                                                       locationId,
-                                                       apiVersion,
-                                                       updateModel,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.POST,
+                                                               locationId,
+                                                               apiVersion,
+                                                               updateModel,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, ProvisioningResult.class);
     }
@@ -3301,13 +3303,13 @@ public abstract class WorkItemTrackingHttpClientBase
         final Map<String, Object> routeValues = new HashMap<String, Object>();
         routeValues.put("project", project); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.POST,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       updateModel,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.POST,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               updateModel,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, ProvisioningResult.class);
     }
@@ -3331,13 +3333,13 @@ public abstract class WorkItemTrackingHttpClientBase
         final Map<String, Object> routeValues = new HashMap<String, Object>();
         routeValues.put("project", project); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.POST,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       updateModel,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.POST,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               updateModel,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, ProvisioningResult.class);
     }

--- a/Rest/alm-tfs-client/src/main/generated/com/microsoft/alm/teamfoundation/workitemtracking/webapi/models/GetFieldsExpand.java
+++ b/Rest/alm-tfs-client/src/main/generated/com/microsoft/alm/teamfoundation/workitemtracking/webapi/models/GetFieldsExpand.java
@@ -1,0 +1,51 @@
+// @formatter:off
+/*
+* ---------------------------------------------------------
+* Copyright(C) Microsoft Corporation. All rights reserved.
+* Licensed under the MIT license. See License.txt in the project root.
+* ---------------------------------------------------------
+*
+* ---------------------------------------------------------
+* Generated file, DO NOT EDIT
+* ---------------------------------------------------------
+*
+* See following wiki page for instructions on how to regenerate:
+*   https://vsowiki.com/index.php?title=Rest_Client_Generation
+*/
+
+package com.microsoft.alm.teamfoundation.workitemtracking.webapi.models;
+
+
+/** 
+ */
+public enum GetFieldsExpand {
+
+    NONE(0),
+    EXTENSION_FIELDS(1),
+    ;
+
+    private int value;
+
+    private GetFieldsExpand(final int value) {
+        this.value = value;
+    }
+
+    public int getValue() {
+        return value;
+    }
+
+    @Override
+    public String toString() {
+        final String name = super.toString();
+
+        if (name.equals("NONE")) { //$NON-NLS-1$
+            return "none"; //$NON-NLS-1$
+        }
+
+        if (name.equals("EXTENSION_FIELDS")) { //$NON-NLS-1$
+            return "extensionFields"; //$NON-NLS-1$
+        }
+
+        return null;
+    }
+}

--- a/Rest/alm-tfs-client/src/main/java/com/microsoft/alm/teamfoundation/build/webapi/BuildHttpClient.java
+++ b/Rest/alm-tfs-client/src/main/java/com/microsoft/alm/teamfoundation/build/webapi/BuildHttpClient.java
@@ -4,6 +4,7 @@
 package com.microsoft.alm.teamfoundation.build.webapi;
 
 import java.net.URI;
+import java.util.ArrayList;
 import java.util.UUID;
 
 import com.microsoft.alm.client.VssRestClientHandler;
@@ -13,6 +14,30 @@ public class BuildHttpClient extends BuildHttpClientBase {
 
     public BuildHttpClient(final VssRestClientHandler clientHandler, final URI baseUrl) {
         super(clientHandler, baseUrl);
+    }
+
+    /**
+     * [Preview API 3.0-preview.2] Gets definitions
+     * 
+     * @param projectName
+     *        Project ID or project name
+     * 
+     * @return ArrayList&lt;BuildDefinitionReference&gt;
+     */
+    public ArrayList<BuildDefinitionReference> getDefinitions(final String projectName) {
+        return super.getDefinitions(projectName, null, null, null, null, null, null, null, null, null, null, null);
+    }
+
+    /**
+     * [Preview API 3.0-preview.2] Gets definitions
+     * 
+     * @param project
+     *        Project ID or project name
+     * 
+     * @return ArrayList&lt;BuildDefinitionReference&gt;
+     */
+    public ArrayList<BuildDefinitionReference> getDefinitions(final UUID projectId) {
+        return super.getDefinitions(projectId, null, null, null, null, null, null, null, null, null, null, null);
     }
 
     /**

--- a/Rest/alm-tfs-client/src/main/java/com/microsoft/alm/teamfoundation/build/webapi/BuildHttpClient.java
+++ b/Rest/alm-tfs-client/src/main/java/com/microsoft/alm/teamfoundation/build/webapi/BuildHttpClient.java
@@ -4,20 +4,15 @@
 package com.microsoft.alm.teamfoundation.build.webapi;
 
 import java.net.URI;
-import java.util.List;
 import java.util.UUID;
 
-import com.microsoft.alm.teamfoundation.build.webapi.Build;
-import com.microsoft.alm.teamfoundation.build.webapi.BuildDefinition;
-import com.microsoft.alm.teamfoundation.build.webapi.DefinitionReference;
+import com.microsoft.alm.client.VssRestClientHandler;
 import com.microsoft.alm.client.utils.ArgumentUtility;
-
-import javax.ws.rs.client.Client;
 
 public class BuildHttpClient extends BuildHttpClientBase {
 
-    public BuildHttpClient(final Client jaxrsClient, final URI baseUrl) {
-        super(jaxrsClient, baseUrl);
+    public BuildHttpClient(final VssRestClientHandler clientHandler, final URI baseUrl) {
+        super(clientHandler, baseUrl);
     }
 
     /**

--- a/Rest/alm-tfs-client/src/main/java/com/microsoft/alm/teamfoundation/chat/webapi/ChatHttpClient.java
+++ b/Rest/alm-tfs-client/src/main/java/com/microsoft/alm/teamfoundation/chat/webapi/ChatHttpClient.java
@@ -3,12 +3,13 @@
 
 package com.microsoft.alm.teamfoundation.chat.webapi;
 
-import javax.ws.rs.client.Client;
 import java.net.URI;
+
+import com.microsoft.alm.client.VssRestClientHandler;
 
 public class ChatHttpClient extends ChatHttpClientBase {
 
-    public ChatHttpClient(final Client jaxrsClient, final URI baseUrl) {
-        super(jaxrsClient, baseUrl);
+    public ChatHttpClient(final VssRestClientHandler clientHandler, final URI baseUrl) {
+        super(clientHandler, baseUrl);
     }
 }

--- a/Rest/alm-tfs-client/src/main/java/com/microsoft/alm/teamfoundation/core/webapi/CoreHttpClient.java
+++ b/Rest/alm-tfs-client/src/main/java/com/microsoft/alm/teamfoundation/core/webapi/CoreHttpClient.java
@@ -6,17 +6,13 @@ package com.microsoft.alm.teamfoundation.core.webapi;
 import java.net.URI;
 import java.util.List;
 
-import com.microsoft.alm.teamfoundation.core.webapi.ProjectState;
-import com.microsoft.alm.teamfoundation.core.webapi.TeamProject;
-import com.microsoft.alm.teamfoundation.core.webapi.TeamProjectReference;
+import com.microsoft.alm.client.VssRestClientHandler;
 import com.microsoft.alm.client.utils.ArgumentUtility;
-
-import javax.ws.rs.client.Client;
 
 public class CoreHttpClient extends CoreHttpClientBase {
 
-    public CoreHttpClient(final Client jaxrsClient, final URI baseUrl) {
-        super(jaxrsClient, baseUrl);
+    public CoreHttpClient(final VssRestClientHandler clientHandler, final URI baseUrl) {
+        super(clientHandler, baseUrl);
     }
 
     /**

--- a/Rest/alm-tfs-client/src/main/java/com/microsoft/alm/teamfoundation/policy/webapi/PolicyHttpClient.java
+++ b/Rest/alm-tfs-client/src/main/java/com/microsoft/alm/teamfoundation/policy/webapi/PolicyHttpClient.java
@@ -3,12 +3,13 @@
 
 package com.microsoft.alm.teamfoundation.policy.webapi;
 
-import javax.ws.rs.client.Client;
 import java.net.URI;
+
+import com.microsoft.alm.client.VssRestClientHandler;
 
 public class PolicyHttpClient extends PolicyHttpClientBase {
 
-    public PolicyHttpClient(final Client jaxrsClient, final URI baseUrl) {
-        super(jaxrsClient, baseUrl);
+    public PolicyHttpClient(final VssRestClientHandler clientHandler, final URI baseUrl) {
+        super(clientHandler, baseUrl);
     }
 }

--- a/Rest/alm-tfs-client/src/main/java/com/microsoft/alm/teamfoundation/sourcecontrol/webapi/GitHttpClient.java
+++ b/Rest/alm-tfs-client/src/main/java/com/microsoft/alm/teamfoundation/sourcecontrol/webapi/GitHttpClient.java
@@ -8,19 +8,13 @@ import java.net.URI;
 import java.util.List;
 import java.util.UUID;
 
-import com.microsoft.alm.teamfoundation.sourcecontrol.webapi.GitItem;
-import com.microsoft.alm.teamfoundation.sourcecontrol.webapi.GitRef;
-import com.microsoft.alm.teamfoundation.sourcecontrol.webapi.GitRepository;
-import com.microsoft.alm.teamfoundation.sourcecontrol.webapi.GitVersionDescriptor;
-import com.microsoft.alm.teamfoundation.sourcecontrol.webapi.VersionControlRecursionType;
+import com.microsoft.alm.client.VssRestClientHandler;
 import com.microsoft.alm.client.utils.ArgumentUtility;
-
-import javax.ws.rs.client.Client;
 
 public class GitHttpClient extends GitHttpClientBase {
 
-    public GitHttpClient(final Client jaxrsClient, final URI baseUrl) {
-        super(jaxrsClient, baseUrl);
+    public GitHttpClient(final VssRestClientHandler clientHandler, final URI baseUrl) {
+        super(clientHandler, baseUrl);
     }
 
     /**

--- a/Rest/alm-tfs-client/src/main/java/com/microsoft/alm/teamfoundation/sourcecontrol/webapi/TfvcHttpClient.java
+++ b/Rest/alm-tfs-client/src/main/java/com/microsoft/alm/teamfoundation/sourcecontrol/webapi/TfvcHttpClient.java
@@ -3,12 +3,13 @@
 
 package com.microsoft.alm.teamfoundation.sourcecontrol.webapi;
 
-import javax.ws.rs.client.Client;
 import java.net.URI;
+
+import com.microsoft.alm.client.VssRestClientHandler;
 
 public class TfvcHttpClient extends TfvcHttpClientBase {
 
-    public TfvcHttpClient(final Client jaxrsClient, final URI baseUrl) {
-        super(jaxrsClient, baseUrl);
+    public TfvcHttpClient(final VssRestClientHandler clientHandler, final URI baseUrl) {
+        super(clientHandler, baseUrl);
     }
 }

--- a/Rest/alm-tfs-client/src/main/java/com/microsoft/alm/teamfoundation/testmanagement/webapi/TestHttpClient.java
+++ b/Rest/alm-tfs-client/src/main/java/com/microsoft/alm/teamfoundation/testmanagement/webapi/TestHttpClient.java
@@ -3,12 +3,13 @@
 
 package com.microsoft.alm.teamfoundation.testmanagement.webapi;
 
-import javax.ws.rs.client.Client;
 import java.net.URI;
+
+import com.microsoft.alm.client.VssRestClientHandler;
 
 public class TestHttpClient extends TestHttpClientBase {
 
-    public TestHttpClient(final Client jaxrsClient, final URI baseUrl) {
-        super(jaxrsClient, baseUrl);
+    public TestHttpClient(final VssRestClientHandler clientHandler, final URI baseUrl) {
+        super(clientHandler, baseUrl);
     }
 }

--- a/Rest/alm-tfs-client/src/main/java/com/microsoft/alm/teamfoundation/work/webapi/WorkHttpClient.java
+++ b/Rest/alm-tfs-client/src/main/java/com/microsoft/alm/teamfoundation/work/webapi/WorkHttpClient.java
@@ -3,12 +3,13 @@
 
 package com.microsoft.alm.teamfoundation.work.webapi;
 
-import javax.ws.rs.client.Client;
 import java.net.URI;
+
+import com.microsoft.alm.client.VssRestClientHandler;
 
 public class WorkHttpClient extends WorkHttpClientBase {
 
-    public WorkHttpClient(final Client jaxrsClient, final URI baseUrl) {
-        super(jaxrsClient, baseUrl);
+    public WorkHttpClient(final VssRestClientHandler clientHandler, final URI baseUrl) {
+        super(clientHandler, baseUrl);
     }
 }

--- a/Rest/alm-tfs-client/src/main/java/com/microsoft/alm/teamfoundation/workitemtracking/webapi/WorkItemTrackingHttpClient.java
+++ b/Rest/alm-tfs-client/src/main/java/com/microsoft/alm/teamfoundation/workitemtracking/webapi/WorkItemTrackingHttpClient.java
@@ -3,18 +3,13 @@
 
 package com.microsoft.alm.teamfoundation.workitemtracking.webapi;
 
-import java.io.InputStream;
 import java.net.URI;
-import java.util.List;
-import java.util.UUID;
 
-import com.microsoft.alm.client.utils.ArgumentUtility;
-
-import javax.ws.rs.client.Client;
+import com.microsoft.alm.client.VssRestClientHandler;
 
 public class WorkItemTrackingHttpClient extends WorkItemTrackingHttpClientBase {
 
-    public WorkItemTrackingHttpClient(final Client jaxrsClient, final URI baseUrl) {
-        super(jaxrsClient, baseUrl);
+    public WorkItemTrackingHttpClient(final VssRestClientHandler clientHandler, final URI baseUrl) {
+        super(clientHandler, baseUrl);
     }
 }

--- a/Rest/alm-vss-client/src/main/generated/com/microsoft/alm/visualstudio/services/account/client/AccountHttpClientBase.java
+++ b/Rest/alm-vss-client/src/main/generated/com/microsoft/alm/visualstudio/services/account/client/AccountHttpClientBase.java
@@ -22,8 +22,12 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import com.fasterxml.jackson.core.type.TypeReference;
+import com.microsoft.alm.client.HttpMethod;
 import com.microsoft.alm.client.model.NameValueCollection;
 import com.microsoft.alm.client.VssHttpClientBase;
+import com.microsoft.alm.client.VssMediaTypes;
+import com.microsoft.alm.client.VssRestClientHandler;
+import com.microsoft.alm.client.VssRestRequest;
 import com.microsoft.alm.visualstudio.services.account.Account;
 import com.microsoft.alm.visualstudio.services.account.AccountNameAvailability;
 import com.microsoft.alm.visualstudio.services.account.AccountRegion;
@@ -43,22 +47,13 @@ public abstract class AccountHttpClientBase
     * Create a new instance of AccountHttpClientBase
     *
     * @param jaxrsClient
-    *            an initialized instance of a JAX-RS Client implementation
+    *            a DefaultRestClientHandler initialized with an instance of a JAX-RS Client implementation or
+    *            a TEERestClientHamdler initialized with TEE HTTP client implementation
     * @param baseUrl
-    *            a TFS project collection URL
+    *            a TFS services URL
     */
-    protected AccountHttpClientBase(final Object jaxrsClient, final URI baseUrl) {
-        super(jaxrsClient, baseUrl);
-    }
-
-    /**
-    * Create a new instance of AccountHttpClientBase
-    *
-    * @param tfsConnection
-    *            an initialized instance of a TfsTeamProjectCollection
-    */
-    protected AccountHttpClientBase(final Object tfsConnection) {
-        super(tfsConnection);
+    protected AccountHttpClientBase(final VssRestClientHandler clientHandler, final URI baseUrl) {
+        super(clientHandler, baseUrl);
     }
 
     @Override
@@ -81,11 +76,11 @@ public abstract class AccountHttpClientBase
         final Map<String, Object> routeValues = new HashMap<String, Object>();
         routeValues.put("accountId", accountId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.POST,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.POST,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, UUID.class);
     }
@@ -109,13 +104,13 @@ public abstract class AccountHttpClientBase
         final NameValueCollection queryParameters = new NameValueCollection();
         queryParameters.addIfNotNull("usePrecreated", usePrecreated); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.POST,
-                                                       locationId,
-                                                       apiVersion,
-                                                       info,
-                                                       APPLICATION_JSON_TYPE,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.POST,
+                                                               locationId,
+                                                               apiVersion,
+                                                               info,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, Account.class);
     }
@@ -142,12 +137,12 @@ public abstract class AccountHttpClientBase
         final NameValueCollection queryParameters = new NameValueCollection();
         queryParameters.addIfNotEmpty("properties", properties); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, Account.class);
     }
@@ -188,11 +183,11 @@ public abstract class AccountHttpClientBase
         queryParameters.addIfNotEmpty("properties", properties); //$NON-NLS-1$
         queryParameters.addIfNotNull("includeDisabledAccounts", includeDisabledAccounts); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<Account>>() {});
     }
@@ -215,13 +210,13 @@ public abstract class AccountHttpClientBase
         final Map<String, Object> routeValues = new HashMap<String, Object>();
         routeValues.put("accountId", accountId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.PATCH,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       account,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.PATCH,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               account,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         super.sendRequest(httpRequest);
     }
@@ -241,11 +236,11 @@ public abstract class AccountHttpClientBase
         final Map<String, Object> routeValues = new HashMap<String, Object>();
         routeValues.put("accountName", accountName); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, AccountNameAvailability.class);
     }
@@ -260,10 +255,10 @@ public abstract class AccountHttpClientBase
         final UUID locationId = UUID.fromString("642a93c7-8385-4d63-a5a5-20d044fe504f"); //$NON-NLS-1$
         final ApiResourceVersion apiVersion = new ApiResourceVersion("3.0-preview.1"); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<AccountRegion>>() {});
     }
@@ -278,10 +273,10 @@ public abstract class AccountHttpClientBase
         final UUID locationId = UUID.fromString("4e012dd4-f8e1-485d-9bb3-c50d83c5b71b"); //$NON-NLS-1$
         final ApiResourceVersion apiVersion = new ApiResourceVersion("3.0-preview.1"); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<HashMap<String, String>>() {});
     }

--- a/Rest/alm-vss-client/src/main/generated/com/microsoft/alm/visualstudio/services/authentication/client/AuthenticationHttpClientBase.java
+++ b/Rest/alm-vss-client/src/main/generated/com/microsoft/alm/visualstudio/services/authentication/client/AuthenticationHttpClientBase.java
@@ -21,8 +21,12 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import com.fasterxml.jackson.core.type.TypeReference;
+import com.microsoft.alm.client.HttpMethod;
 import com.microsoft.alm.client.model.NameValueCollection;
 import com.microsoft.alm.client.VssHttpClientBase;
+import com.microsoft.alm.client.VssMediaTypes;
+import com.microsoft.alm.client.VssRestClientHandler;
+import com.microsoft.alm.client.VssRestRequest;
 import com.microsoft.alm.visualstudio.services.webapi.ApiResourceVersion;
 import com.microsoft.alm.visualstudio.services.webplatform.WebSessionToken;
 
@@ -39,22 +43,13 @@ public abstract class AuthenticationHttpClientBase
     * Create a new instance of AuthenticationHttpClientBase
     *
     * @param jaxrsClient
-    *            an initialized instance of a JAX-RS Client implementation
+    *            a DefaultRestClientHandler initialized with an instance of a JAX-RS Client implementation or
+    *            a TEERestClientHamdler initialized with TEE HTTP client implementation
     * @param baseUrl
-    *            a TFS project collection URL
+    *            a TFS services URL
     */
-    protected AuthenticationHttpClientBase(final Object jaxrsClient, final URI baseUrl) {
-        super(jaxrsClient, baseUrl);
-    }
-
-    /**
-    * Create a new instance of AuthenticationHttpClientBase
-    *
-    * @param tfsConnection
-    *            an initialized instance of a TfsTeamProjectCollection
-    */
-    protected AuthenticationHttpClientBase(final Object tfsConnection) {
-        super(tfsConnection);
+    protected AuthenticationHttpClientBase(final VssRestClientHandler clientHandler, final URI baseUrl) {
+        super(clientHandler, baseUrl);
     }
 
     @Override
@@ -74,12 +69,12 @@ public abstract class AuthenticationHttpClientBase
         final UUID locationId = UUID.fromString("11420b6b-3324-490a-848d-b8aafdb906ba"); //$NON-NLS-1$
         final ApiResourceVersion apiVersion = new ApiResourceVersion("3.0-preview.1"); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.POST,
-                                                       locationId,
-                                                       apiVersion,
-                                                       sessionToken,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.POST,
+                                                               locationId,
+                                                               apiVersion,
+                                                               sessionToken,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, WebSessionToken.class);
     }

--- a/Rest/alm-vss-client/src/main/generated/com/microsoft/alm/visualstudio/services/customerintelligence/webapi/CustomerIntelligenceHttpClientBase.java
+++ b/Rest/alm-vss-client/src/main/generated/com/microsoft/alm/visualstudio/services/customerintelligence/webapi/CustomerIntelligenceHttpClientBase.java
@@ -21,8 +21,12 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import com.fasterxml.jackson.core.type.TypeReference;
+import com.microsoft.alm.client.HttpMethod;
 import com.microsoft.alm.client.model.NameValueCollection;
 import com.microsoft.alm.client.VssHttpClientBase;
+import com.microsoft.alm.client.VssMediaTypes;
+import com.microsoft.alm.client.VssRestClientHandler;
+import com.microsoft.alm.client.VssRestRequest;
 import com.microsoft.alm.visualstudio.services.webapi.ApiResourceVersion;
 import com.microsoft.alm.visualstudio.services.webplatform.CustomerIntelligenceEvent;
 
@@ -39,22 +43,13 @@ public abstract class CustomerIntelligenceHttpClientBase
     * Create a new instance of CustomerIntelligenceHttpClientBase
     *
     * @param jaxrsClient
-    *            an initialized instance of a JAX-RS Client implementation
+    *            a DefaultRestClientHandler initialized with an instance of a JAX-RS Client implementation or
+    *            a TEERestClientHamdler initialized with TEE HTTP client implementation
     * @param baseUrl
-    *            a TFS project collection URL
+    *            a TFS services URL
     */
-    protected CustomerIntelligenceHttpClientBase(final Object jaxrsClient, final URI baseUrl) {
-        super(jaxrsClient, baseUrl);
-    }
-
-    /**
-    * Create a new instance of CustomerIntelligenceHttpClientBase
-    *
-    * @param tfsConnection
-    *            an initialized instance of a TfsTeamProjectCollection
-    */
-    protected CustomerIntelligenceHttpClientBase(final Object tfsConnection) {
-        super(tfsConnection);
+    protected CustomerIntelligenceHttpClientBase(final VssRestClientHandler clientHandler, final URI baseUrl) {
+        super(clientHandler, baseUrl);
     }
 
     @Override
@@ -73,12 +68,12 @@ public abstract class CustomerIntelligenceHttpClientBase
         final UUID locationId = UUID.fromString("b5cc35c2-ff2b-491d-a085-24b6e9f396fd"); //$NON-NLS-1$
         final ApiResourceVersion apiVersion = new ApiResourceVersion("3.0-preview.1"); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.POST,
-                                                       locationId,
-                                                       apiVersion,
-                                                       events,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.POST,
+                                                               locationId,
+                                                               apiVersion,
+                                                               events,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         super.sendRequest(httpRequest);
     }

--- a/Rest/alm-vss-client/src/main/generated/com/microsoft/alm/visualstudio/services/filecontainer/client/FileContainerHttpClientBase.java
+++ b/Rest/alm-vss-client/src/main/generated/com/microsoft/alm/visualstudio/services/filecontainer/client/FileContainerHttpClientBase.java
@@ -23,8 +23,12 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import com.fasterxml.jackson.core.type.TypeReference;
+import com.microsoft.alm.client.HttpMethod;
 import com.microsoft.alm.client.model.NameValueCollection;
 import com.microsoft.alm.client.VssHttpClientBase;
+import com.microsoft.alm.client.VssMediaTypes;
+import com.microsoft.alm.client.VssRestClientHandler;
+import com.microsoft.alm.client.VssRestRequest;
 import com.microsoft.alm.visualstudio.services.filecontainer.FileContainer;
 import com.microsoft.alm.visualstudio.services.filecontainer.FileContainerItem;
 import com.microsoft.alm.visualstudio.services.webapi.ApiResourceVersion;
@@ -43,22 +47,13 @@ public abstract class FileContainerHttpClientBase
     * Create a new instance of FileContainerHttpClientBase
     *
     * @param jaxrsClient
-    *            an initialized instance of a JAX-RS Client implementation
+    *            a DefaultRestClientHandler initialized with an instance of a JAX-RS Client implementation or
+    *            a TEERestClientHamdler initialized with TEE HTTP client implementation
     * @param baseUrl
-    *            a TFS project collection URL
+    *            a TFS services URL
     */
-    protected FileContainerHttpClientBase(final Object jaxrsClient, final URI baseUrl) {
-        super(jaxrsClient, baseUrl);
-    }
-
-    /**
-    * Create a new instance of FileContainerHttpClientBase
-    *
-    * @param tfsConnection
-    *            an initialized instance of a TfsTeamProjectCollection
-    */
-    protected FileContainerHttpClientBase(final Object tfsConnection) {
-        super(tfsConnection);
+    protected FileContainerHttpClientBase(final VssRestClientHandler clientHandler, final URI baseUrl) {
+        super(clientHandler, baseUrl);
     }
 
     @Override
@@ -91,14 +86,14 @@ public abstract class FileContainerHttpClientBase
         final NameValueCollection queryParameters = new NameValueCollection();
         queryParameters.addIfNotEmpty("itemPath", itemPath); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.PUT,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       uploadStream,
-                                                       APPLICATION_OCTET_STREAM_TYPE,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.PUT,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               uploadStream,
+                                                               VssMediaTypes.APPLICATION_OCTET_STREAM_TYPE,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, FileContainerItem.class);
     }
@@ -132,14 +127,14 @@ public abstract class FileContainerHttpClientBase
         queryParameters.addIfNotEmpty("itemPath", itemPath); //$NON-NLS-1$
         queryParameters.addIfNotNull("scope", scope); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.PUT,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       uploadStream,
-                                                       APPLICATION_OCTET_STREAM_TYPE,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.PUT,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               uploadStream,
+                                                               VssMediaTypes.APPLICATION_OCTET_STREAM_TYPE,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, FileContainerItem.class);
     }
@@ -163,13 +158,13 @@ public abstract class FileContainerHttpClientBase
         final Map<String, Object> routeValues = new HashMap<String, Object>();
         routeValues.put("containerId", containerId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.POST,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       items,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.POST,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               items,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<FileContainerItem>>() {});
     }
@@ -199,14 +194,14 @@ public abstract class FileContainerHttpClientBase
         final NameValueCollection queryParameters = new NameValueCollection();
         queryParameters.addIfNotNull("scope", scope); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.POST,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       items,
-                                                       APPLICATION_JSON_TYPE,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.POST,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               items,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<FileContainerItem>>() {});
     }
@@ -232,12 +227,12 @@ public abstract class FileContainerHttpClientBase
         final NameValueCollection queryParameters = new NameValueCollection();
         queryParameters.addIfNotEmpty("itemPath", itemPath); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.DELETE,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.DELETE,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         super.sendRequest(httpRequest);
     }
@@ -267,12 +262,12 @@ public abstract class FileContainerHttpClientBase
         queryParameters.addIfNotEmpty("itemPath", itemPath); //$NON-NLS-1$
         queryParameters.addIfNotNull("scope", scope); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.DELETE,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.DELETE,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         super.sendRequest(httpRequest);
     }
@@ -292,11 +287,11 @@ public abstract class FileContainerHttpClientBase
         final NameValueCollection queryParameters = new NameValueCollection();
         queryParameters.addIfNotEmpty("artifactUris", artifactUris); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<FileContainer>>() {});
     }
@@ -321,11 +316,11 @@ public abstract class FileContainerHttpClientBase
         queryParameters.addIfNotNull("scope", scope); //$NON-NLS-1$
         queryParameters.addIfNotEmpty("artifactUris", artifactUris); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<FileContainer>>() {});
     }
@@ -372,12 +367,12 @@ public abstract class FileContainerHttpClientBase
         queryParameters.addIfNotNull("includeDownloadTickets", includeDownloadTickets); //$NON-NLS-1$
         queryParameters.addIfNotNull("isShallow", isShallow); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<FileContainerItem>>() {});
     }
@@ -428,12 +423,12 @@ public abstract class FileContainerHttpClientBase
         queryParameters.addIfNotNull("includeDownloadTickets", includeDownloadTickets); //$NON-NLS-1$
         queryParameters.addIfNotNull("isShallow", isShallow); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<FileContainerItem>>() {});
     }
@@ -460,12 +455,12 @@ public abstract class FileContainerHttpClientBase
         final NameValueCollection queryParameters = new NameValueCollection();
         queryParameters.addIfNotEmpty("itemPath", itemPath); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<FileContainerItem>>() {});
     }

--- a/Rest/alm-vss-client/src/main/generated/com/microsoft/alm/visualstudio/services/identity/client/IdentityHttpClientBase.java
+++ b/Rest/alm-vss-client/src/main/generated/com/microsoft/alm/visualstudio/services/identity/client/IdentityHttpClientBase.java
@@ -23,8 +23,12 @@ import java.util.Map;
 import java.util.UUID;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.microsoft.alm.client.HttpMethod;
 import com.microsoft.alm.client.model.NameValueCollection;
 import com.microsoft.alm.client.VssHttpClientBase;
+import com.microsoft.alm.client.VssMediaTypes;
+import com.microsoft.alm.client.VssRestClientHandler;
+import com.microsoft.alm.client.VssRestRequest;
 import com.microsoft.alm.visualstudio.services.identity.ChangedIdentities;
 import com.microsoft.alm.visualstudio.services.identity.CreateScopeInfo;
 import com.microsoft.alm.visualstudio.services.identity.FrameworkIdentityInfo;
@@ -54,22 +58,13 @@ public abstract class IdentityHttpClientBase
     * Create a new instance of IdentityHttpClientBase
     *
     * @param jaxrsClient
-    *            an initialized instance of a JAX-RS Client implementation
+    *            a DefaultRestClientHandler initialized with an instance of a JAX-RS Client implementation or
+    *            a TEERestClientHamdler initialized with TEE HTTP client implementation
     * @param baseUrl
-    *            a TFS project collection URL
+    *            a TFS services URL
     */
-    protected IdentityHttpClientBase(final Object jaxrsClient, final URI baseUrl) {
-        super(jaxrsClient, baseUrl);
-    }
-
-    /**
-    * Create a new instance of IdentityHttpClientBase
-    *
-    * @param tfsConnection
-    *            an initialized instance of a TfsTeamProjectCollection
-    */
-    protected IdentityHttpClientBase(final Object tfsConnection) {
-        super(tfsConnection);
+    protected IdentityHttpClientBase(final VssRestClientHandler clientHandler, final URI baseUrl) {
+        super(clientHandler, baseUrl);
     }
 
     @Override
@@ -89,12 +84,12 @@ public abstract class IdentityHttpClientBase
         final UUID locationId = UUID.fromString("5966283b-4196-4d57-9211-1b68f41ec1c2"); //$NON-NLS-1$
         final ApiResourceVersion apiVersion = new ApiResourceVersion("3.0-preview.1"); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.POST,
-                                                       locationId,
-                                                       apiVersion,
-                                                       container,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.POST,
+                                                               locationId,
+                                                               apiVersion,
+                                                               container,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<Identity>>() {});
     }
@@ -113,11 +108,11 @@ public abstract class IdentityHttpClientBase
         final Map<String, Object> routeValues = new HashMap<String, Object>();
         routeValues.put("groupId", groupId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.DELETE,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.DELETE,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         super.sendRequest(httpRequest);
     }
@@ -150,11 +145,11 @@ public abstract class IdentityHttpClientBase
         queryParameters.addIfNotNull("deleted", deleted); //$NON-NLS-1$
         queryParameters.addIfNotEmpty("properties", properties); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<Identity>>() {});
     }
@@ -183,11 +178,11 @@ public abstract class IdentityHttpClientBase
         queryParameters.put("groupSequenceId", String.valueOf(groupSequenceId)); //$NON-NLS-1$
         queryParameters.addIfNotNull("scopeId", scopeId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, ChangedIdentities.class);
     }
@@ -236,11 +231,11 @@ public abstract class IdentityHttpClientBase
         queryParameters.addIfNotNull("includeRestrictedVisibility", includeRestrictedVisibility); //$NON-NLS-1$
         queryParameters.addIfNotNull("options", options); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<Identity>>() {});
     }
@@ -269,11 +264,11 @@ public abstract class IdentityHttpClientBase
         queryParameters.addIfNotNull("queryMembership", queryMembership); //$NON-NLS-1$
         queryParameters.addIfNotEmpty("properties", properties); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<Identity>>() {});
     }
@@ -304,12 +299,12 @@ public abstract class IdentityHttpClientBase
         queryParameters.addIfNotNull("queryMembership", queryMembership); //$NON-NLS-1$
         queryParameters.addIfNotEmpty("properties", properties); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, Identity.class);
     }
@@ -326,12 +321,12 @@ public abstract class IdentityHttpClientBase
         final UUID locationId = UUID.fromString("28010c54-d0c0-4c89-a5b0-1c9e188b9fb7"); //$NON-NLS-1$
         final ApiResourceVersion apiVersion = new ApiResourceVersion("3.0-preview.1"); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.PUT,
-                                                       locationId,
-                                                       apiVersion,
-                                                       identities,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.PUT,
+                                                               locationId,
+                                                               apiVersion,
+                                                               identities,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<IdentityUpdateData>>() {});
     }
@@ -354,13 +349,13 @@ public abstract class IdentityHttpClientBase
         final Map<String, Object> routeValues = new HashMap<String, Object>();
         routeValues.put("identityId", identityId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.PUT,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       identity,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.PUT,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               identity,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         super.sendRequest(httpRequest);
     }
@@ -377,12 +372,12 @@ public abstract class IdentityHttpClientBase
         final UUID locationId = UUID.fromString("dd55f0eb-6ea2-4fe4-9ebe-919e7dd1dfb4"); //$NON-NLS-1$
         final ApiResourceVersion apiVersion = new ApiResourceVersion("3.0-preview.1"); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.PUT,
-                                                       locationId,
-                                                       apiVersion,
-                                                       frameworkIdentityInfo,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.PUT,
+                                                               locationId,
+                                                               apiVersion,
+                                                               frameworkIdentityInfo,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, Identity.class);
     }
@@ -399,12 +394,12 @@ public abstract class IdentityHttpClientBase
         final UUID locationId = UUID.fromString("299e50df-fe45-4d3a-8b5b-a5836fac74dc"); //$NON-NLS-1$
         final ApiResourceVersion apiVersion = new ApiResourceVersion("3.0-preview.1"); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.POST,
-                                                       locationId,
-                                                       apiVersion,
-                                                       batchInfo,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.POST,
+                                                               locationId,
+                                                               apiVersion,
+                                                               batchInfo,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<Identity>>() {});
     }
@@ -424,11 +419,11 @@ public abstract class IdentityHttpClientBase
         final Map<String, Object> routeValues = new HashMap<String, Object>();
         routeValues.put("scopeId", scopeId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, IdentitySnapshot.class);
     }
@@ -443,10 +438,10 @@ public abstract class IdentityHttpClientBase
         final UUID locationId = UUID.fromString("4bb02b5b-c120-4be2-b68e-21f7c50a4b82"); //$NON-NLS-1$
         final ApiResourceVersion apiVersion = new ApiResourceVersion("3.0-preview.1"); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, IdentitySelf.class);
     }
@@ -471,11 +466,11 @@ public abstract class IdentityHttpClientBase
         routeValues.put("containerId", containerId); //$NON-NLS-1$
         routeValues.put("memberId", memberId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.PUT,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.PUT,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, boolean.class);
     }
@@ -506,12 +501,12 @@ public abstract class IdentityHttpClientBase
         final NameValueCollection queryParameters = new NameValueCollection();
         queryParameters.addIfNotNull("queryMembership", queryMembership); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, IdentityDescriptor.class);
     }
@@ -538,12 +533,12 @@ public abstract class IdentityHttpClientBase
         final NameValueCollection queryParameters = new NameValueCollection();
         queryParameters.addIfNotNull("queryMembership", queryMembership); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<IdentityDescriptor>>() {});
     }
@@ -568,11 +563,11 @@ public abstract class IdentityHttpClientBase
         routeValues.put("containerId", containerId); //$NON-NLS-1$
         routeValues.put("memberId", memberId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.DELETE,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.DELETE,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, boolean.class);
     }
@@ -603,12 +598,12 @@ public abstract class IdentityHttpClientBase
         final NameValueCollection queryParameters = new NameValueCollection();
         queryParameters.addIfNotNull("queryMembership", queryMembership); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, IdentityDescriptor.class);
     }
@@ -635,12 +630,12 @@ public abstract class IdentityHttpClientBase
         final NameValueCollection queryParameters = new NameValueCollection();
         queryParameters.addIfNotNull("queryMembership", queryMembership); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<IdentityDescriptor>>() {});
     }
@@ -664,13 +659,13 @@ public abstract class IdentityHttpClientBase
         final Map<String, Object> routeValues = new HashMap<String, Object>();
         routeValues.put("scopeId", scopeId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.PUT,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       info,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.PUT,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               info,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, IdentityScope.class);
     }
@@ -689,11 +684,11 @@ public abstract class IdentityHttpClientBase
         final Map<String, Object> routeValues = new HashMap<String, Object>();
         routeValues.put("scopeId", scopeId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.DELETE,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.DELETE,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         super.sendRequest(httpRequest);
     }
@@ -713,11 +708,11 @@ public abstract class IdentityHttpClientBase
         final Map<String, Object> routeValues = new HashMap<String, Object>();
         routeValues.put("scopeId", scopeId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, IdentityScope.class);
     }
@@ -737,11 +732,11 @@ public abstract class IdentityHttpClientBase
         final NameValueCollection queryParameters = new NameValueCollection();
         queryParameters.addIfNotEmpty("scopeName", scopeName); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, IdentityScope.class);
     }
@@ -764,13 +759,13 @@ public abstract class IdentityHttpClientBase
         final Map<String, Object> routeValues = new HashMap<String, Object>();
         routeValues.put("scopeId", scopeId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.PATCH,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       renameScope,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.PATCH,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               renameScope,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         super.sendRequest(httpRequest);
     }
@@ -790,11 +785,11 @@ public abstract class IdentityHttpClientBase
         final Map<String, Object> routeValues = new HashMap<String, Object>();
         routeValues.put("tenantId", tenantId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, TenantInfo.class);
     }

--- a/Rest/alm-vss-client/src/main/generated/com/microsoft/alm/visualstudio/services/location/client/LocationHttpClientBase.java
+++ b/Rest/alm-vss-client/src/main/generated/com/microsoft/alm/visualstudio/services/location/client/LocationHttpClientBase.java
@@ -22,8 +22,12 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import com.fasterxml.jackson.core.type.TypeReference;
+import com.microsoft.alm.client.HttpMethod;
 import com.microsoft.alm.client.model.NameValueCollection;
 import com.microsoft.alm.client.VssHttpClientBase;
+import com.microsoft.alm.client.VssMediaTypes;
+import com.microsoft.alm.client.VssRestClientHandler;
+import com.microsoft.alm.client.VssRestRequest;
 import com.microsoft.alm.visualstudio.services.location.ConnectionData;
 import com.microsoft.alm.visualstudio.services.location.ServiceDefinition;
 import com.microsoft.alm.visualstudio.services.webapi.ApiResourceVersion;
@@ -43,22 +47,13 @@ public abstract class LocationHttpClientBase
     * Create a new instance of LocationHttpClientBase
     *
     * @param jaxrsClient
-    *            an initialized instance of a JAX-RS Client implementation
+    *            a DefaultRestClientHandler initialized with an instance of a JAX-RS Client implementation or
+    *            a TEERestClientHamdler initialized with TEE HTTP client implementation
     * @param baseUrl
-    *            a TFS project collection URL
+    *            a TFS services URL
     */
-    protected LocationHttpClientBase(final Object jaxrsClient, final URI baseUrl) {
-        super(jaxrsClient, baseUrl);
-    }
-
-    /**
-    * Create a new instance of LocationHttpClientBase
-    *
-    * @param tfsConnection
-    *            an initialized instance of a TfsTeamProjectCollection
-    */
-    protected LocationHttpClientBase(final Object tfsConnection) {
-        super(tfsConnection);
+    protected LocationHttpClientBase(final VssRestClientHandler clientHandler, final URI baseUrl) {
+        super(clientHandler, baseUrl);
     }
 
     @Override
@@ -90,11 +85,11 @@ public abstract class LocationHttpClientBase
         queryParameters.addIfNotNull("lastChangeId", lastChangeId); //$NON-NLS-1$
         queryParameters.addIfNotNull("lastChangeId64", lastChangeId64); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, ConnectionData.class);
     }
@@ -118,11 +113,11 @@ public abstract class LocationHttpClientBase
         routeValues.put("serviceType", serviceType); //$NON-NLS-1$
         routeValues.put("identifier", identifier); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.DELETE,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.DELETE,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         super.sendRequest(httpRequest);
     }
@@ -153,12 +148,12 @@ public abstract class LocationHttpClientBase
         final NameValueCollection queryParameters = new NameValueCollection();
         queryParameters.addIfNotNull("allowFaultIn", allowFaultIn); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, ServiceDefinition.class);
     }
@@ -178,11 +173,11 @@ public abstract class LocationHttpClientBase
         final Map<String, Object> routeValues = new HashMap<String, Object>();
         routeValues.put("serviceType", serviceType); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<ServiceDefinition>>() {});
     }
@@ -198,12 +193,12 @@ public abstract class LocationHttpClientBase
         final UUID locationId = UUID.fromString("d810a47d-f4f4-4a62-a03f-fa1860585c4c"); //$NON-NLS-1$
         final ApiResourceVersion apiVersion = new ApiResourceVersion("3.0-preview.1"); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.PATCH,
-                                                       locationId,
-                                                       apiVersion,
-                                                       serviceDefinitions,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.PATCH,
+                                                               locationId,
+                                                               apiVersion,
+                                                               serviceDefinitions,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         super.sendRequest(httpRequest);
     }

--- a/Rest/alm-vss-client/src/main/generated/com/microsoft/alm/visualstudio/services/operations/OperationsHttpClientBase.java
+++ b/Rest/alm-vss-client/src/main/generated/com/microsoft/alm/visualstudio/services/operations/OperationsHttpClientBase.java
@@ -21,8 +21,12 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import com.fasterxml.jackson.core.type.TypeReference;
+import com.microsoft.alm.client.HttpMethod;
 import com.microsoft.alm.client.model.NameValueCollection;
 import com.microsoft.alm.client.VssHttpClientBase;
+import com.microsoft.alm.client.VssMediaTypes;
+import com.microsoft.alm.client.VssRestClientHandler;
+import com.microsoft.alm.client.VssRestRequest;
 import com.microsoft.alm.visualstudio.services.operations.Operation;
 import com.microsoft.alm.visualstudio.services.webapi.ApiResourceVersion;
 
@@ -39,22 +43,13 @@ public abstract class OperationsHttpClientBase
     * Create a new instance of OperationsHttpClientBase
     *
     * @param jaxrsClient
-    *            an initialized instance of a JAX-RS Client implementation
+    *            a DefaultRestClientHandler initialized with an instance of a JAX-RS Client implementation or
+    *            a TEERestClientHamdler initialized with TEE HTTP client implementation
     * @param baseUrl
-    *            a TFS project collection URL
+    *            a TFS services URL
     */
-    protected OperationsHttpClientBase(final Object jaxrsClient, final URI baseUrl) {
-        super(jaxrsClient, baseUrl);
-    }
-
-    /**
-    * Create a new instance of OperationsHttpClientBase
-    *
-    * @param tfsConnection
-    *            an initialized instance of a TfsTeamProjectCollection
-    */
-    protected OperationsHttpClientBase(final Object tfsConnection) {
-        super(tfsConnection);
+    protected OperationsHttpClientBase(final VssRestClientHandler clientHandler, final URI baseUrl) {
+        super(clientHandler, baseUrl);
     }
 
     @Override
@@ -77,11 +72,11 @@ public abstract class OperationsHttpClientBase
         final Map<String, Object> routeValues = new HashMap<String, Object>();
         routeValues.put("operationId", operationId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, Operation.class);
     }

--- a/Rest/alm-vss-client/src/main/generated/com/microsoft/alm/visualstudio/services/profile/client/ProfileHttpClientBase.java
+++ b/Rest/alm-vss-client/src/main/generated/com/microsoft/alm/visualstudio/services/profile/client/ProfileHttpClientBase.java
@@ -24,8 +24,12 @@ import java.util.Map;
 import java.util.UUID;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.microsoft.alm.client.HttpMethod;
 import com.microsoft.alm.client.model.NameValueCollection;
 import com.microsoft.alm.client.VssHttpClientBase;
+import com.microsoft.alm.client.VssMediaTypes;
+import com.microsoft.alm.client.VssRestClientHandler;
+import com.microsoft.alm.client.VssRestRequest;
 import com.microsoft.alm.visualstudio.services.profile.Avatar;
 import com.microsoft.alm.visualstudio.services.profile.CreateProfileContext;
 import com.microsoft.alm.visualstudio.services.profile.GeoRegion;
@@ -49,22 +53,13 @@ public abstract class ProfileHttpClientBase
     * Create a new instance of ProfileHttpClientBase
     *
     * @param jaxrsClient
-    *            an initialized instance of a JAX-RS Client implementation
+    *            a DefaultRestClientHandler initialized with an instance of a JAX-RS Client implementation or
+    *            a TEERestClientHamdler initialized with TEE HTTP client implementation
     * @param baseUrl
-    *            a TFS project collection URL
+    *            a TFS services URL
     */
-    protected ProfileHttpClientBase(final Object jaxrsClient, final URI baseUrl) {
-        super(jaxrsClient, baseUrl);
-    }
-
-    /**
-    * Create a new instance of ProfileHttpClientBase
-    *
-    * @param tfsConnection
-    *            an initialized instance of a TfsTeamProjectCollection
-    */
-    protected ProfileHttpClientBase(final Object tfsConnection) {
-        super(tfsConnection);
+    protected ProfileHttpClientBase(final VssRestClientHandler clientHandler, final URI baseUrl) {
+        super(clientHandler, baseUrl);
     }
 
     @Override
@@ -93,12 +88,12 @@ public abstract class ProfileHttpClientBase
         final NameValueCollection queryParameters = new NameValueCollection();
         queryParameters.addIfNotEmpty("descriptor", descriptor); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.DELETE,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.DELETE,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         super.sendRequest(httpRequest);
     }
@@ -125,12 +120,12 @@ public abstract class ProfileHttpClientBase
         final NameValueCollection queryParameters = new NameValueCollection();
         queryParameters.addIfNotEmpty("descriptor", descriptor); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, ProfileAttribute.class);
     }
@@ -173,12 +168,12 @@ public abstract class ProfileHttpClientBase
         queryParameters.addIfNotNull("withCoreAttributes", withCoreAttributes); //$NON-NLS-1$
         queryParameters.addIfNotEmpty("coreAttributes", coreAttributes); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<ProfileAttribute>>() {});
     }
@@ -207,14 +202,14 @@ public abstract class ProfileHttpClientBase
         final NameValueCollection queryParameters = new NameValueCollection();
         queryParameters.addIfNotEmpty("descriptor", descriptor); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.PUT,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       container,
-                                                       APPLICATION_JSON_TYPE,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.PUT,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               container,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         super.sendRequest(httpRequest);
     }
@@ -237,13 +232,13 @@ public abstract class ProfileHttpClientBase
         final Map<String, Object> routeValues = new HashMap<String, Object>();
         routeValues.put("id", id); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.PATCH,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       attributesCollection,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.PATCH,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               attributesCollection,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         super.sendRequest(httpRequest);
     }
@@ -274,12 +269,12 @@ public abstract class ProfileHttpClientBase
         queryParameters.addIfNotEmpty("size", size); //$NON-NLS-1$
         queryParameters.addIfNotEmpty("format", format); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, Avatar.class);
     }
@@ -317,14 +312,14 @@ public abstract class ProfileHttpClientBase
         queryParameters.addIfNotEmpty("format", format); //$NON-NLS-1$
         queryParameters.addIfNotEmpty("displayName", displayName); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.POST,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       container,
-                                                       APPLICATION_JSON_TYPE,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.POST,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               container,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, Avatar.class);
     }
@@ -343,11 +338,11 @@ public abstract class ProfileHttpClientBase
         final Map<String, Object> routeValues = new HashMap<String, Object>();
         routeValues.put("id", id); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.DELETE,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.DELETE,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         super.sendRequest(httpRequest);
     }
@@ -370,13 +365,13 @@ public abstract class ProfileHttpClientBase
         final Map<String, Object> routeValues = new HashMap<String, Object>();
         routeValues.put("id", id); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.PUT,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       container,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.PUT,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               container,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         super.sendRequest(httpRequest);
     }
@@ -396,11 +391,11 @@ public abstract class ProfileHttpClientBase
         final NameValueCollection queryParameters = new NameValueCollection();
         queryParameters.addIfNotEmpty("ipaddress", ipaddress); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, GeoRegion.class);
     }
@@ -424,13 +419,13 @@ public abstract class ProfileHttpClientBase
         final NameValueCollection queryParameters = new NameValueCollection();
         queryParameters.addIfNotNull("autoCreate", autoCreate); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.POST,
-                                                       locationId,
-                                                       apiVersion,
-                                                       createProfileContext,
-                                                       APPLICATION_JSON_TYPE,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.POST,
+                                                               locationId,
+                                                               apiVersion,
+                                                               createProfileContext,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, Profile.class);
     }
@@ -473,12 +468,12 @@ public abstract class ProfileHttpClientBase
         queryParameters.addIfNotEmpty("coreAttributes", coreAttributes); //$NON-NLS-1$
         queryParameters.addIfNotNull("forceRefresh", forceRefresh); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, Profile.class);
     }
@@ -501,13 +496,13 @@ public abstract class ProfileHttpClientBase
         final Map<String, Object> routeValues = new HashMap<String, Object>();
         routeValues.put("id", id); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.PATCH,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       profile,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.PATCH,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               profile,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         super.sendRequest(httpRequest);
     }
@@ -522,10 +517,10 @@ public abstract class ProfileHttpClientBase
         final UUID locationId = UUID.fromString("92d8d1c9-26b8-4774-a929-d640a73da524"); //$NON-NLS-1$
         final ApiResourceVersion apiVersion = new ApiResourceVersion("3.0-preview.1"); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, ProfileRegions.class);
     }
@@ -540,10 +535,10 @@ public abstract class ProfileHttpClientBase
         final UUID locationId = UUID.fromString("d5bd1aa6-c269-4bcd-ad32-75fa17475584"); //$NON-NLS-1$
         final ApiResourceVersion apiVersion = new ApiResourceVersion("3.0-preview.1"); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       apiVersion,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               apiVersion,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<HashSet<String>>() {});
     }
@@ -563,11 +558,11 @@ public abstract class ProfileHttpClientBase
         final NameValueCollection queryParameters = new NameValueCollection();
         queryParameters.addIfNotNull("includeAvatar", includeAvatar); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, Profile.class);
     }

--- a/Rest/alm-vss-client/src/main/generated/com/microsoft/alm/visualstudio/services/security/client/SecurityHttpClientBase.java
+++ b/Rest/alm-vss-client/src/main/generated/com/microsoft/alm/visualstudio/services/security/client/SecurityHttpClientBase.java
@@ -23,8 +23,12 @@ import java.util.Map;
 import java.util.UUID;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.microsoft.alm.client.HttpMethod;
 import com.microsoft.alm.client.model.NameValueCollection;
 import com.microsoft.alm.client.VssHttpClientBase;
+import com.microsoft.alm.client.VssMediaTypes;
+import com.microsoft.alm.client.VssRestClientHandler;
+import com.microsoft.alm.client.VssRestRequest;
 import com.microsoft.alm.visualstudio.services.security.AccessControlEntry;
 import com.microsoft.alm.visualstudio.services.security.AccessControlList;
 import com.microsoft.alm.visualstudio.services.security.PermissionEvaluationBatch;
@@ -45,22 +49,13 @@ public abstract class SecurityHttpClientBase
     * Create a new instance of SecurityHttpClientBase
     *
     * @param jaxrsClient
-    *            an initialized instance of a JAX-RS Client implementation
+    *            a DefaultRestClientHandler initialized with an instance of a JAX-RS Client implementation or
+    *            a TEERestClientHamdler initialized with TEE HTTP client implementation
     * @param baseUrl
-    *            a TFS project collection URL
+    *            a TFS services URL
     */
-    protected SecurityHttpClientBase(final Object jaxrsClient, final URI baseUrl) {
-        super(jaxrsClient, baseUrl);
-    }
-
-    /**
-    * Create a new instance of SecurityHttpClientBase
-    *
-    * @param tfsConnection
-    *            an initialized instance of a TfsTeamProjectCollection
-    */
-    protected SecurityHttpClientBase(final Object tfsConnection) {
-        super(tfsConnection);
+    protected SecurityHttpClientBase(final VssRestClientHandler clientHandler, final URI baseUrl) {
+        super(clientHandler, baseUrl);
     }
 
     @Override
@@ -94,12 +89,12 @@ public abstract class SecurityHttpClientBase
         queryParameters.addIfNotEmpty("token", token); //$NON-NLS-1$
         queryParameters.addIfNotEmpty("descriptors", descriptors); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.DELETE,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.DELETE,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, boolean.class);
     }
@@ -123,13 +118,13 @@ public abstract class SecurityHttpClientBase
         final Map<String, Object> routeValues = new HashMap<String, Object>();
         routeValues.put("securityNamespaceId", securityNamespaceId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.POST,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       container,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.POST,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               container,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<AccessControlEntry>>() {});
     }
@@ -168,12 +163,12 @@ public abstract class SecurityHttpClientBase
         queryParameters.addIfNotNull("includeExtendedInfo", includeExtendedInfo); //$NON-NLS-1$
         queryParameters.addIfNotNull("recurse", recurse); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<AccessControlList>>() {});
     }
@@ -204,12 +199,12 @@ public abstract class SecurityHttpClientBase
         queryParameters.addIfNotEmpty("tokens", tokens); //$NON-NLS-1$
         queryParameters.addIfNotNull("recurse", recurse); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.DELETE,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.DELETE,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, boolean.class);
     }
@@ -232,13 +227,13 @@ public abstract class SecurityHttpClientBase
         final Map<String, Object> routeValues = new HashMap<String, Object>();
         routeValues.put("securityNamespaceId", securityNamespaceId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.POST,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       accessControlLists,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.POST,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               accessControlLists,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         super.sendRequest(httpRequest);
     }
@@ -255,12 +250,12 @@ public abstract class SecurityHttpClientBase
         final UUID locationId = UUID.fromString("cf1faa59-1b63-4448-bf04-13d981a46f5d"); //$NON-NLS-1$
         final ApiResourceVersion apiVersion = new ApiResourceVersion("3.0-preview.1"); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.POST,
-                                                       locationId,
-                                                       apiVersion,
-                                                       evalBatch,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.POST,
+                                                               locationId,
+                                                               apiVersion,
+                                                               evalBatch,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, PermissionEvaluationBatch.class);
     }
@@ -299,12 +294,12 @@ public abstract class SecurityHttpClientBase
         queryParameters.addIfNotNull("alwaysAllowAdministrators", alwaysAllowAdministrators); //$NON-NLS-1$
         queryParameters.addIfNotEmpty("delimiter", delimiter); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<Boolean>>() {});
     }
@@ -339,12 +334,12 @@ public abstract class SecurityHttpClientBase
         queryParameters.addIfNotEmpty("token", token); //$NON-NLS-1$
         queryParameters.addIfNotEmpty("descriptor", descriptor); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.DELETE,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.DELETE,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, AccessControlEntry.class);
     }
@@ -371,12 +366,12 @@ public abstract class SecurityHttpClientBase
         final NameValueCollection queryParameters = new NameValueCollection();
         queryParameters.addIfNotNull("localOnly", localOnly); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               queryParameters,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<ArrayList<SecurityNamespaceDescription>>() {});
     }
@@ -399,13 +394,13 @@ public abstract class SecurityHttpClientBase
         final Map<String, Object> routeValues = new HashMap<String, Object>();
         routeValues.put("securityNamespaceId", securityNamespaceId); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.POST,
-                                                       locationId,
-                                                       routeValues,
-                                                       apiVersion,
-                                                       container,
-                                                       APPLICATION_JSON_TYPE,
-                                                       APPLICATION_JSON_TYPE);
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.POST,
+                                                               locationId,
+                                                               routeValues,
+                                                               apiVersion,
+                                                               container,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE,
+                                                               VssMediaTypes.APPLICATION_JSON_TYPE);
 
         super.sendRequest(httpRequest);
     }

--- a/Rest/alm-vss-client/src/main/generated/com/microsoft/alm/visualstudio/services/webapi/EventActor.java
+++ b/Rest/alm-vss-client/src/main/generated/com/microsoft/alm/visualstudio/services/webapi/EventActor.java
@@ -15,6 +15,7 @@
 
 package com.microsoft.alm.visualstudio.services.webapi;
 
+import java.util.UUID;
 
 /** 
  * Defines an &quot;actor&quot; for an event.
@@ -22,4 +23,40 @@ package com.microsoft.alm.visualstudio.services.webapi;
  */
 public class EventActor {
 
+    /**
+    * Required: This is the identity of the user for the specified role.
+    */
+    private UUID id;
+    /**
+    * Required: The event specific name of a role.
+    */
+    private String role;
+
+    /**
+    * Required: This is the identity of the user for the specified role.
+    */
+    public UUID getId() {
+        return id;
+    }
+
+    /**
+    * Required: This is the identity of the user for the specified role.
+    */
+    public void setId(final UUID id) {
+        this.id = id;
+    }
+
+    /**
+    * Required: The event specific name of a role.
+    */
+    public String getRole() {
+        return role;
+    }
+
+    /**
+    * Required: The event specific name of a role.
+    */
+    public void setRole(final String role) {
+        this.role = role;
+    }
 }

--- a/Rest/alm-vss-client/src/main/java/com/microsoft/alm/client/DefaultRestClientHandler.java
+++ b/Rest/alm-vss-client/src/main/java/com/microsoft/alm/client/DefaultRestClientHandler.java
@@ -78,7 +78,7 @@ public class DefaultRestClientHandler extends VssRestClientHandlerBase implement
 
         final WebTarget target = createTarget(locationId, routeValues, queryParameters);
         final MediaType acceptType =
-            getMediaTypeWithQualityHeaderValue(acceptMediaType, NegotiateRequestVersion(locationId, version));
+            getMediaTypeWithQualityHeaderValue(acceptMediaType, negotiateRequestVersion(locationId, version));
 
         final Invocation.Builder requestBuilder = target.request(acceptType);
 

--- a/Rest/alm-vss-client/src/main/java/com/microsoft/alm/client/DefaultRestClientHandler.java
+++ b/Rest/alm-vss-client/src/main/java/com/microsoft/alm/client/DefaultRestClientHandler.java
@@ -1,6 +1,5 @@
 package com.microsoft.alm.client;
 
-import java.net.URI;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -29,13 +28,11 @@ import com.microsoft.alm.visualstudio.services.webapi.ApiResourceVersion;
 public class DefaultRestClientHandler extends VssRestClientHandlerBase implements VssRestClientHandler {
 
     private final Client rsClient;
-    private final URI baseUrl;
     private final WebTarget baseTarget;
 
-    public DefaultRestClientHandler(final Client rsClient, final URI baseUrl) {
+    public DefaultRestClientHandler(final Client rsClient) {
         this.rsClient = rsClient;
-        this.baseUrl = baseUrl;
-        this.baseTarget = this.rsClient.target(baseUrl).register(ApiResourceEntityProvider.class);
+        this.baseTarget = this.rsClient.target(getBaseUrl()).register(ApiResourceEntityProvider.class);
     }
 
     @Override
@@ -119,7 +116,7 @@ public class DefaultRestClientHandler extends VssRestClientHandlerBase implement
 
         final ApiResourceLocation location = getLocation(locationId);
         if (location == null) {
-            throw new VssResourceNotFoundException(locationId, baseUrl, getLastException());
+            throw new VssResourceNotFoundException(locationId, getBaseUrl(), getLastException());
         }
 
         final Map<String, Object> dictionary =

--- a/Rest/alm-vss-client/src/main/java/com/microsoft/alm/client/DefaultRestClientHandler.java
+++ b/Rest/alm-vss-client/src/main/java/com/microsoft/alm/client/DefaultRestClientHandler.java
@@ -67,14 +67,14 @@ public class DefaultRestClientHandler extends VssRestClientHandlerBase implement
 
     @Override
     public <TEntity> VssRestRequest createRequest(
-        HttpMethod method,
-        UUID locationId,
-        Map<String, Object> routeValues,
-        ApiResourceVersion version,
-        TEntity value,
-        String contentMediaType,
-        Map<String, String> queryParameters,
-        String acceptMediaType) {
+        final HttpMethod method,
+        final UUID locationId,
+        final Map<String, Object> routeValues,
+        final ApiResourceVersion version,
+        final TEntity value,
+        final String contentMediaType,
+        final Map<String, String> queryParameters,
+        final String acceptMediaType) {
 
         final WebTarget target = createTarget(locationId, routeValues, queryParameters);
         final MediaType acceptType =
@@ -158,7 +158,7 @@ public class DefaultRestClientHandler extends VssRestClientHandlerBase implement
         return mediaType;
     }
 
-    public class JaxRsRequest implements VssRestRequest {
+    public static class JaxRsRequest implements VssRestRequest {
 
         final private Invocation request;
 
@@ -188,7 +188,7 @@ public class DefaultRestClientHandler extends VssRestClientHandlerBase implement
         }
     }
 
-    public class JaxRsResponse implements VssRestResponse {
+    public static class JaxRsResponse implements VssRestResponse {
 
         final private Response response;
 
@@ -199,8 +199,7 @@ public class DefaultRestClientHandler extends VssRestClientHandlerBase implement
         @Override
         public boolean isJsonResponse() {
             if (response != null && response.getMediaType() != null) {
-                return response.getMediaType().getType().equalsIgnoreCase("application") //$NON-NLS-1$
-                    && response.getMediaType().getSubtype().equalsIgnoreCase("json"); //$NON-NLS-1$
+                return StringUtil.startsWithIgnoreCase(response.getMediaType().toString(), MediaType.APPLICATION_JSON);
             } else {
                 return false;
             }
@@ -213,7 +212,7 @@ public class DefaultRestClientHandler extends VssRestClientHandlerBase implement
 
         @Override
         public boolean isSuccessResponse() {
-            return response.getStatusInfo().getFamily() != Response.Status.Family.SUCCESSFUL;
+            return response.getStatusInfo().getFamily() == Response.Status.Family.SUCCESSFUL;
         }
 
         @Override

--- a/Rest/alm-vss-client/src/main/java/com/microsoft/alm/client/DefaultRestClientHandler.java
+++ b/Rest/alm-vss-client/src/main/java/com/microsoft/alm/client/DefaultRestClientHandler.java
@@ -1,0 +1,248 @@
+package com.microsoft.alm.client;
+
+import java.net.URI;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.UUID;
+import java.util.concurrent.ExecutionException;
+
+import javax.ws.rs.client.Client;
+import javax.ws.rs.client.Entity;
+import javax.ws.rs.client.Invocation;
+import javax.ws.rs.client.Invocation.Builder;
+import javax.ws.rs.client.WebTarget;
+import javax.ws.rs.core.GenericType;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.MultivaluedMap;
+import javax.ws.rs.core.Response;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.microsoft.alm.client.jaxrs.ApiResourceEntityProvider;
+import com.microsoft.alm.client.model.VssResourceNotFoundException;
+import com.microsoft.alm.client.model.VssServiceException;
+import com.microsoft.alm.client.utils.StringUtil;
+import com.microsoft.alm.visualstudio.services.webapi.ApiResourceLocation;
+import com.microsoft.alm.visualstudio.services.webapi.ApiResourceLocationCollection;
+import com.microsoft.alm.visualstudio.services.webapi.ApiResourceVersion;
+
+public class DefaultRestClientHandler extends VssRestClientHandlerBase implements VssRestClientHandler {
+
+    private final Client rsClient;
+    private final URI baseUrl;
+    private final WebTarget baseTarget;
+
+    public DefaultRestClientHandler(final Client rsClient, final URI baseUrl) {
+        this.rsClient = rsClient;
+        this.baseUrl = baseUrl;
+        this.baseTarget = this.rsClient.target(baseUrl).register(ApiResourceEntityProvider.class);
+    }
+
+    @Override
+    public boolean checkConnection() {
+        final WebTarget optionsTarget = baseTarget.path(CONNECTION_DATA_RELATIVE_PATH);
+        final Builder builder = optionsTarget.request(MediaType.APPLICATION_JSON_TYPE);
+
+        try {
+            return builder.build(HttpMethod.GET.getVerb()).submit().get() != null;
+        } catch (final Exception e) {
+            setLastException(e);
+        }
+
+        return false;
+    }
+
+    @Override
+    protected ApiResourceLocationCollection loadLocations() {
+        final WebTarget optionsTarget = baseTarget.path(OPTIONS_RELATIVE_PATH);
+        final Builder builder = optionsTarget.request(MediaType.APPLICATION_JSON_TYPE);
+
+        try {
+            return builder.async().options(ApiResourceLocationCollection.class).get();
+        } catch (final InterruptedException e) {
+            // TODO log errors
+        } catch (final ExecutionException e) {
+            setLastException((Exception) e.getCause());
+        }
+
+        return null;
+    }
+
+    @Override
+    public <TEntity> VssRestRequest createRequest(
+        HttpMethod method,
+        UUID locationId,
+        Map<String, Object> routeValues,
+        ApiResourceVersion version,
+        TEntity value,
+        String contentMediaType,
+        Map<String, String> queryParameters,
+        String acceptMediaType) {
+
+        final WebTarget target = createTarget(locationId, routeValues, queryParameters);
+        final MediaType acceptType =
+            getMediaTypeWithQualityHeaderValue(acceptMediaType, NegotiateRequestVersion(locationId, version));
+
+        final Invocation.Builder requestBuilder = target.request(acceptType);
+
+        final HttpMethod httpMethod;
+        if (shouldOverrideHttpMethod(method)) {
+            httpMethod = HttpMethod.POST;
+            requestBuilder.header(VssHttpHeaders.HTTP_METHOD_OVERRIDE, method);
+        } else {
+            httpMethod = method;
+        }
+
+        requestBuilder.header(VssHttpHeaders.TFS_VERSION, getClientVersion());
+
+        final Invocation request;
+
+        if (value != null) {
+            final MediaType contentType = getMediaTypeWithQualityHeaderValue(contentMediaType);
+            request = requestBuilder.build(httpMethod.getVerb(), Entity.entity(value, contentType));
+        } else if (httpMethod == HttpMethod.POST) {
+            final MediaType contentType = getMediaTypeWithQualityHeaderValue(VssMediaTypes.APPLICATION_JSON_TYPE);
+            // value is null but it is POST (most likely because of method
+            // overriding), adding an empty entity body
+            request = requestBuilder.build(httpMethod.getVerb(), Entity.entity(StringUtil.EMPTY, contentType));
+        } else {
+            request = requestBuilder.build(httpMethod.getVerb());
+        }
+
+        return new JaxRsRequest(request);
+    }
+
+    private WebTarget createTarget(
+        final UUID locationId,
+        final Map<String, Object> routeValues,
+        final Map<String, String> queryParameters) {
+
+        final ApiResourceLocation location = getLocation(locationId);
+        if (location == null) {
+            throw new VssResourceNotFoundException(locationId, baseUrl, getLastException());
+        }
+
+        final Map<String, Object> dictionary =
+            toRouteDictionary(routeValues, location.getArea(), location.getResourceName());
+
+        final String routeTemplate = location.getRouteTemplate();
+        final String actualTemplate = removeUndefinedOptionalParameters(routeTemplate, dictionary);
+        final WebTarget targetTemplate = baseTarget.path(actualTemplate);
+
+        WebTarget target = targetTemplate.resolveTemplates(dictionary);
+
+        if (queryParameters != null) {
+            for (final Entry<String, String> queryParameter : queryParameters.entrySet()) {
+                target = target.queryParam(queryParameter.getKey(), queryParameter.getValue());
+            }
+        }
+
+        return target;
+    }
+
+    private MediaType getMediaTypeWithQualityHeaderValue(final String baseMediaType, final ApiResourceVersion version) {
+        final Map<String, String> parameters = new HashMap<String, String>();
+        parameters.put(API_VERSION_PARAMETER_NAME, version.toString());
+        parameters.put(CHARSET_PARAMETER_NAME, StringUtil.UTF8_CHARSET);
+
+        final String[] mediaTypePart = baseMediaType.split("/", 2); //$NON-NLS-1$
+        final MediaType mediaType = new MediaType(mediaTypePart[0], mediaTypePart[1], parameters);
+
+        return mediaType;
+    }
+
+    private MediaType getMediaTypeWithQualityHeaderValue(final String baseMediaType) {
+        final Map<String, String> parameters = new HashMap<String, String>();
+        parameters.put(CHARSET_PARAMETER_NAME, StringUtil.UTF8_CHARSET);
+
+        final String[] mediaTypePart = baseMediaType.split("/", 2); //$NON-NLS-1$
+        final MediaType mediaType = new MediaType(mediaTypePart[0], mediaTypePart[1], parameters);
+
+        return mediaType;
+    }
+
+    public class JaxRsRequest implements VssRestRequest {
+
+        final private Invocation request;
+
+        public JaxRsRequest(final Invocation request) {
+            this.request = request;
+        }
+
+        @Override
+        public VssRestResponse sendRequest() {
+            Response response;
+
+            try {
+                response = request.submit().get();
+            } catch (final ExecutionException e) {
+                // TODO log exception
+                // TODO process cancellation
+
+                throw new VssServiceException(e.getMessage(), e);
+            } catch (final InterruptedException e) {
+                // TODO log exception
+                // TODO process cancellation
+
+                throw new VssServiceException(e.getMessage(), e);
+            }
+
+            return new JaxRsResponse(response);
+        }
+    }
+
+    public class JaxRsResponse implements VssRestResponse {
+
+        final private Response response;
+
+        public JaxRsResponse(final Response response) {
+            this.response = response;
+        }
+
+        @Override
+        public boolean isJsonResponse() {
+            if (response != null && response.getMediaType() != null) {
+                return response.getMediaType().getType().equalsIgnoreCase("application") //$NON-NLS-1$
+                    && response.getMediaType().getSubtype().equalsIgnoreCase("json"); //$NON-NLS-1$
+            } else {
+                return false;
+            }
+        }
+
+        @Override
+        public boolean isProxyAuthRequired() {
+            return response.getStatusInfo() == Response.Status.PROXY_AUTHENTICATION_REQUIRED;
+        }
+
+        @Override
+        public boolean isSuccessResponse() {
+            return response.getStatusInfo().getFamily() != Response.Status.Family.SUCCESSFUL;
+        }
+
+        @Override
+        public <TEntity> TEntity readEntity(Class<TEntity> resultClass) {
+            return response.readEntity(resultClass);
+        }
+
+        @Override
+        public <TEntity> TEntity readEntity(TypeReference<TEntity> resultClass) {
+            return response.readEntity(new GenericType<TEntity>(resultClass.getType()));
+        }
+
+        @Override
+        public String getHeader(String headerName) {
+            final MultivaluedMap<String, String> headers = response.getStringHeaders();
+            return headers.getFirst(headerName);
+        }
+
+        @Override
+        public String getStatusText() {
+            return response.getStatusInfo().getReasonPhrase();
+        }
+
+        @Override
+        public int getStatusCode() {
+            return response.getStatusInfo().getStatusCode();
+        }
+    }
+}

--- a/Rest/alm-vss-client/src/main/java/com/microsoft/alm/client/HttpMethod.java
+++ b/Rest/alm-vss-client/src/main/java/com/microsoft/alm/client/HttpMethod.java
@@ -1,0 +1,27 @@
+package com.microsoft.alm.client;
+
+public enum HttpMethod {
+    PATCH("PATCH", true), //$NON-NLS-1$
+    GET("GET", false), //$NON-NLS-1$
+    POST("POST", false), //$NON-NLS-1$
+    PUT("PUT", true), //$NON-NLS-1$
+    DELETE("DELETE", true), //$NON-NLS-1$
+    HEAD("HEAD", false), //$NON-NLS-1$
+    OPTIONS("OPTIONS", true); //$NON-NLS-1$
+
+    private String verb;
+    private boolean overrideable;
+
+    private HttpMethod(final String verb, final boolean overrideable) {
+        this.verb = verb;
+        this.overrideable = overrideable;
+    }
+
+    public boolean isOverrideable() {
+        return this.overrideable;
+    }
+
+    public String getVerb() {
+        return this.verb;
+    }
+}

--- a/Rest/alm-vss-client/src/main/java/com/microsoft/alm/client/VssHttpClientBase.java
+++ b/Rest/alm-vss-client/src/main/java/com/microsoft/alm/client/VssHttpClientBase.java
@@ -7,90 +7,39 @@ import java.io.InputStream;
 import java.io.UnsupportedEncodingException;
 import java.net.URI;
 import java.net.URLDecoder;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Properties;
 import java.util.UUID;
-import java.util.concurrent.ExecutionException;
-
-import javax.ws.rs.client.Client;
-import javax.ws.rs.client.Entity;
-import javax.ws.rs.client.Invocation;
-import javax.ws.rs.client.Invocation.Builder;
-import javax.ws.rs.client.WebTarget;
-import javax.ws.rs.core.GenericType;
-import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.MultivaluedMap;
-import javax.ws.rs.core.Response;
 
 import com.fasterxml.jackson.core.type.TypeReference;
-import com.microsoft.alm.client.jaxrs.ApiResourceEntityProvider;
 import com.microsoft.alm.client.model.NameValueCollection;
 import com.microsoft.alm.client.model.ProxyAuthenticationRequiredException;
 import com.microsoft.alm.client.model.VssException;
-import com.microsoft.alm.client.model.VssResourceNotFoundException;
 import com.microsoft.alm.client.model.VssServiceException;
 import com.microsoft.alm.client.model.VssServiceResponseException;
 import com.microsoft.alm.client.utils.JsonHelper;
 import com.microsoft.alm.client.utils.StringUtil;
-import com.microsoft.alm.visualstudio.services.webapi.ApiResourceLocation;
-import com.microsoft.alm.visualstudio.services.webapi.ApiResourceLocationCollection;
 import com.microsoft.alm.visualstudio.services.webapi.ApiResourceVersion;
 import com.microsoft.alm.visualstudio.services.webapi.WrappedException;
 
 public abstract class VssHttpClientBase {
-    protected final static MediaType APPLICATION_JSON_TYPE = MediaType.APPLICATION_JSON_TYPE;
-    protected final static MediaType APPLICATION_OCTET_STREAM_TYPE = MediaType.APPLICATION_OCTET_STREAM_TYPE;
-    protected final static MediaType APPLICATION_ZIP_TYPE = new MediaType("application", "zip"); //$NON-NLS-1$ //$NON-NLS-2$
-    protected final static MediaType TEXT_PLAIN_TYPE = MediaType.TEXT_PLAIN_TYPE;
-    protected final static MediaType TEXT_HTML_TYPE = MediaType.TEXT_HTML_TYPE;
-    protected final static MediaType APPLICATION_JSON_PATCH_TYPE = new MediaType("application", "json-patch+json"); //$NON-NLS-1$ //$NON-NLS-2$
-    protected final static MediaType APPLICATION_GIT_MEDIA_TYPE = new MediaType("application", "vnd.git-media"); //$NON-NLS-1$ //$NON-NLS-2$
-    protected final static MediaType IMAGE_SVG_XML_MEDIA_TYPE = new MediaType("image", "svg+xml"); //$NON-NLS-1$ //$NON-NLS-2$
-    protected final static MediaType IMAGE_PNG_MEDIA_TYPE = new MediaType("image", "png"); //$NON-NLS-1$ //$NON-NLS-2$
-    protected final static MediaType APPLICATION_GZIP = new MediaType("application", "gzip"); //$NON-NLS-1$ //$NON-NLS-2$
 
-    private final static String OPTIONS_RELATIVE_PATH = "_apis"; //$NON-NLS-1$
-    private final static String CONNECTION_DATA_RELATIVE_PATH = "_apis/connectiondata"; //$NON-NLS-1$
-    private final static String AREA_PARAMETER_NAME = "area"; //$NON-NLS-1$
-    private final static String RESOURCE_PARAMETER_NAME = "resource"; //$NON-NLS-1$
-    private final static String ROUTE_TEMPLATE_SEPARATOR = "/"; //$NON-NLS-1$
+    public final static String VSS_HTTP_METHOD_OVERRIDE_PROPERTY = "VSS_HTTP_METHOD_OVERRIDE"; //$NON-NLS-1$
 
-    private final static ApiResourceVersion DEFAULT_API_VERSION = new ApiResourceVersion();
-
-    private final static String API_VERSION_PARAMETER_NAME = "api-version"; //$NON-NLS-1$
-    private final static String CHARSET_PARAMETER_NAME = "charset"; //$NON-NLS-1$
-    private final static String VSS_HTTP_METHOD_OVERRIDE_PROPERTY = "VSS_HTTP_METHOD_OVERRIDE"; //$NON-NLS-1$
-
-    private final Client rsClient;
     private final URI baseUrl;
-    private final WebTarget baseTarget;
     private final static Properties clientProperties = new Properties();
+
+    private final VssRestClientHandler clientHandler;
+
     static {
         loadClientProperties();
     }
 
-    private final boolean overrideEnabled;
-
-    private ApiResourceLocationCollection resourceLocations;
-    private Exception lastException;
-
-    protected VssHttpClientBase(final Object tfsConnection) {
-        this.rsClient = null;
-        this.baseUrl = null;
-        this.baseTarget = null;
-
-        this.overrideEnabled = getOverrideSetting();
-    }
-
-    protected VssHttpClientBase(final Object rsClient, final URI baseUrl) {
-        this.rsClient = (Client) rsClient;
+    protected VssHttpClientBase(final VssRestClientHandler clientHandler, final URI baseUrl) {
         this.baseUrl = baseUrl;
-        this.baseTarget = this.rsClient.target(baseUrl).register(ApiResourceEntityProvider.class);
-        this.overrideEnabled = getOverrideSetting();
+        this.clientHandler = clientHandler;
+        this.clientHandler.init(getOverrideSetting(), clientProperties.getProperty("version"), baseUrl); //$NON-NLS-1$
     }
 
     protected boolean getOverrideSetting() {
@@ -102,10 +51,6 @@ public abstract class VssHttpClientBase {
         return true;
     }
 
-    protected boolean isOverrideEnabled() {
-        return this.overrideEnabled;
-    }
-
     protected Map<String, Class<? extends Exception>> getTranslatedExceptions() {
         return null;
     }
@@ -115,220 +60,14 @@ public abstract class VssHttpClientBase {
     }
 
     public Exception getLastExecutionException() {
-        return lastException;
-    }
-
-    private ApiResourceLocation getLocation(final UUID locationId) {
-        if (resourceLocations == null) {
-            resourceLocations = loadLocations();
-        }
-
-        if (resourceLocations != null) {
-            return resourceLocations.getLocationById(locationId);
-        } else {
-            return null;
-        }
+        return clientHandler.getLastException();
     }
 
     public boolean checkConnection() {
-        final WebTarget optionsTarget = baseTarget.path(CONNECTION_DATA_RELATIVE_PATH);
-        final Builder builder = optionsTarget.request(MediaType.APPLICATION_JSON_TYPE);
-
-        try {
-            return sendRequest(builder.build(HttpMethod.GET.getVerb())) != null;
-        } catch (final Exception e) {
-            lastException = e;
-        }
-
-        return false;
+        return clientHandler.checkConnection();
     }
 
-    private ApiResourceLocationCollection loadLocations() {
-        final WebTarget optionsTarget = baseTarget.path(OPTIONS_RELATIVE_PATH);
-        final Builder builder = optionsTarget.request(MediaType.APPLICATION_JSON_TYPE);
-
-        try {
-            return builder.async().options(ApiResourceLocationCollection.class).get();
-        } catch (final InterruptedException e) {
-            // TODO log errors
-        } catch (final ExecutionException e) {
-            lastException = (Exception) e.getCause();
-        }
-
-        return null;
-    }
-
-    private WebTarget createTarget(
-        final UUID locationId,
-        final Map<String, Object> routeValues,
-        final Map<String, String> queryParameters) {
-
-        final ApiResourceLocation location = getLocation(locationId);
-        if (location == null) {
-            throw new VssResourceNotFoundException(locationId, baseUrl, lastException);
-        }
-
-        final Map<String, Object> dictionary =
-            toRouteDictionary(routeValues, location.getArea(), location.getResourceName());
-
-        final String routeTemplate = location.getRouteTemplate();
-        final String actualTemplate = removeUndefinedOptionalParameters(routeTemplate, dictionary);
-        final WebTarget targetTemplate = baseTarget.path(actualTemplate);
-
-        WebTarget target = targetTemplate.resolveTemplates(dictionary);
-
-        if (queryParameters != null) {
-            for (final Entry<String, String> queryParameter : queryParameters.entrySet()) {
-                target = target.queryParam(queryParameter.getKey(), queryParameter.getValue());
-            }
-        }
-
-        return target;
-    }
-
-    private String removeUndefinedOptionalParameters(final String template, final Map<String, Object> routeValues) {
-        final String[] templateParameters = template.split(ROUTE_TEMPLATE_SEPARATOR);
-        final List<String> actualParameters = new ArrayList<String>();
-
-        for (int i = 0; i < templateParameters.length; i++) {
-            final String parameter = templateParameters[i];
-
-            if (parameter.startsWith("{")) { //$NON-NLS-1$
-                final String name;
-
-                if (parameter.startsWith("{*")) { //$NON-NLS-1$
-                    name = parameter.substring(2, parameter.length() - 1);
-                } else {
-                    name = parameter.substring(1, parameter.length() - 1);
-                }
-
-                if (routeValues.get(name) != null) {
-                    actualParameters.add("{" + name + "}"); //$NON-NLS-1$ //$NON-NLS-2$
-                }
-            } else {
-                actualParameters.add(parameter);
-            }
-        }
-
-        return StringUtil.join(ROUTE_TEMPLATE_SEPARATOR, actualParameters);
-    }
-
-    private Map<String, Object> toRouteDictionary(
-        final Map<String, Object> routeValues,
-        final String areaName,
-        final String resourceName) {
-
-        final HashMap<String, Object> dictionary = new HashMap<String, Object>();
-        if (routeValues != null) {
-
-            for (final Entry<String, Object> e : routeValues.entrySet()) {
-                if (e.getValue() != null) {
-                    dictionary.put(e.getKey(), e.getValue());
-                }
-            }
-        }
-
-        if (!dictionary.containsKey(AREA_PARAMETER_NAME)) {
-            dictionary.put(AREA_PARAMETER_NAME, areaName);
-        }
-
-        if (!dictionary.containsKey(RESOURCE_PARAMETER_NAME)) {
-            dictionary.put(RESOURCE_PARAMETER_NAME, resourceName);
-        }
-
-        return dictionary;
-    }
-
-    private MediaType getMediaTypeWithQualityHeaderValue(
-        final MediaType baseMediaType,
-        final ApiResourceVersion version) {
-        final Map<String, String> parameters = new HashMap<String, String>();
-        parameters.put(API_VERSION_PARAMETER_NAME, version.toString());
-        parameters.put(CHARSET_PARAMETER_NAME, StringUtil.UTF8_CHARSET);
-
-        final MediaType mediaType = new MediaType(baseMediaType.getType(), baseMediaType.getSubtype(), parameters);
-
-        return mediaType;
-    }
-
-    private MediaType getMediaTypeWithQualityHeaderValue(final MediaType baseMediaType) {
-        final Map<String, String> parameters = new HashMap<String, String>();
-        parameters.put(CHARSET_PARAMETER_NAME, StringUtil.UTF8_CHARSET);
-
-        final MediaType mediaType = new MediaType(baseMediaType.getType(), baseMediaType.getSubtype(), parameters);
-
-        return mediaType;
-    }
-
-    private boolean isJsonResponse(final Response response) {
-        if (response != null && response.getMediaType() != null) {
-            return response.getMediaType().getType().equalsIgnoreCase("application") //$NON-NLS-1$
-                && response.getMediaType().getSubtype().equalsIgnoreCase("json"); //$NON-NLS-1$
-        } else {
-            return false;
-        }
-    }
-
-    /**
-     * Negotiate the appropriate request version to use for the given api
-     * resource location, based on the client and server capabilities
-     *
-     * @param location
-     *        - Location of the API resource
-     * @param version
-     *        - Client version to attempt to use (use the latest VSS API version
-     *        if unspecified)
-     * @return - Max API version supported on the server that is less than or
-     *         equal to the client version. Returns null if the server does not
-     *         support this location or this version of the client.
-     */
-    protected ApiResourceVersion negotiateRequestVersion(
-        final ApiResourceLocation location,
-        final ApiResourceVersion version) {
-
-        if (version == null) {
-            return DEFAULT_API_VERSION;
-        }
-
-        if (location.getMinVersion().compareTo(version.getApiVersion()) > 0) {
-            // Client is older than the server. The server no longer supports
-            // this resource (deprecated).
-            return null;
-        } else if (location.getMaxVersion().compareTo(version.getApiVersion()) < 0) {
-            // Client is newer than the server. Negotiate down to the latest
-            // version on the server.
-            final ApiResourceVersion negotiatedVersion = new ApiResourceVersion(location.getMaxVersion());
-
-            // If the server latest version is greater than the released one,
-            // it is in preview mode.
-            final boolean isPreview = location.getReleasedVersion().compareTo(location.getMaxVersion()) < 0;
-            negotiatedVersion.setPreview(isPreview);
-
-            return negotiatedVersion;
-        } else {
-            // We can send at the requested API version. Make sure the resource
-            // version is not bigger than what the server supports.
-            final int resourceVersion = Math.min(version.getResourceVersion(), location.getResourceVersion());
-            final ApiResourceVersion negotiatedVersion =
-                new ApiResourceVersion(version.getApiVersion(), resourceVersion);
-
-            // If server released version is less than the requested one, the
-            // negotiated version is in preview mode.
-            if (location.getReleasedVersion().compareTo(version.getApiVersion()) < 0) {
-                negotiatedVersion.setPreview(true);
-            } else {
-                negotiatedVersion.setPreview(version.isPreview());
-            }
-
-            return negotiatedVersion;
-        }
-    }
-
-    private ApiResourceVersion NegotiateRequestVersion(final UUID locationId, final ApiResourceVersion version) {
-        return negotiateRequestVersion(getLocation(locationId), version);
-    }
-
-    protected Invocation createRequest(
+    protected VssRestRequest createRequest(
         final HttpMethod method,
         final UUID locationId,
         final Map<String, Object> routeValues,
@@ -343,80 +82,80 @@ public abstract class VssHttpClientBase {
             null,
             null,
             queryParameters,
-            APPLICATION_JSON_TYPE);
+            VssMediaTypes.APPLICATION_JSON_TYPE);
     }
 
-    protected Invocation createRequest(
+    protected VssRestRequest createRequest(
         final HttpMethod method,
         final UUID locationId,
         final ApiResourceVersion version,
-        final MediaType acceptMediaType) {
+        final String acceptMediaType) {
 
         return createRequest(method, locationId, null, version, null, null, null, acceptMediaType);
     }
 
-    protected Invocation createRequest(
+    protected VssRestRequest createRequest(
         final HttpMethod method,
         final UUID locationId,
         final Map<String, Object> routeValues,
         final ApiResourceVersion version,
-        final MediaType acceptMediaType) {
+        final String acceptMediaType) {
 
         return createRequest(method, locationId, routeValues, version, null, null, null, acceptMediaType);
     }
 
-    protected Invocation createRequest(
+    protected VssRestRequest createRequest(
         final HttpMethod method,
         final UUID locationId,
         final Map<String, Object> routeValues,
         final ApiResourceVersion version,
         final Map<String, String> queryParameters,
-        final MediaType acceptMediaType) {
+        final String acceptMediaType) {
 
         return createRequest(method, locationId, routeValues, version, null, null, queryParameters, acceptMediaType);
     }
 
-    protected Invocation createRequest(
+    protected VssRestRequest createRequest(
         final HttpMethod method,
         final UUID locationId,
         final ApiResourceVersion version,
         final Map<String, String> queryParameters,
-        final MediaType acceptMediaType) {
+        final String acceptMediaType) {
 
         return createRequest(method, locationId, null, version, null, null, queryParameters, acceptMediaType);
     }
 
-    protected <TEntity> Invocation createRequest(
+    protected <TEntity> VssRestRequest createRequest(
         final HttpMethod method,
         final UUID locationId,
         final ApiResourceVersion version,
         final TEntity value,
-        final MediaType contentMediaType,
-        final MediaType acceptMediaType) {
+        final String contentMediaType,
+        final String acceptMediaType) {
 
         return createRequest(method, locationId, null, version, value, contentMediaType, null, acceptMediaType);
     }
 
-    protected <TEntity> Invocation createRequest(
+    protected <TEntity> VssRestRequest createRequest(
         final HttpMethod method,
         final UUID locationId,
         final Map<String, Object> routeValues,
         final ApiResourceVersion version,
         final TEntity value,
-        final MediaType contentMediaType,
-        final MediaType acceptMediaType) {
+        final String contentMediaType,
+        final String acceptMediaType) {
 
         return createRequest(method, locationId, routeValues, version, value, contentMediaType, null, acceptMediaType);
     }
 
-    protected <TEntity> Invocation createRequest(
+    protected <TEntity> VssRestRequest createRequest(
         final HttpMethod method,
         final UUID locationId,
         final ApiResourceVersion version,
         final TEntity value,
-        final MediaType contentMediaType,
+        final String contentMediaType,
         final Map<String, String> queryParameters,
-        final MediaType acceptMediaType) {
+        final String acceptMediaType) {
 
         return createRequest(
             method,
@@ -429,7 +168,7 @@ public abstract class VssHttpClientBase {
             acceptMediaType);
     }
 
-    protected <TEntity> Invocation createRequest(
+    protected <TEntity> VssRestRequest createRequest(
         final HttpMethod method,
         final UUID locationId,
         final Map<String, Object> routeValues,
@@ -443,94 +182,55 @@ public abstract class VssHttpClientBase {
             routeValues,
             version,
             value,
-            APPLICATION_JSON_TYPE,
+            VssMediaTypes.APPLICATION_JSON_TYPE,
             queryParameters,
-            APPLICATION_JSON_TYPE);
+            VssMediaTypes.APPLICATION_JSON_TYPE);
     }
 
-    protected <TEntity> Invocation createRequest(
+    public <TEntity> VssRestRequest createRequest(
         final HttpMethod method,
         final UUID locationId,
         final Map<String, Object> routeValues,
         final ApiResourceVersion version,
         final TEntity value,
-        final MediaType contentMediaType,
+        final String contentMediaType,
         final Map<String, String> queryParameters,
-        final MediaType acceptMediaType) {
+        final String acceptMediaType) {
 
-        final WebTarget target = createTarget(locationId, routeValues, queryParameters);
-        final MediaType acceptType =
-            getMediaTypeWithQualityHeaderValue(acceptMediaType, NegotiateRequestVersion(locationId, version));
-
-        final Invocation.Builder requestBuilder = target.request(acceptType);
-
-        final HttpMethod httpMethod;
-        if (shouldOverrideHttpMethod(method)) {
-            httpMethod = HttpMethod.POST;
-            requestBuilder.header(VssHttpHeaders.HTTP_METHOD_OVERRIDE, method);
-        } else {
-            httpMethod = method;
-        }
-
-        requestBuilder.header(VssHttpHeaders.TFS_VERSION, clientProperties.getProperty("version")); //$NON-NLS-1$
-
-        if (value != null) {
-            final MediaType contentType = getMediaTypeWithQualityHeaderValue(contentMediaType);
-            return requestBuilder.build(httpMethod.getVerb(), Entity.entity(value, contentType));
-        } else if (httpMethod == HttpMethod.POST) {
-            final MediaType contentType = getMediaTypeWithQualityHeaderValue(APPLICATION_JSON_TYPE);
-            // value is null but it is POST (most likely because of method
-            // overriding), adding an empty entity body
-            return requestBuilder.build(httpMethod.getVerb(), Entity.entity(StringUtil.EMPTY, contentType));
-        } else {
-            return requestBuilder.build(httpMethod.getVerb());
-        }
+        return clientHandler.createRequest(
+            method,
+            locationId,
+            routeValues,
+            version,
+            value,
+            contentMediaType,
+            queryParameters,
+            acceptMediaType);
     }
 
-    private Response sendRequest(final Invocation request) {
-        Response response;
-
-        try {
-            response = request.submit().get();
-        } catch (final ExecutionException e) {
-            // TODO log exception
-            // TODO process cancellation
-
-            throw new VssServiceException(e.getMessage(), e);
-        } catch (final InterruptedException e) {
-            // TODO log exception
-            // TODO process cancellation
-
-            throw new VssServiceException(e.getMessage(), e);
-        }
-
+    public VssRestResponse sendRequest(final VssRestRequest request) {
+        VssRestResponse response = request.sendRequest();
         handleResponse(response);
-
         return response;
     }
 
-    protected void sendRequest(final Object request) {
-        sendRequest((Invocation) request);
-    }
-
-    protected <TResult> TResult sendRequest(final Object request, final Class<TResult> resultClass) {
-        final Response response = sendRequest((Invocation) request);
-
+    public <TResult> TResult sendRequest(final VssRestRequest request, final Class<TResult> resultClass) {
+        final VssRestResponse response = sendRequest(request);
         return response.readEntity(resultClass);
     }
 
-    protected <TResult> TResult sendRequest(final Object request, final TypeReference<TResult> resultClass) {
-        final Response response = sendRequest((Invocation) request);
-        return response.readEntity(new GenericType<TResult>(resultClass.getType()));
+    public <TResult> TResult sendRequest(final VssRestRequest request, final TypeReference<TResult> resultClass) {
+        final VssRestResponse response = sendRequest(request);
+        return response.readEntity(resultClass);
     }
 
-    protected void handleResponse(final Response response) {
-        if (response.getStatusInfo() == Response.Status.PROXY_AUTHENTICATION_REQUIRED) {
+    private void handleResponse(final VssRestResponse response) {
+        if (response.isProxyAuthRequired()) {
             throw new ProxyAuthenticationRequiredException();
-        } else if (response.getStatusInfo().getFamily() != Response.Status.Family.SUCCESSFUL) {
+        } else if (!response.isSuccessResponse()) {
             Exception exceptionToThrow = null;
 
-            if (isJsonResponse(response)) {
+            if (response.isJsonResponse()) {
                 final WrappedException wrappedException = response.readEntity(WrappedException.class);
                 exceptionToThrow = wrappedException.Unwrap(getTranslatedExceptions());
             }
@@ -542,20 +242,24 @@ public abstract class VssHttpClientBase {
                     message = exceptionToThrow.getMessage();
                 }
 
-                final MultivaluedMap<String, String> headers = response.getStringHeaders();
+                final String tfsServiceError = response.getHeader(VssHttpHeaders.TFS_SERVICE_ERROR);
 
-                if (headers.containsKey(VssHttpHeaders.TFS_SERVICE_ERROR)) {
+                if (!StringUtil.isNullOrEmpty(tfsServiceError)) {
                     try {
-                        message = URLDecoder.decode(headers.getFirst(VssHttpHeaders.TFS_SERVICE_ERROR), "UTF-8"); //$NON-NLS-1$
-                    } catch (final UnsupportedEncodingException e) {
+                        message = URLDecoder.decode(tfsServiceError, "UTF-8"); //$NON-NLS-1$
+                    } catch (UnsupportedEncodingException e) {
                         // do nothing
                     }
-                } else if (StringUtil.isNullOrEmpty(message)
-                    && !StringUtil.isNullOrEmpty(response.getStatusInfo().getReasonPhrase())) {
-                    message = response.getStatusInfo().getReasonPhrase();
+                } else if (StringUtil.isNullOrEmpty(message)) {
+
+                    final String statusText = response.getStatusText();
+
+                    if (!StringUtil.isNullOrEmpty(statusText)) {
+                        message = statusText;
+                    }
                 }
 
-                exceptionToThrow = new VssServiceResponseException(response.getStatusInfo(), message, exceptionToThrow);
+                exceptionToThrow = new VssServiceResponseException(response.getStatusCode(), message, exceptionToThrow);
             }
 
             throw (VssException) exceptionToThrow;
@@ -581,40 +285,6 @@ public abstract class VssHttpClientBase {
             in.close();
         } catch (Exception ex) {
             throw new VssServiceException(ex.getMessage(), ex);
-        }
-    }
-
-    private boolean shouldOverrideHttpMethod(HttpMethod method) {
-        if (this.isOverrideEnabled()) {
-            return method.isOverrideable();
-        }
-
-        return false;
-    }
-
-    protected static enum HttpMethod {
-        PATCH("PATCH", true), //$NON-NLS-1$
-        GET("GET", false), //$NON-NLS-1$
-        POST("POST", false), //$NON-NLS-1$
-        PUT("PUT", true), //$NON-NLS-1$
-        DELETE("DELETE", true), //$NON-NLS-1$
-        HEAD("HEAD", false), //$NON-NLS-1$
-        OPTIONS("OPTIONS", true); //$NON-NLS-1$
-
-        private String verb;
-        private boolean overrideable;
-
-        private HttpMethod(final String verb, final boolean overrideable) {
-            this.verb = verb;
-            this.overrideable = overrideable;
-        }
-
-        public boolean isOverrideable() {
-            return this.overrideable;
-        }
-
-        public String getVerb() {
-            return this.verb;
         }
     }
 }

--- a/Rest/alm-vss-client/src/main/java/com/microsoft/alm/client/VssMediaTypes.java
+++ b/Rest/alm-vss-client/src/main/java/com/microsoft/alm/client/VssMediaTypes.java
@@ -1,0 +1,15 @@
+package com.microsoft.alm.client;
+
+public class VssMediaTypes {
+
+    public final static String APPLICATION_JSON_TYPE = "application/json"; //$NON-NLS-1$
+    public final static String APPLICATION_OCTET_STREAM_TYPE = "application/octet-stream"; //$NON-NLS-1$
+    public final static String APPLICATION_ZIP_TYPE = "application/zip"; //$NON-NLS-1$
+    public final static String TEXT_PLAIN_TYPE = "text/plaint"; //$NON-NLS-1$
+    public final static String TEXT_HTML_TYPE = "text/html"; //$NON-NLS-1$
+    public final static String APPLICATION_JSON_PATCH_TYPE = "application/json-patch+json"; //$NON-NLS-1$
+    public final static String APPLICATION_GIT_MEDIA_TYPE = "application/vnd.git-media"; //$NON-NLS-1$
+    public final static String IMAGE_SVG_XML_MEDIA_TYPE = "image/svg+xml"; //$NON-NLS-1$
+    public final static String IMAGE_PNG_MEDIA_TYPE = "image/png"; //$NON-NLS-1$
+    public final static String APPLICATION_GZIP = "application/gzip"; //$NON-NLS-1$
+}

--- a/Rest/alm-vss-client/src/main/java/com/microsoft/alm/client/VssRestClientHandler.java
+++ b/Rest/alm-vss-client/src/main/java/com/microsoft/alm/client/VssRestClientHandler.java
@@ -1,0 +1,40 @@
+package com.microsoft.alm.client;
+
+import java.net.URI;
+import java.util.Map;
+import java.util.UUID;
+
+import com.microsoft.alm.visualstudio.services.webapi.ApiResourceLocationCollection;
+import com.microsoft.alm.visualstudio.services.webapi.ApiResourceVersion;
+
+public interface VssRestClientHandler {
+
+    final static String OPTIONS_RELATIVE_PATH = "_apis"; //$NON-NLS-1$
+    final static String CONNECTION_DATA_RELATIVE_PATH = "_apis/connectiondata"; //$NON-NLS-1$
+    final static String AREA_PARAMETER_NAME = "area"; //$NON-NLS-1$
+    final static String RESOURCE_PARAMETER_NAME = "resource"; //$NON-NLS-1$
+    final static String ROUTE_TEMPLATE_SEPARATOR = "/"; //$NON-NLS-1$
+
+    final static ApiResourceVersion DEFAULT_API_VERSION = new ApiResourceVersion();
+
+    final static String API_VERSION_PARAMETER_NAME = "api-version"; //$NON-NLS-1$
+    final static String CHARSET_PARAMETER_NAME = "charset"; //$NON-NLS-1$
+
+    void init(final boolean overrideEnabled, final String clientVersion, final URI baseUrl);
+
+    Exception getLastException();
+
+    ApiResourceLocationCollection getLocations();
+
+    boolean checkConnection();
+
+    <TEntity> VssRestRequest createRequest(
+        final HttpMethod method,
+        final UUID locationId,
+        final Map<String, Object> routeValues,
+        final ApiResourceVersion version,
+        final TEntity value,
+        final String contentMediaType,
+        final Map<String, String> queryParameters,
+        final String acceptMediaType);
+}

--- a/Rest/alm-vss-client/src/main/java/com/microsoft/alm/client/VssRestClientHandlerBase.java
+++ b/Rest/alm-vss-client/src/main/java/com/microsoft/alm/client/VssRestClientHandlerBase.java
@@ -1,0 +1,191 @@
+package com.microsoft.alm.client;
+
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.UUID;
+
+import com.microsoft.alm.client.utils.StringUtil;
+import com.microsoft.alm.visualstudio.services.webapi.ApiResourceLocation;
+import com.microsoft.alm.visualstudio.services.webapi.ApiResourceLocationCollection;
+import com.microsoft.alm.visualstudio.services.webapi.ApiResourceVersion;
+
+public abstract class VssRestClientHandlerBase implements VssRestClientHandler {
+
+    private boolean overrideEnabled;
+    private ApiResourceLocationCollection resourceLocations;
+    private URI baseUrl;
+    private Exception lastException;
+    private String clientVersion;
+
+    @Override
+    public void init(final boolean overrideEnabled, final String clientVersion, final URI baseUrl) {
+
+        this.overrideEnabled = overrideEnabled;
+        this.clientVersion = clientVersion;
+        this.baseUrl = baseUrl;
+    }
+
+    public URI getBaseUrl() {
+        return baseUrl;
+    }
+
+    @Override
+    public Exception getLastException() {
+        return lastException;
+    }
+
+    protected void setLastException(final Exception e) {
+        lastException = e;
+    }
+
+    protected String getClientVersion() {
+        return clientVersion;
+    }
+
+    protected abstract ApiResourceLocationCollection loadLocations();
+
+    @Override
+    public ApiResourceLocationCollection getLocations() {
+        if (resourceLocations == null) {
+            resourceLocations = loadLocations();
+        }
+
+        return resourceLocations;
+    }
+
+    protected ApiResourceLocation getLocation(final UUID locationId) {
+        if (resourceLocations == null) {
+            resourceLocations = loadLocations();
+        }
+
+        if (resourceLocations != null) {
+            return resourceLocations.getLocationById(locationId);
+        } else {
+            return null;
+        }
+    }
+
+    /**
+     * Negotiate the appropriate request version to use for the given api
+     * resource location, based on the client and server capabilities
+     *
+     * @param location
+     *        - Location of the API resource
+     * @param version
+     *        - Client version to attempt to use (use the latest VSS API version
+     *        if unspecified)
+     * @return - Max API version supported on the server that is less than or
+     *         equal to the client version. Returns null if the server does not
+     *         support this location or this version of the client.
+     */
+    public ApiResourceVersion negotiateRequestVersion(
+        final ApiResourceLocation location,
+        final ApiResourceVersion version) {
+
+        if (version == null) {
+            return VssRestClientHandler.DEFAULT_API_VERSION;
+        }
+
+        if (location.getMinVersion().compareTo(version.getApiVersion()) > 0) {
+            // Client is older than the server. The server no longer supports
+            // this resource (deprecated).
+            return null;
+        } else if (location.getMaxVersion().compareTo(version.getApiVersion()) < 0) {
+            // Client is newer than the server. Negotiate down to the latest
+            // version on the server.
+            final ApiResourceVersion negotiatedVersion = new ApiResourceVersion(location.getMaxVersion());
+
+            // If the server latest version is greater than the released one,
+            // it is in preview mode.
+            final boolean isPreview = location.getReleasedVersion().compareTo(location.getMaxVersion()) < 0;
+            negotiatedVersion.setPreview(isPreview);
+
+            return negotiatedVersion;
+        } else {
+            // We can send at the requested API version. Make sure the resource
+            // version is not bigger than what the server supports.
+            final int resourceVersion = Math.min(version.getResourceVersion(), location.getResourceVersion());
+            final ApiResourceVersion negotiatedVersion =
+                new ApiResourceVersion(version.getApiVersion(), resourceVersion);
+
+            // If server released version is less than the requested one, the
+            // negotiated version is in preview mode.
+            if (location.getReleasedVersion().compareTo(version.getApiVersion()) < 0) {
+                negotiatedVersion.setPreview(true);
+            } else {
+                negotiatedVersion.setPreview(version.isPreview());
+            }
+
+            return negotiatedVersion;
+        }
+    }
+
+    protected ApiResourceVersion NegotiateRequestVersion(final UUID locationId, final ApiResourceVersion version) {
+        return negotiateRequestVersion(getLocation(locationId), version);
+    }
+
+    protected String removeUndefinedOptionalParameters(final String template, final Map<String, Object> routeValues) {
+        final String[] templateParameters = template.split(ROUTE_TEMPLATE_SEPARATOR);
+        final List<String> actualParameters = new ArrayList<String>();
+
+        for (int i = 0; i < templateParameters.length; i++) {
+            final String parameter = templateParameters[i];
+
+            if (parameter.startsWith("{")) { //$NON-NLS-1$
+                final String name;
+
+                if (parameter.startsWith("{*")) { //$NON-NLS-1$
+                    name = parameter.substring(2, parameter.length() - 1);
+                } else {
+                    name = parameter.substring(1, parameter.length() - 1);
+                }
+
+                if (routeValues.get(name) != null) {
+                    actualParameters.add("{" + name + "}"); //$NON-NLS-1$ //$NON-NLS-2$
+                }
+            } else {
+                actualParameters.add(parameter);
+            }
+        }
+
+        return StringUtil.join(ROUTE_TEMPLATE_SEPARATOR, actualParameters);
+    }
+
+    protected Map<String, Object> toRouteDictionary(
+        final Map<String, Object> routeValues,
+        final String areaName,
+        final String resourceName) {
+
+        final HashMap<String, Object> dictionary = new HashMap<String, Object>();
+        if (routeValues != null) {
+
+            for (final Entry<String, Object> e : routeValues.entrySet()) {
+                if (e.getValue() != null) {
+                    dictionary.put(e.getKey(), e.getValue());
+                }
+            }
+        }
+
+        if (!dictionary.containsKey(AREA_PARAMETER_NAME)) {
+            dictionary.put(AREA_PARAMETER_NAME, areaName);
+        }
+
+        if (!dictionary.containsKey(RESOURCE_PARAMETER_NAME)) {
+            dictionary.put(RESOURCE_PARAMETER_NAME, resourceName);
+        }
+
+        return dictionary;
+    }
+
+    protected boolean shouldOverrideHttpMethod(HttpMethod method) {
+        if (overrideEnabled) {
+            return method.isOverrideable();
+        }
+
+        return false;
+    }
+}

--- a/Rest/alm-vss-client/src/main/java/com/microsoft/alm/client/VssRestClientHandlerBase.java
+++ b/Rest/alm-vss-client/src/main/java/com/microsoft/alm/client/VssRestClientHandlerBase.java
@@ -124,7 +124,7 @@ public abstract class VssRestClientHandlerBase implements VssRestClientHandler {
         }
     }
 
-    protected ApiResourceVersion NegotiateRequestVersion(final UUID locationId, final ApiResourceVersion version) {
+    protected ApiResourceVersion negotiateRequestVersion(final UUID locationId, final ApiResourceVersion version) {
         return negotiateRequestVersion(getLocation(locationId), version);
     }
 

--- a/Rest/alm-vss-client/src/main/java/com/microsoft/alm/client/VssRestClientHandlerBase.java
+++ b/Rest/alm-vss-client/src/main/java/com/microsoft/alm/client/VssRestClientHandlerBase.java
@@ -13,7 +13,7 @@ import com.microsoft.alm.visualstudio.services.webapi.ApiResourceLocation;
 import com.microsoft.alm.visualstudio.services.webapi.ApiResourceLocationCollection;
 import com.microsoft.alm.visualstudio.services.webapi.ApiResourceVersion;
 
-public abstract class VssRestClientHandlerBase implements VssRestClientHandler {
+abstract class VssRestClientHandlerBase implements VssRestClientHandler {
 
     private boolean overrideEnabled;
     private ApiResourceLocationCollection resourceLocations;

--- a/Rest/alm-vss-client/src/main/java/com/microsoft/alm/client/VssRestRequest.java
+++ b/Rest/alm-vss-client/src/main/java/com/microsoft/alm/client/VssRestRequest.java
@@ -1,0 +1,5 @@
+package com.microsoft.alm.client;
+
+public interface VssRestRequest {
+    VssRestResponse sendRequest();
+}

--- a/Rest/alm-vss-client/src/main/java/com/microsoft/alm/client/VssRestResponse.java
+++ b/Rest/alm-vss-client/src/main/java/com/microsoft/alm/client/VssRestResponse.java
@@ -1,0 +1,22 @@
+package com.microsoft.alm.client;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+
+public interface VssRestResponse {
+
+    boolean isJsonResponse();
+
+    boolean isProxyAuthRequired();
+
+    boolean isSuccessResponse();
+
+    <TEntity> TEntity readEntity(final Class<TEntity> resultClass);
+
+    <TEntity> TEntity readEntity(final TypeReference<TEntity> resultClass);
+
+    String getHeader(final String headerName);
+
+    String getStatusText();
+
+    int getStatusCode();
+}

--- a/Rest/alm-vss-client/src/main/java/com/microsoft/alm/client/model/VssServiceResponseException.java
+++ b/Rest/alm-vss-client/src/main/java/com/microsoft/alm/client/model/VssServiceResponseException.java
@@ -3,16 +3,12 @@
 
 package com.microsoft.alm.client.model;
 
-import javax.ws.rs.core.Response;
-
+@SuppressWarnings("serial")
 public class VssServiceResponseException extends VssServiceException {
 
-    final Response.StatusType statusCode;
+    final int statusCode;
 
-    public VssServiceResponseException(
-        final Response.StatusType statusCode,
-        final String message,
-        final Exception innerException) {
+    public VssServiceResponseException(final int statusCode, final String message, final Exception innerException) {
         super(message, innerException);
         this.statusCode = statusCode;
     }

--- a/Rest/alm-vss-client/src/main/java/com/microsoft/alm/client/utils/StringUtil.java
+++ b/Rest/alm-vss-client/src/main/java/com/microsoft/alm/client/utils/StringUtil.java
@@ -282,4 +282,11 @@ public abstract class StringUtil {
     public static String pad(final Number n, final int width) {
         return pad(n, width, ' ');
     }
+
+    public static boolean startsWithIgnoreCase(final String s, final String searchFor) {
+        if (s == null || searchFor == null) {
+            return false;
+        }
+        return s.toLowerCase().startsWith(searchFor.toLowerCase());
+    }
 }

--- a/Rest/alm-vss-client/src/main/java/com/microsoft/alm/visualstudio/services/account/client/AccountHttpClient.java
+++ b/Rest/alm-vss-client/src/main/java/com/microsoft/alm/visualstudio/services/account/client/AccountHttpClient.java
@@ -3,18 +3,13 @@
 
 package com.microsoft.alm.visualstudio.services.account.client;
 
-import java.io.InputStream;
 import java.net.URI;
-import java.util.List;
-import java.util.UUID;
 
-import com.microsoft.alm.client.utils.ArgumentUtility;
-
-import javax.ws.rs.client.Client;
+import com.microsoft.alm.client.VssRestClientHandler;
 
 public class AccountHttpClient extends AccountHttpClientBase {
 
-    public AccountHttpClient(final Client jaxrsClient, final URI baseUrl) {
-        super(jaxrsClient, baseUrl);
+    public AccountHttpClient(final VssRestClientHandler clientHandler, final URI baseUrl) {
+        super(clientHandler, baseUrl);
     }
 }

--- a/Rest/alm-vss-client/src/main/java/com/microsoft/alm/visualstudio/services/account/client/AccountHttpClient.java
+++ b/Rest/alm-vss-client/src/main/java/com/microsoft/alm/visualstudio/services/account/client/AccountHttpClient.java
@@ -4,12 +4,19 @@
 package com.microsoft.alm.visualstudio.services.account.client;
 
 import java.net.URI;
+import java.util.List;
+import java.util.UUID;
 
 import com.microsoft.alm.client.VssRestClientHandler;
+import com.microsoft.alm.visualstudio.services.account.Account;
 
 public class AccountHttpClient extends AccountHttpClientBase {
 
     public AccountHttpClient(final VssRestClientHandler clientHandler, final URI baseUrl) {
         super(clientHandler, baseUrl);
+    }
+
+    public List<Account> getAccounts(final UUID memberId) {
+        return super.getAccounts(null, null, memberId, null, null, null);
     }
 }

--- a/Rest/alm-vss-client/src/main/java/com/microsoft/alm/visualstudio/services/authentication/client/AuthenticationHttpClient.java
+++ b/Rest/alm-vss-client/src/main/java/com/microsoft/alm/visualstudio/services/authentication/client/AuthenticationHttpClient.java
@@ -3,18 +3,13 @@
 
 package com.microsoft.alm.visualstudio.services.authentication.client;
 
-import java.io.InputStream;
 import java.net.URI;
-import java.util.List;
-import java.util.UUID;
 
-import com.microsoft.alm.client.utils.ArgumentUtility;
-
-import javax.ws.rs.client.Client;
+import com.microsoft.alm.client.VssRestClientHandler;
 
 public class AuthenticationHttpClient extends AuthenticationHttpClientBase {
 
-    public AuthenticationHttpClient(final Client jaxrsClient, final URI baseUrl) {
-        super(jaxrsClient, baseUrl);
+    public AuthenticationHttpClient(final VssRestClientHandler clientHandler, final URI baseUrl) {
+        super(clientHandler, baseUrl);
     }
 }

--- a/Rest/alm-vss-client/src/main/java/com/microsoft/alm/visualstudio/services/customerintelligence/webapi/CustomerIntelligenceHttpClient.java
+++ b/Rest/alm-vss-client/src/main/java/com/microsoft/alm/visualstudio/services/customerintelligence/webapi/CustomerIntelligenceHttpClient.java
@@ -3,18 +3,13 @@
 
 package com.microsoft.alm.visualstudio.services.customerintelligence.webapi;
 
-import java.io.InputStream;
 import java.net.URI;
-import java.util.List;
-import java.util.UUID;
 
-import com.microsoft.alm.client.utils.ArgumentUtility;
-
-import javax.ws.rs.client.Client;
+import com.microsoft.alm.client.VssRestClientHandler;
 
 public class CustomerIntelligenceHttpClient extends CustomerIntelligenceHttpClientBase {
 
-    public CustomerIntelligenceHttpClient(final Client jaxrsClient, final URI baseUrl) {
-        super(jaxrsClient, baseUrl);
+    public CustomerIntelligenceHttpClient(final VssRestClientHandler clientHandler, final URI baseUrl) {
+        super(clientHandler, baseUrl);
     }
 }

--- a/Rest/alm-vss-client/src/main/java/com/microsoft/alm/visualstudio/services/delegatedauthorization/SessionTokenScope.java
+++ b/Rest/alm-vss-client/src/main/java/com/microsoft/alm/visualstudio/services/delegatedauthorization/SessionTokenScope.java
@@ -1,0 +1,145 @@
+package com.microsoft.alm.visualstudio.services.delegatedauthorization;
+
+public enum SessionTokenScope {
+
+    /**
+     * Grants the ability to access build artifacts, including build results,
+     * definitions, and requests, and the ability to receive notifications about
+     * build events via service hooks.
+     */
+    BUILD_ACCESS("vso.build"), //$NON-NLS-1$
+
+    /**
+     * Grants the ability to access build artifacts, including build results,
+     * definitions, and requests, and the ability to queue a build, update build
+     * properties, and the ability to receive notifications about build events
+     * via service hooks.
+     */
+    BUILD_EXECUTE("vso.build_execute"), //$NON-NLS-1$
+
+    /**
+     * Grants the ability to access rooms and view, post, and update messages.
+     * Also grants the ability to manage rooms and users and to receive
+     * notifications about new messages via service hooks.
+     */
+    CHAT_MANAGE("vso.chat_manage"), //$NON-NLS-1$
+
+    /**
+     * Grants the ability to access rooms and view, post, and update messages.
+     * Also grants the ability to receive notifications about new messages via
+     * service hooks.
+     */
+    CHAT_WRITE("vso.chat_write"), //$NON-NLS-1$
+
+    /**
+     * Grants the ability to read, update, and delete source code, access
+     * metadata about commits, changesets, branches, and other version control
+     * artifacts. Also grants the ability to create and manage code
+     * repositories, create and manage pull requests and code reviews, and to
+     * receive notifications about version control events via service hooks.
+     */
+    CODE_MANAGE("vso.code_manage"), //$NON-NLS-1$
+
+    /**
+     * Grants the ability to read source code and metadata about commits,
+     * changesets, branches, and other version control artifacts. Also grants
+     * the ability to get notified about version control events via service
+     * hooks.
+     */
+    CODE_READ("vso.code"), //$NON-NLS-1$
+
+    /**
+     * Grants the ability to read, update, and delete source code, access
+     * metadata about commits, changesets, branches, and other version control
+     * artifacts. Also grants the ability to create and manage pull requests and
+     * code reviews and to receive notifications about version control events
+     * via service hooks.
+     */
+    CODE_WRITE("vso.code_write"), //$NON-NLS-1$
+
+    /**
+     * Grants the ability to read, write, and delete feeds and packages.
+     */
+    PACKAGING_MANAGE("vso.packaging_manage"), //$NON-NLS-1$
+
+    /**
+     * Grants the ability to list feeds and read packages in those feeds.
+     */
+    PACKAGING_READ("vso.packaging"), //$NON-NLS-1$
+
+    /**
+     * Grants the ability to list feeds and read, write, and delete packages in
+     * those feeds.
+     */
+    PACKAGING_WRITE("vso.packaging_write"), //$NON-NLS-1$
+
+    /**
+     * Grants the ability to read your profile, accounts, collections, projects,
+     * teams, and other top-level organizational artifacts.
+     */
+    PROFILE_READ("vso.profile"), //$NON-NLS-1$
+
+    /**
+     * Grants the ability to read service hook subscriptions and metadata,
+     * including supported events, consumers, and actions.
+     */
+    SERVICE_HOOK_READ("vso.hooks"), //$NON-NLS-1$
+
+    /**
+     * Grants the ability to create and update service hook subscriptions and
+     * read metadata, including supported events, consumers, and actions."
+     */
+    SERVICE_HOOK_WRITE("vso.hooks_write"), //$NON-NLS-1$
+
+    /**
+     * Grants the ability to read test plans, cases, results and other test
+     * management related artifacts.
+     */
+    TEST_READ("vso.test"), //$NON-NLS-1$
+
+    /**
+     * Grants the ability to read, create, and update test plans, cases, results
+     * and other test management related artifacts.
+     */
+    TEST_WRITE("vso.test_write"), //$NON-NLS-1$
+
+    /**
+     * Grants the ability to read work items, queries, boards, area and
+     * iterations paths, and other work item tracking related metadata. Also
+     * grants the ability to execute queries and to receive notifications about
+     * work item events via service hooks.
+     */
+    WORK_READ("vso.work"), //$NON-NLS-1$
+
+    /**
+     * Grants the ability to read, create, and update work items and queries,
+     * update board metadata, read area and iterations paths other work item
+     * tracking related metadata, execute queries, and to receive notifications
+     * about work item events via service hooks.
+     */
+    WORK_WRITE("vso.work_write"); //$NON-NLS-1$
+
+    private String value;
+
+    SessionTokenScope(final String value) {
+        this.value = value;
+    }
+
+    @Override
+    public String toString() {
+        return this.value;
+    }
+
+    public static String combine(final SessionTokenScope... tokens) {
+        StringBuilder sb = new StringBuilder();
+
+        for (final SessionTokenScope token : tokens) {
+            if (sb.length() > 0) {
+                sb.append(' ');
+            }
+            sb.append(token);
+        }
+
+        return sb.toString();
+    }
+}

--- a/Rest/alm-vss-client/src/main/java/com/microsoft/alm/visualstudio/services/delegatedauthorization/client/DelegatedAuthorizationHttpClient.java
+++ b/Rest/alm-vss-client/src/main/java/com/microsoft/alm/visualstudio/services/delegatedauthorization/client/DelegatedAuthorizationHttpClient.java
@@ -4,10 +4,13 @@
 package com.microsoft.alm.visualstudio.services.delegatedauthorization.client;
 
 import java.net.URI;
+import java.util.Arrays;
+import java.util.UUID;
 
 import com.microsoft.alm.client.VssRestClientHandler;
 import com.microsoft.alm.client.utils.ArgumentUtility;
 import com.microsoft.alm.visualstudio.services.delegatedauthorization.SessionToken;
+import com.microsoft.alm.visualstudio.services.delegatedauthorization.SessionTokenScope;
 import com.microsoft.alm.visualstudio.services.delegatedauthorization.SessionTokenType;
 
 /**
@@ -29,4 +32,21 @@ public class DelegatedAuthorizationHttpClient extends DelegatedAuthorizationHttp
 
         return super.createSessionToken(sessionToken, SessionTokenType.COMPACT, null);
     }
+
+    public SessionToken createAccountSessionToken(
+        final String displayName,
+        final UUID accountId,
+        final SessionTokenScope... scopes) {
+
+        final SessionToken token = new SessionToken();
+
+        token.setDisplayName(displayName);
+        token.setScope(SessionTokenScope.combine(scopes));
+        token.setTargetAccounts(Arrays.asList(new UUID[] {
+            accountId
+        }));
+
+        return createSessionToken(token);
+    }
+
 }

--- a/Rest/alm-vss-client/src/main/java/com/microsoft/alm/visualstudio/services/delegatedauthorization/client/DelegatedAuthorizationHttpClient.java
+++ b/Rest/alm-vss-client/src/main/java/com/microsoft/alm/visualstudio/services/delegatedauthorization/client/DelegatedAuthorizationHttpClient.java
@@ -5,8 +5,8 @@ package com.microsoft.alm.visualstudio.services.delegatedauthorization.client;
 
 import java.net.URI;
 
+import com.microsoft.alm.client.VssRestClientHandler;
 import com.microsoft.alm.client.utils.ArgumentUtility;
-import com.microsoft.alm.visualstudio.services.delegatedauthorization.client.DelegatedAuthorizationHttpClientBase;
 import com.microsoft.alm.visualstudio.services.delegatedauthorization.SessionToken;
 import com.microsoft.alm.visualstudio.services.delegatedauthorization.SessionTokenType;
 
@@ -17,8 +17,8 @@ import com.microsoft.alm.visualstudio.services.delegatedauthorization.SessionTok
  */
 public class DelegatedAuthorizationHttpClient extends DelegatedAuthorizationHttpClientBase {
 
-    public DelegatedAuthorizationHttpClient(final Object jaxrsClient, final URI baseUrl) {
-        super(jaxrsClient, baseUrl);
+    protected DelegatedAuthorizationHttpClient(final VssRestClientHandler clientHandler, final URI baseUrl) {
+        super(clientHandler, baseUrl);
     }
 
     /**

--- a/Rest/alm-vss-client/src/main/java/com/microsoft/alm/visualstudio/services/delegatedauthorization/client/DelegatedAuthorizationHttpClient.java
+++ b/Rest/alm-vss-client/src/main/java/com/microsoft/alm/visualstudio/services/delegatedauthorization/client/DelegatedAuthorizationHttpClient.java
@@ -17,7 +17,7 @@ import com.microsoft.alm.visualstudio.services.delegatedauthorization.SessionTok
  */
 public class DelegatedAuthorizationHttpClient extends DelegatedAuthorizationHttpClientBase {
 
-    protected DelegatedAuthorizationHttpClient(final VssRestClientHandler clientHandler, final URI baseUrl) {
+    public DelegatedAuthorizationHttpClient(final VssRestClientHandler clientHandler, final URI baseUrl) {
         super(clientHandler, baseUrl);
     }
 

--- a/Rest/alm-vss-client/src/main/java/com/microsoft/alm/visualstudio/services/delegatedauthorization/client/DelegatedAuthorizationHttpClientBase.java
+++ b/Rest/alm-vss-client/src/main/java/com/microsoft/alm/visualstudio/services/delegatedauthorization/client/DelegatedAuthorizationHttpClientBase.java
@@ -20,9 +20,14 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
+
 import com.fasterxml.jackson.core.type.TypeReference;
-import com.microsoft.alm.client.model.NameValueCollection;
+import com.microsoft.alm.client.HttpMethod;
 import com.microsoft.alm.client.VssHttpClientBase;
+import com.microsoft.alm.client.VssMediaTypes;
+import com.microsoft.alm.client.VssRestClientHandler;
+import com.microsoft.alm.client.VssRestRequest;
+import com.microsoft.alm.client.model.NameValueCollection;
 import com.microsoft.alm.visualstudio.services.delegatedauthorization.SessionToken;
 import com.microsoft.alm.visualstudio.services.delegatedauthorization.SessionTokenType;
 import com.microsoft.alm.visualstudio.services.webapi.ApiResourceVersion;
@@ -39,23 +44,14 @@ public abstract class DelegatedAuthorizationHttpClientBase
     /**
     * Create a new instance of TokenHttpClientBase
     *
-    * @param jaxrsClient
-    *            an initialized instance of a JAX-RS Client implementation
+    * @param clientHandler
+    *            a DefaultRestClientHandler initialized with an instance of a JAX-RS Client implementation or
+    *            a TEERestClientHamdler initialized with TEE HTTP client implementation
     * @param baseUrl
-    *            a TFS project collection URL
+    *            a TFS services URL, 
     */
-    protected DelegatedAuthorizationHttpClientBase(final Object jaxrsClient, final URI baseUrl) {
-        super(jaxrsClient, baseUrl);
-    }
-
-    /**
-    * Create a new instance of TokenHttpClientBase
-    *
-    * @param tfsConnection
-    *            an initialized instance of a TfsTeamProjectCollection
-    */
-    protected DelegatedAuthorizationHttpClientBase(final Object tfsConnection) {
-        super(tfsConnection);
+    protected DelegatedAuthorizationHttpClientBase(final VssRestClientHandler clientHandler, final URI baseUrl) {
+        super(clientHandler, baseUrl);
     }
 
     @Override
@@ -86,13 +82,13 @@ public abstract class DelegatedAuthorizationHttpClientBase
         queryParameters.addIfNotNull("tokenType", tokenType); //$NON-NLS-1$
         queryParameters.addIfNotNull("isPublic", isPublic); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.POST,
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.POST,
                                                        locationId,
                                                        apiVersion,
                                                        sessionToken,
-                                                       APPLICATION_JSON_TYPE,
+                                                       VssMediaTypes.APPLICATION_JSON_TYPE,
                                                        queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+                                                       VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, SessionToken.class);
     }
@@ -123,12 +119,12 @@ public abstract class DelegatedAuthorizationHttpClientBase
         queryParameters.addIfNotNull("isPublic", isPublic); //$NON-NLS-1$
         queryParameters.addIfNotNull("includePublicData", includePublicData); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.GET,
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.GET,
                                                        locationId,
                                                        routeValues,
                                                        apiVersion,
                                                        queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+                                                       VssMediaTypes.APPLICATION_JSON_TYPE);
 
         return super.sendRequest(httpRequest, new TypeReference<List<SessionToken>>() {});
     }
@@ -153,12 +149,12 @@ public abstract class DelegatedAuthorizationHttpClientBase
         final NameValueCollection queryParameters = new NameValueCollection();
         queryParameters.addIfNotNull("isPublic", isPublic); //$NON-NLS-1$
 
-        final Object httpRequest = super.createRequest(HttpMethod.DELETE,
+        final VssRestRequest httpRequest = super.createRequest(HttpMethod.DELETE,
                                                        locationId,
                                                        routeValues,
                                                        apiVersion,
                                                        queryParameters,
-                                                       APPLICATION_JSON_TYPE);
+                                                       VssMediaTypes.APPLICATION_JSON_TYPE);
 
         super.sendRequest(httpRequest);
     }

--- a/Rest/alm-vss-client/src/main/java/com/microsoft/alm/visualstudio/services/delegatedauthorization/client/DelegatedAuthorizationHttpClientBase.java
+++ b/Rest/alm-vss-client/src/main/java/com/microsoft/alm/visualstudio/services/delegatedauthorization/client/DelegatedAuthorizationHttpClientBase.java
@@ -50,7 +50,7 @@ public abstract class DelegatedAuthorizationHttpClientBase
     * @param baseUrl
     *            a TFS services URL, 
     */
-    protected DelegatedAuthorizationHttpClientBase(final VssRestClientHandler clientHandler, final URI baseUrl) {
+    public DelegatedAuthorizationHttpClientBase(final VssRestClientHandler clientHandler, final URI baseUrl) {
         super(clientHandler, baseUrl);
     }
 

--- a/Rest/alm-vss-client/src/main/java/com/microsoft/alm/visualstudio/services/featureavailability/webapi/FeatureAvailabilityHttpClient.java
+++ b/Rest/alm-vss-client/src/main/java/com/microsoft/alm/visualstudio/services/featureavailability/webapi/FeatureAvailabilityHttpClient.java
@@ -3,18 +3,13 @@
 
 package com.microsoft.alm.visualstudio.services.featureavailability.webapi;
 
-import java.io.InputStream;
 import java.net.URI;
-import java.util.List;
-import java.util.UUID;
 
-import com.microsoft.alm.client.utils.ArgumentUtility;
-
-import javax.ws.rs.client.Client;
+import com.microsoft.alm.client.VssRestClientHandler;
 
 public class FeatureAvailabilityHttpClient extends FeatureAvailabilityHttpClientBase {
 
-    public FeatureAvailabilityHttpClient(final Client jaxrsClient, final URI baseUrl) {
-        super(jaxrsClient, baseUrl);
+    public FeatureAvailabilityHttpClient(final VssRestClientHandler clientHandler, final URI baseUrl) {
+        super(clientHandler, baseUrl);
     }
 }

--- a/Rest/alm-vss-client/src/main/java/com/microsoft/alm/visualstudio/services/filecontainer/client/FileContainerHttpClient.java
+++ b/Rest/alm-vss-client/src/main/java/com/microsoft/alm/visualstudio/services/filecontainer/client/FileContainerHttpClient.java
@@ -3,18 +3,13 @@
 
 package com.microsoft.alm.visualstudio.services.filecontainer.client;
 
-import java.io.InputStream;
 import java.net.URI;
-import java.util.List;
-import java.util.UUID;
 
-import com.microsoft.alm.client.utils.ArgumentUtility;
-
-import javax.ws.rs.client.Client;
+import com.microsoft.alm.client.VssRestClientHandler;
 
 public class FileContainerHttpClient extends FileContainerHttpClientBase {
 
-    public FileContainerHttpClient(final Client jaxrsClient, final URI baseUrl) {
-        super(jaxrsClient, baseUrl);
+    public FileContainerHttpClient(final VssRestClientHandler clientHandler, final URI baseUrl) {
+        super(clientHandler, baseUrl);
     }
 }

--- a/Rest/alm-vss-client/src/main/java/com/microsoft/alm/visualstudio/services/identity/client/IdentityHttpClient.java
+++ b/Rest/alm-vss-client/src/main/java/com/microsoft/alm/visualstudio/services/identity/client/IdentityHttpClient.java
@@ -3,18 +3,13 @@
 
 package com.microsoft.alm.visualstudio.services.identity.client;
 
-import java.io.InputStream;
 import java.net.URI;
-import java.util.List;
-import java.util.UUID;
 
-import com.microsoft.alm.client.utils.ArgumentUtility;
-
-import javax.ws.rs.client.Client;
+import com.microsoft.alm.client.VssRestClientHandler;
 
 public class IdentityHttpClient extends IdentityHttpClientBase {
 
-    public IdentityHttpClient(final Client jaxrsClient, final URI baseUrl) {
-        super(jaxrsClient, baseUrl);
+    public IdentityHttpClient(final VssRestClientHandler clientHandler, final URI baseUrl) {
+        super(clientHandler, baseUrl);
     }
 }

--- a/Rest/alm-vss-client/src/main/java/com/microsoft/alm/visualstudio/services/location/client/LocationHttpClient.java
+++ b/Rest/alm-vss-client/src/main/java/com/microsoft/alm/visualstudio/services/location/client/LocationHttpClient.java
@@ -3,18 +3,13 @@
 
 package com.microsoft.alm.visualstudio.services.location.client;
 
-import java.io.InputStream;
 import java.net.URI;
-import java.util.List;
-import java.util.UUID;
 
-import com.microsoft.alm.client.utils.ArgumentUtility;
-
-import javax.ws.rs.client.Client;
+import com.microsoft.alm.client.VssRestClientHandler;
 
 public class LocationHttpClient extends LocationHttpClientBase {
 
-    public LocationHttpClient(final Client jaxrsClient, final URI baseUrl) {
-        super(jaxrsClient, baseUrl);
+    public LocationHttpClient(final VssRestClientHandler clientHandler, final URI baseUrl) {
+        super(clientHandler, baseUrl);
     }
 }

--- a/Rest/alm-vss-client/src/main/java/com/microsoft/alm/visualstudio/services/operations/OperationsHttpClient.java
+++ b/Rest/alm-vss-client/src/main/java/com/microsoft/alm/visualstudio/services/operations/OperationsHttpClient.java
@@ -3,18 +3,13 @@
 
 package com.microsoft.alm.visualstudio.services.operations;
 
-import java.io.InputStream;
 import java.net.URI;
-import java.util.List;
-import java.util.UUID;
 
-import com.microsoft.alm.client.utils.ArgumentUtility;
-
-import javax.ws.rs.client.Client;
+import com.microsoft.alm.client.VssRestClientHandler;
 
 public class OperationsHttpClient extends OperationsHttpClientBase {
 
-    public OperationsHttpClient(final Client jaxrsClient, final URI baseUrl) {
-        super(jaxrsClient, baseUrl);
+    public OperationsHttpClient(final VssRestClientHandler clientHandler, final URI baseUrl) {
+        super(clientHandler, baseUrl);
     }
 }

--- a/Rest/alm-vss-client/src/main/java/com/microsoft/alm/visualstudio/services/profile/client/ProfileHttpClient.java
+++ b/Rest/alm-vss-client/src/main/java/com/microsoft/alm/visualstudio/services/profile/client/ProfileHttpClient.java
@@ -3,18 +3,13 @@
 
 package com.microsoft.alm.visualstudio.services.profile.client;
 
-import java.io.InputStream;
 import java.net.URI;
-import java.util.List;
-import java.util.UUID;
 
-import com.microsoft.alm.client.utils.ArgumentUtility;
-
-import javax.ws.rs.client.Client;
+import com.microsoft.alm.client.VssRestClientHandler;
 
 public class ProfileHttpClient extends ProfileHttpClientBase {
 
-    public ProfileHttpClient(final Client jaxrsClient, final URI baseUrl) {
-        super(jaxrsClient, baseUrl);
+    public ProfileHttpClient(final VssRestClientHandler clientHandler, final URI baseUrl) {
+        super(clientHandler, baseUrl);
     }
 }

--- a/Rest/alm-vss-client/src/main/java/com/microsoft/alm/visualstudio/services/profile/client/ProfileHttpClient.java
+++ b/Rest/alm-vss-client/src/main/java/com/microsoft/alm/visualstudio/services/profile/client/ProfileHttpClient.java
@@ -6,10 +6,15 @@ package com.microsoft.alm.visualstudio.services.profile.client;
 import java.net.URI;
 
 import com.microsoft.alm.client.VssRestClientHandler;
+import com.microsoft.alm.visualstudio.services.profile.Profile;
 
 public class ProfileHttpClient extends ProfileHttpClientBase {
 
     public ProfileHttpClient(final VssRestClientHandler clientHandler, final URI baseUrl) {
         super(clientHandler, baseUrl);
+    }
+
+    public Profile getMyProfile() {
+        return super.getProfile("me", null, null, null, null, null); //$NON-NLS-1$
     }
 }

--- a/Rest/alm-vss-client/src/main/java/com/microsoft/alm/visualstudio/services/security/client/SecurityHttpClient.java
+++ b/Rest/alm-vss-client/src/main/java/com/microsoft/alm/visualstudio/services/security/client/SecurityHttpClient.java
@@ -3,18 +3,13 @@
 
 package com.microsoft.alm.visualstudio.services.security.client;
 
-import java.io.InputStream;
 import java.net.URI;
-import java.util.List;
-import java.util.UUID;
 
-import com.microsoft.alm.client.utils.ArgumentUtility;
-
-import javax.ws.rs.client.Client;
+import com.microsoft.alm.client.VssRestClientHandler;
 
 public class SecurityHttpClient extends SecurityHttpClientBase {
 
-    public SecurityHttpClient(final Client jaxrsClient, final URI baseUrl) {
-        super(jaxrsClient, baseUrl);
+    public SecurityHttpClient(final VssRestClientHandler clientHandler, final URI baseUrl) {
+        super(clientHandler, baseUrl);
     }
 }

--- a/Rest/alm-vss-client/src/test/java/com/microsoft/alm/client/apiversion/VersionNegotiationTest.java
+++ b/Rest/alm-vss-client/src/test/java/com/microsoft/alm/client/apiversion/VersionNegotiationTest.java
@@ -8,6 +8,7 @@ import java.net.URISyntaxException;
 
 import javax.ws.rs.client.Client;
 
+import com.microsoft.alm.client.DefaultRestClientHandler;
 import com.microsoft.alm.client.VssHttpClientBase;
 import com.microsoft.alm.client.moke.MokeClient;
 import com.microsoft.alm.visualstudio.services.webapi.ApiResourceLocation;
@@ -187,6 +188,7 @@ public class VersionNegotiationTest extends TestCase {
 
         final static Client client = new MokeClient();
         final static URI testUri = getBaseUri("http://ar01.me.tfsallin.net:81/DefaultCollection"); //$NON-NLS-1$
+        final static DefaultRestClientHandler clientHandler = new DefaultRestClientHandler(client);
 
         private static URI getBaseUri(final String uri) {
             try {
@@ -200,11 +202,11 @@ public class VersionNegotiationTest extends TestCase {
         }
 
         public TestClient() {
-            super(client, testUri);
+            super(clientHandler, testUri);
         }
 
         public ApiResourceVersion negotiate(ApiResourceLocation location, ApiResourceVersion version) {
-            return super.negotiateRequestVersion(location, version);
+            return clientHandler.negotiateRequestVersion(location, version);
         }
     }
 }

--- a/Rest/pom.xml
+++ b/Rest/pom.xml
@@ -22,10 +22,10 @@
     <url>https://www.visualstudio.com/</url>
 
     <properties>
-<!-- 
+<!-- -->
         <skip.javadoc>true</skip.javadoc>
         <skip.sources>true</skip.sources>
-  -->
+<!--  -->
         <jaxrs-api.version>2.0.1</jaxrs-api.version>
         <common-codec.version>1.10</common-codec.version>
         <mvn.compiler.version>3.3</mvn.compiler.version>


### PR DESCRIPTION
All Jax-RS dependencies are moved to a Jax-RS specific implementation of the VssRestClientHandler interface. Default Jax-RS based implementation of the interface is currently added to the base project. I'll move it to a separate project later.