### PR TITLE
Fix deserialization of PropertiesCollection

### DIFF
--- a/Rest/alm-vss-client/src/main/java/com/microsoft/alm/visualstudio/services/webapi/PropertiesCollection.java
+++ b/Rest/alm-vss-client/src/main/java/com/microsoft/alm/visualstudio/services/webapi/PropertiesCollection.java
@@ -5,5 +5,8 @@ package com.microsoft.alm.visualstudio.services.webapi;
 
 import java.util.HashMap;
 
-public class PropertiesCollection 
-    extends HashMap<String, String> { }
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+
+@JsonDeserialize(using = PropertiesCollectionDeserializer.class)
+public class PropertiesCollection extends HashMap<String, String> {
+}

--- a/Rest/alm-vss-client/src/main/java/com/microsoft/alm/visualstudio/services/webapi/PropertiesCollectionDeserializer.java
+++ b/Rest/alm-vss-client/src/main/java/com/microsoft/alm/visualstudio/services/webapi/PropertiesCollectionDeserializer.java
@@ -1,0 +1,70 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root.
+
+package com.microsoft.alm.visualstudio.services.webapi;
+
+import java.io.IOException;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.JsonToken;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.microsoft.alm.client.Messages;
+import com.microsoft.alm.client.utils.StringUtil;
+
+public class PropertiesCollectionDeserializer extends JsonDeserializer<PropertiesCollection> {
+
+    /**
+     * Deserializes JSON to PropertiesCollection
+     * 
+     * @param parser
+     * @param context
+     * @return PropertiesCollection
+     * @throws IOException
+     * @throws JsonProcessingException
+     */
+    @Override
+    public PropertiesCollection deserialize(final JsonParser parser, final DeserializationContext context)
+        throws IOException,
+            JsonProcessingException {
+
+        final PropertiesCollection result = new PropertiesCollection();
+
+        if (parser.getCurrentToken().equals(JsonToken.START_OBJECT)) {
+
+            while (parser.nextToken() != JsonToken.END_OBJECT) {
+                // Read the property collection key. We know this is a string
+                // because the JsonReader validates that the first token
+                // is a property name, and it has to be a string.
+                final String propertyKey = parser.getCurrentName();
+
+                if (StringUtil.isNullOrEmpty(propertyKey)) {
+                    throw new IOException(
+                        Messages.getString("PropertiesCollectionDeserializer.InvalidPropertiesCollection")); //$NON-NLS-1$
+                }
+
+                // Now read the typed value
+                parser.nextToken();
+                TypedValue typedValue = parser.readValueAs(TypedValue.class);
+                result.put(propertyKey, typedValue.value);
+            }
+
+        } else {
+            // consume this stream
+            final ObjectMapper mapper = (ObjectMapper) parser.getCodec();
+            mapper.readTree(parser);
+        }
+
+        return result;
+    }
+
+    public static class TypedValue {
+        @JsonProperty("$type")
+        public String type;
+        @JsonProperty("$value")
+        public String value;
+    }
+}

--- a/Rest/alm-vss-client/src/main/resources/com/microsoft/alm/client/messages.properties
+++ b/Rest/alm-vss-client/src/main/resources/com/microsoft/alm/client/messages.properties
@@ -8,3 +8,4 @@ VssResourceNotFoundException.NotRegisteredFormat=API resource location {0} is no
 VssResourceNotFoundException.NotRegisteredOnFormat=API resource location {0} is not registered on {1}.
 ProxyAuthenticationRequiredException.ErrorMessage=SP324097: Your network proxy requires authentikation.
 ReferenceLinksDeserializer.InvalidReferenceLink=ReferenceLinks is a dictionary that contains either a single ReferenceLink or an array of ReferenceLinks.
+PropertiesCollectionDeserializer.InvalidPropertiesCollection=PropertiesCollection is a dictionary that contains typed values.


### PR DESCRIPTION
Creating a CommentThread and passing some custom properties works fine, but reading them back fails with:
````java
gitHttpClient.getThreads(PROJECT_NAME, REPO_NAME, PR_ID, null, null);
````

> Exception in thread "main" javax.ws.rs.ProcessingException: Error reading entity from input stream.
> 	at org.glassfish.jersey.message.internal.InboundMessageContext.readEntity(InboundMessageContext.java:889)
> 	at org.glassfish.jersey.message.internal.InboundMessageContext.readEntity(InboundMessageContext.java:834)
> 	at org.glassfish.jersey.client.ClientResponse.readEntity(ClientResponse.java:363)
> 	at org.glassfish.jersey.client.InboundJaxrsResponse$2.call(InboundJaxrsResponse.java:126)
> 	at org.glassfish.jersey.internal.Errors.process(Errors.java:316)
> 	at org.glassfish.jersey.internal.Errors.process(Errors.java:298)
> 	at org.glassfish.jersey.internal.Errors.process(Errors.java:229)
> 	at org.glassfish.jersey.process.internal.RequestScope.runInScope(RequestScope.java:389)
> 	at org.glassfish.jersey.client.InboundJaxrsResponse.runInScopeIfPossible(InboundJaxrsResponse.java:264)
> 	at org.glassfish.jersey.client.InboundJaxrsResponse.readEntity(InboundJaxrsResponse.java:123)
> 	at com.microsoft.alm.client.DefaultRestClientHandler$JaxRsResponse.readEntity(DefaultRestClientHandler.java:231)
> 	at com.microsoft.alm.client.VssHttpClientBase.sendRequest(VssHttpClientBase.java:224)
> 	at com.microsoft.alm.teamfoundation.sourcecontrol.webapi.GitHttpClientBase.getThreads(GitHttpClientBase.java:13726)
> 	at main.Main2.main(Main2.java:59)
> Caused by: com.fasterxml.jackson.databind.JsonMappingException: Can not deserialize instance of java.lang.String out of START_OBJECT token
>  at [Source: org.glassfish.jersey.message.internal.ReaderInterceptorExecutor$UnCloseableInputStream@6ca8564a; line: 1, column: 1349] (through reference chain: com.microsoft.alm.visualstudio.services.webapi.VssJsonCollectionWrapper["value"]->com.microsoft.alm.teamfoundation.sourcecontrol.webapi.GitPullRequestCommentThread["properties"])
> 	at com.fasterxml.jackson.databind.JsonMappingException.from(JsonMappingException.java:164)
> 	at com.fasterxml.jackson.databind.DeserializationContext.mappingException(DeserializationContext.java:749)
> 	at com.fasterxml.jackson.databind.deser.std.StringDeserializer.deserialize(StringDeserializer.java:59)
> 	at com.fasterxml.jackson.databind.deser.std.StringDeserializer.deserialize(StringDeserializer.java:12)
> 	at com.fasterxml.jackson.databind.deser.std.MapDeserializer._readAndBindStringMap(MapDeserializer.java:449)
> 	at com.fasterxml.jackson.databind.deser.std.MapDeserializer.deserialize(MapDeserializer.java:311)
> 	at com.fasterxml.jackson.databind.deser.std.MapDeserializer.deserialize(MapDeserializer.java:26)
> 	at com.fasterxml.jackson.databind.deser.SettableBeanProperty.deserialize(SettableBeanProperty.java:538)
> 	at com.fasterxml.jackson.databind.deser.impl.MethodProperty.deserializeAndSet(MethodProperty.java:99)
> 	at com.fasterxml.jackson.databind.deser.BeanDeserializer.vanillaDeserialize(BeanDeserializer.java:242)
> 	at com.fasterxml.jackson.databind.deser.BeanDeserializer.deserialize(BeanDeserializer.java:118)
> 	at com.fasterxml.jackson.databind.deser.std.CollectionDeserializer.deserialize(CollectionDeserializer.java:232)
> 	at com.fasterxml.jackson.databind.deser.std.CollectionDeserializer.deserialize(CollectionDeserializer.java:206)
> 	at com.fasterxml.jackson.databind.deser.std.CollectionDeserializer.deserialize(CollectionDeserializer.java:25)
> 	at com.fasterxml.jackson.databind.deser.SettableBeanProperty.deserialize(SettableBeanProperty.java:538)
> 	at com.fasterxml.jackson.databind.deser.impl.MethodProperty.deserializeAndSet(MethodProperty.java:99)
> 	at com.fasterxml.jackson.databind.deser.BeanDeserializer.vanillaDeserialize(BeanDeserializer.java:242)
> 	at com.fasterxml.jackson.databind.deser.BeanDeserializer.deserialize(BeanDeserializer.java:118)
> 	at com.fasterxml.jackson.databind.ObjectMapper._readValue(ObjectMapper.java:3023)
> 	at com.fasterxml.jackson.databind.ObjectMapper.readValue(ObjectMapper.java:1676)
> 	at com.microsoft.alm.client.jaxrs.ApiResourceEntityProvider.readFrom(ApiResourceEntityProvider.java:133)
> 	at org.glassfish.jersey.message.internal.ReaderInterceptorExecutor$TerminalReaderInterceptor.invokeReadFrom(ReaderInterceptorExecutor.java:257)
> 	at org.glassfish.jersey.message.internal.ReaderInterceptorExecutor$TerminalReaderInterceptor.aroundReadFrom(ReaderInterceptorExecutor.java:236)
> 	at org.glassfish.jersey.message.internal.ReaderInterceptorExecutor.proceed(ReaderInterceptorExecutor.java:156)
> 	at org.glassfish.jersey.message.internal.MessageBodyFactory.readFrom(MessageBodyFactory.java:1091)
> 	at org.glassfish.jersey.message.internal.InboundMessageContext.readEntity(InboundMessageContext.java:874)
> 	... 13 more

This is because PropertiesCollection is a Map<String, String>, while in JSON the format looks like:
````json
"properties": {
    "Microsoft.TeamFoundation.Discussion.SupportsMarkdown": {
        "$type": "System.Int32",
        "$value": 1
    },
    "Microsoft.TeamFoundation.Discussion.UniqueID": {
        "$type": "System.String",
        "$value": "399262e6-9180-4dcc-ae97-9586798328a9"
    }
}
````

I have added a custom deserializer to fix the issue.